### PR TITLE
Fix and speed up publish_sandbox

### DIFF
--- a/scripts/publish_sandbox.sh
+++ b/scripts/publish_sandbox.sh
@@ -8,10 +8,9 @@
 #!/bin/bash
 set -e
 
-# Move into the scripts directory
+# Move into the root directory
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-cd $SCRIPTS_DIR
+cd $SCRIPTS_DIR/..
 
-./build_binary_and_layer_dockerized.sh
-aws-vault exec sandbox-account-admin -- ./sign_layers.sh sandbox
-REGIONS=sa-east-1 aws-vault exec sandbox-account-admin -- ./publish_layers.sh
+./scripts/build_binary_and_layer_dockerized.sh
+REGIONS=sa-east-1 aws-vault exec sandbox-account-admin -- ./scripts/publish_layers.sh


### PR DESCRIPTION
- Move into the correct directory to use the `publish_sandbox` script
- Do not sign the layer when publishing to the sandbox AWS account. Signing the layer is time-consuming, requires an additional MFA token, and it not needed when testing in the sandbox account.