### PR TITLE
 SLS-1543: Automatically open documentation PR when deploying

### DIFF
--- a/scripts/create_documentation_pr.sh
+++ b/scripts/create_documentation_pr.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+# This script automatically opens a PR to the Documentation repo for lambda layer deploys
+
+GREEN="\033[0;32m"
+NC="\033[0;0m"
+DOCUMENTATION_REPO_PATH=$HOME/go/src/github.com/DataDog/documentation
+DOCUMENTATION_FILE=./layouts/shortcodes/latest-lambda-layer-version.html
+
+function print_color {
+    printf "$GREEN$1$NC\n"
+}
+
+print_color "Creating a Github PR to update documentation"
+
+if [ ! -d $DOCUMENTATION_REPO_PATH ]; then
+    print_color "Documentation directory does not exist, cloning into $DOCUMENTATION_REPO_PATH"
+    git clone git@github.com:DataDog/documentation $DOCUMENTATION_REPO_PATH
+fi
+
+cd $DOCUMENTATION_REPO_PATH
+
+# Make sure they don't have any local changes
+if [ ! -z "$(git status --porcelain)" ]; then
+    print_color "Documentation directory is dirty -- please stash or save your changes and manually create the PR"
+    exit 1
+fi
+
+print_color "Pulling latest changes from Github"
+git checkout master
+git pull
+
+print_color "Checking out new branch that has version changes"
+git checkout -b $USER/bump-$LAYER-version-$VERSION
+sed -i '' -e '/.*"extension"/{' -e 'n;s/.*/    '"$VERSION"'/' -e '}' $DOCUMENTATION_FILE
+git add $DOCUMENTATION_FILE
+
+print_color "Creating commit -- please tap your Yubikey if prompted"
+git commit -m "Bump $LAYER layer to version $VERSION"
+git push --set-upstream origin $USER/bump-$LAYER-version-$VERSION
+dd-pr
+
+# Reset documentation repo to clean a state that's tracking master
+print_color "Resetting documentation git branch to master"
+git checkout -B master origin/master

--- a/scripts/publish_prod.sh
+++ b/scripts/publish_prod.sh
@@ -87,3 +87,6 @@ echo "IMPORTANT: Please follow the following steps to create release notes:"
 echo "1. Manually create a new tag called lambda-extension-${VERSION} in the datadog-agent repository"
 echo "2. Create a new GitHub release in the datadog-lambda-extension repository using the tag v${VERSION}, and add release notes"
 echo ">>> https://github.com/DataDog/datadog-lambda-extension/releases/new?tag=v${VERSION}&title=v${VERSION}"
+
+# Open a PR to the documentation repo to automatically bump layer version
+VERSION=$VERSION LAYER=datadog-lambda-extension ./scripts/create_documentation_pr.sh

--- a/scripts/publish_sandbox.sh
+++ b/scripts/publish_sandbox.sh
@@ -5,7 +5,8 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-#!/bin/bash
+# Usage: VERSION=5 aws-vault exec sandbox-account-admin -- ./scripts/publish_sandbox.sh
+
 set -e
 
 # Move into the root directory
@@ -14,3 +15,7 @@ cd $SCRIPTS_DIR/..
 
 ./scripts/build_binary_and_layer_dockerized.sh
 REGIONS=sa-east-1 aws-vault exec sandbox-account-admin -- ./scripts/publish_layers.sh
+
+# Automatically create PR against github.com/DataDog/documentation
+# If you'd like to test, please uncomment the below line
+# VERSION=$VERSION LAYER=datadog-lambda-extension ./scripts/create_documentation_pr.sh


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This PR automatically adds a step at the end of deploying layers that creates a PR against the documentation with the updated version variable.

This PR clones the `documentation` repo to `$DATADOG_ROOT/documentation` if it doesn't exist, creates a new branch, makes the changes to bump the version, opens a tab to create a PR. If the documentation repo is not clean (there are local changes), then the script will fail and ask the user to continue and manually create the PR.

### Motivation

Reduce friction for deploying new lambda layers.

### Testing Guidelines

Changes were tested locally via the deploy sandbox lambda script.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
