### PR TITLE
Remove compress option, inject version number, and other miscellaney

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -51,12 +51,9 @@ jobs:
           ref: refs/heads/release/lambda-extension-v9 # todo : change after merge of current PRs
           path: "datadog-agent"
 
-      - name: Build the layer
-        # This version number is arbitrary and won't be used by AWS
-        run: VERSION=123 ./scripts/build_binary_and_layer.sh
-
       - name: Run tests
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: cp -R ../.layers . && ./integration_tests/run.sh
+          BUILD_EXTENSION: true
+        run: ./integration_tests/run.sh

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -52,7 +52,7 @@ jobs:
           path: "datadog-agent"
 
       - name: Build the layer
-        # This version number is injected into the binary but not used in AWS 
+        # This version number is arbitrary and won't be used by AWS
         run: VERSION=123 ./scripts/build_binary_and_layer.sh
 
       - name: Run tests

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -52,7 +52,8 @@ jobs:
           path: "datadog-agent"
 
       - name: Build the layer
-        run: ./scripts/build_binary_and_layer.sh
+        # This version number is injected into the binary but not used in AWS 
+        run: VERSION=123 ./scripts/build_binary_and_layer.sh
 
       - name: Run tests
         env:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -51,9 +51,12 @@ jobs:
           ref: refs/heads/release/lambda-extension-v9 # todo : change after merge of current PRs
           path: "datadog-agent"
 
+      - name: Build the layer
+        # This version number is arbitrary and won't be used by AWS
+        run: VERSION=123 ./scripts/build_binary_and_layer.sh
+
       - name: Run tests
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          BUILD_EXTENSION: true
-        run: ./integration_tests/run.sh
+        run: cp -R ../.layers . && ./integration_tests/run.sh

--- a/integration_tests/run.sh
+++ b/integration_tests/run.sh
@@ -2,7 +2,7 @@
 
 # Usage - run commands from repo root:
 # To check if new changes to the extension cause changes to any snapshots:
-#   aws-vault exec sandbox-account-admin -- ./integration_tests/run.sh
+#   BUILD_EXTENSION=true aws-vault exec sandbox-account-admin -- ./integration_tests/run.sh
 # To regenerate snapshots:
 #   UPDATE_SNAPSHOTS=true aws-vault exec sandbox-account-admin -- ./integration_tests/run.sh
 
@@ -16,6 +16,14 @@ if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
     echo "No AWS credentials were found in the environment."
     echo "Note that only Datadog employees can run these integration tests."
     exit 1
+fi
+
+if [ -n "$BUILD_EXTENSION" ]; then
+    echo "Building extension that will be deployed with our test functions"
+    # This version number is arbitrary and won't be used by AWS
+    VERSION=123 ./scripts/build_binary_and_layer.sh
+else
+    echo "Not building extension, ensure it has already been built or re-run with 'BUILD_EXTENSION=true'"
 fi
 
 cd "./integration_tests"

--- a/integration_tests/run.sh
+++ b/integration_tests/run.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Usage - run commands from repo root:
+# To check if new changes to the extension cause changes to any snapshots:
+#   aws-vault exec sandbox-account-admin -- ./integration_tests/run.sh
+# To regenerate snapshots:
+#   UPDATE_SNAPSHOTS=true aws-vault exec sandbox-account-admin -- ./integration_tests/run.sh
+
 LOGS_WAIT_SECONDS=45
 
 set -e

--- a/integration_tests/run.sh
+++ b/integration_tests/run.sh
@@ -6,20 +6,25 @@ set -e
 
 script_utc_start_time=$(date -u +"%Y%m%dT%H%M%S")
 
+if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+    echo "No AWS credentials were found in the environment."
+    echo "Note that only Datadog employees can run these integration tests."
+    exit 1
+fi
+
 cd "./integration_tests"
 
