### PR TITLE
add script to redirect issues from datadog-agent

### DIFF
--- a/.github/workflows/redirect_issues.yml
+++ b/.github/workflows/redirect_issues.yml
@@ -1,0 +1,20 @@
+name: redirect
+
+on:
+  schedule:
+    - cron: "0 12 * * *"
+
+  workflow_dispatch: # should be deleted after manual test
+    
+jobs:
+  redirect-issues:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Ping on slack issues related to serverless in the datadog-agent repo
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run: ./scripts/redirect_issues.sh

--- a/scripts/redirect_issues.sh
+++ b/scripts/redirect_issues.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+# Retrieve all issues from a repo
+
+yesterday=$(date --iso-8601=seconds --date="yesterday")
+
+GH_REPO_OWNER="DataDog"
+GH_REPO="datadog-agent"
+GH_URL="https://api.github.com/repos/$GH_REPO_OWNER/$GH_REPO/issues?since=$yesterday"
+
+SLACK_CHANNEL="#serverless"
+
+KEYWORDS="lambda|serverless|extension|layer"
+
+response=$(curl -H "Authorization: token $GH_TOKEN" -H "Accept: application/vnd.github.v3+json" -X GET "$GH_URL")
+echo "$response" | jq -c '.[]' | while read -r issue; do 
+  # Check if the retrieved issue is not a PR
+  if [[ $(echo "${issue}" | jq '.pull_request') == "null"  && \
+     ( ! -z $(echo "${issue}" | jq '.body' | grep -E "$KEYWORDS") || \
+     ! -z $(echo "${issue}" | jq '.title' | grep -E "$KEYWORDS") ) \
+    ]]; then
+      issue_url=$(echo "${issue}" | jq '.html_url')
+      curl -H "Content-type: application/json" -X POST "$SLACK_WEBHOOK" -d '{"channel": "'$SLACK_CHANNEL'", "text": ":sos: '$issue_url'"}'  
+  fi
+done


### PR DESCRIPTION
### What does this PR do?

Adds a mechanism to redirect issues in the [datadog-agent](https://github.com/DataDog/datadog-agent) repo related to serverless.

### Motivation

There are multiple issues created in the datadog-agent, some might get lost because we are not actively checking if they are related to our team.

### Testing Guidelines

N/A

### Additional Notes

Secrets were added in the settings in order for the script to run.
At some point, we could even transfer the issue to this repo by using the GitHub CLI command.
Right now, it just pings our slack channel `#serverless`.

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