-#build and zip extension
+# build and zip recorder extension
 cd recorder-extension
     GOOS=linux GOARCH=amd64 go build -o extensions/recorder-extension main.go
     zip -rq ext.zip extensions/* -x ".*" -x "__MACOSX" -x "extensions/.*"
 cd ..
 
-#buid go
+# build Go Lambda function
 cd src
 env GOOS=linux go build -ldflags="-s -w" -o ../bootstrap traceGo.go
 cd ..
 
-#get the latest layer vesion number
 function getLatestLayerVersion() {
     layerName=$1
     lastVersion=$(aws lambda list-layer-versions --layer-name $layerName --region sa-east-1 | jq -r ".LayerVersions | .[0] |  .Version")
@@ -33,13 +38,13 @@ function getLatestLayerVersion() {
 if [ -z "$NODE_LAYER_VERSION" ]; then
    echo "NODE_LAYER_VERSION not found, getting the latest one"
    export NODE_LAYER_VERSION=$(getLatestLayerVersion "Datadog-Node14-x")
-   echo "NODE_LAYER_VERSION set to : $NODE_LAYER_VERSION"
+   echo "NODE_LAYER_VERSION set to: $NODE_LAYER_VERSION"
 fi
 
 if [ -z "$PYTHON_LAYER_VERSION" ]; then
    echo "PYTHON_LAYER_VERSION not found, getting the latest one"
    export PYTHON_LAYER_VERSION=$(getLatestLayerVersion "Datadog-Python38")
-   echo "PYTHON_LAYER_VERSION set to : $PYTHON_LAYER_VERSION"
+   echo "PYTHON_LAYER_VERSION set to: $PYTHON_LAYER_VERSION"
 fi
 
 # random 8-character ID to avoid collisions with other runs
@@ -106,8 +111,9 @@ for function_name in "${all_functions[@]}"; do
         break
     done
 
+    # Replace invocation-specific data like timestamps and IDs with XXX to normalize across executions
     if [[ " ${metric_function_names[@]} " =~ " ${function_name} " ]]; then
-        # Replace invocation-specific data like timestamps and IDs with XXXX to normalize logs across executions
+        # Normalize metrics
         logs=$(
             echo "$raw_logs" | \
             grep "\[sketch\]" | \
@@ -120,12 +126,14 @@ for function_name in "${all_functions[@]}"; do
             perl -p -e "s/(k\":\[)[0-9\.e\-]{1,20}/\1XXX/g" | \
             perl -p -e "s/(datadog-nodev)[0-9]+\.[0-9]+\.[0-9]+/\1X\.X\.X/g" | \
             perl -p -e "s/(datadog_lambda:v)[0-9]+\.[0-9]+\.[0-9]+/\1X\.X\.X/g" | \
+            perl -p -e "s/(extension_version:)[0-9]+/\1XXX/g" | \
             perl -p -e "s/(dd_lambda_layer:datadog-python)[0-9_]+\.[0-9]+\.[0-9]+/\1X\.X\.X/g" | \
             perl -p -e "s/(serverless.lambda-extension.integration-test.count)[0-9\.]+/\1/g" | \
             perl -p -e "s/$stage/XXXXXX/g" | \
             sort
         )
     elif [[ " ${log_function_names[@]} " =~ " ${function_name} " ]]; then
+        # Normalize logs
         logs=$(
             echo "$raw_logs" | \
             grep "\[log\]" | \
@@ -133,11 +141,13 @@ for function_name in "${all_functions[@]}"; do
             perl -p -e "s/(\"REPORT |START |END ).*/\1XXX\"}}/g" | \
             perl -p -e "s/(\"HTTP ).*/\1\"}}/g" | \
             perl -p -e "s/(,\"request_id\":\")[a-zA-Z0-9\-,]+\"//g" | \
+            perl -p -e "s/(extension_version:)[0-9]+/\1XXX/g" | \
             perl -p -e "s/$stage/STAGE/g" | \
             perl -p -e "s/(\"message\":\").*(XXX LOG)/\1\2\3/g" | \
             grep XXX
         )
-    else #traces are not yet integration-tested
+    else
+        # Normalize traces
         logs=$(
             echo "$raw_logs" | \
             grep "\[trace\]" | \
@@ -147,6 +157,7 @@ for function_name in "${all_functions[@]}"; do
             perl -p -e "s/((datadog_lambda|dd_trace)\":\")[0-9]+\.[0-9]+\.[0-9]+/\1X\.X\.X/g" | \
             perl -p -e "s/(,\"request_id\":\")[a-zA-Z0-9\-,]+\"/\1XXX\"/g" | \
             perl -p -e "s/(,\"runtime-id\":\")[a-zA-Z0-9\-,]+\"/\1XXX\"/g" | \
+            perl -p -e "s/(,\"extension_version\":\")[0-9]+\"/\1XXX\"/g" | \
             perl -p -e "s/(,\"system.pid\":\")[a-zA-Z0-9\-,]+\"/\1XXX\"/g" | \
             perl -p -e "s/$stage/XXXXXX/g" | \
             sort

--- a/integration_tests/serverless.yml
+++ b/integration_tests/serverless.yml
@@ -1,3 +1,4 @@
+# IAM permissions require service name to begin with 'integration-tests'
 service: integration-tests-extension
 
 resources:

--- a/scripts/build_binary_and_layer.sh
+++ b/scripts/build_binary_and_layer.sh
@@ -8,6 +8,14 @@
 set -e
 
 
+# Ensure the target extension version is defined
+if [ -z "$VERSION" ]; then
+    echo "Extension version not specified"
+    echo ""
+    echo "EXITING SCRIPT."
+    exit 1
+fi
+
 if [ -z "$CI" ]; then
     SERVERLESS_CMD_PATH="../datadog-agent/cmd/serverless"
 else
@@ -35,19 +43,16 @@ TARGET_DIR=$(pwd)/$EXTENSION_DIR
 echo "Building Lambda extension binary"
 cd $SERVERLESS_CMD_PATH
 
-LD_FLAGS=""
+# Add the current version number to the tags package before compilation
+LD_FLAGS="-X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=${VERSION}"
 
-if [ "$COMPRESS" = true ]; then
-    LD_FLAGS="-s -w"
+if [ "$PRODUCTION" = true ]; then
+    LD_FLAGS+=" -s -w"
 fi
 
 GOOS=linux go build -ldflags="${LD_FLAGS}" -tags serverless -o $TARGET_DIR/datadog-agent
 
-if [ "$COMPRESS" = true ]; then
-    upx --brute $TARGET_DIR/datadog-agent
-fi
-
-cd -
+cd $SCRIPTS_DIR/..
 rm -rf "./var"
 
 echo "Building Lambda layer"

--- a/scripts/build_binary_and_layer.sh
+++ b/scripts/build_binary_and_layer.sh
@@ -44,12 +44,7 @@ echo "Building Lambda extension binary"
 cd $SERVERLESS_CMD_PATH
 
 # Add the current version number to the tags package before compilation
-LD_FLAGS="-X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=${VERSION}"
-
-if [ "$PRODUCTION" = true ]; then
-    LD_FLAGS+=" -s -w"
-fi
-
+LD_FLAGS="-s -w -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=${VERSION}"
 GOOS=linux go build -ldflags="${LD_FLAGS}" -tags serverless -o $TARGET_DIR/datadog-agent
 
 cd $SCRIPTS_DIR/..

--- a/scripts/publish_prod.sh
+++ b/scripts/publish_prod.sh
@@ -63,7 +63,7 @@ echo "Checking that you have access to the GovCloud AWS account"
 saml2aws login -a govcloud-us1-fed-human-engineering
 AWS_PROFILE=govcloud-us1-fed-human-engineering aws sts get-caller-identity
 
-COMPRESS=true ./build_binary_and_layer.sh
+PRODUCTION=true ./build_binary_and_layer.sh
 ./build_docker_image.sh
 
 echo "Signing the layer"

--- a/scripts/publish_prod.sh
+++ b/scripts/publish_prod.sh
@@ -63,7 +63,7 @@ echo "Checking that you have access to the GovCloud AWS account"
 saml2aws login -a govcloud-us1-fed-human-engineering
 AWS_PROFILE=govcloud-us1-fed-human-engineering aws sts get-caller-identity
 
-PRODUCTION=true ./build_binary_and_layer.sh
+./build_binary_and_layer.sh
 ./build_docker_image.sh
 
 echo "Signing the layer"


### PR DESCRIPTION
Build script:
- **Remove COMPRESS option** - We no longer want to compress the extension binary because we found it causes a significant performance penalty on cold starts. The old option also removed the symbol tables from the binary with the `-ldflags="-s -w"` option. We will now do this for all builds (production and sandbox) for consistency.
- **Inject the current extension version number into the binary** - This is achieved using another `ldflags` option. I will open another PR in the datadog-agent repository that adds this version number to all telemetry from the Lambda extension.

Integration tests:
- Mask extension version numbers in the snapshots so that they will be consistent from execution to execution. The new snapshots with the version numbers are not present in this pull request, as the corresponding datadog-agent pull request has not been merged yet.
- Add a `BUILD_EXTENSION` option that lets us build a new version of the extension as part of running the integration tests.
- Add usage instructions as a comment.
- Check for AWS credentials before running the integration tests.
- A few other minor changes, such as clarifying some comments.