### PR TITLE
Add us5 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The Datadog API Key must be defined by setting one of the following environment 
 
 ### DD_SITE
 
-Possible values are `datadoghq.com`, `datadoghq.eu`, `us3.datadoghq.com` and `ddog-gov.com`. The default is `datadoghq.com`.
+Possible values are `datadoghq.com`, `datadoghq.eu`, `us3.datadoghq.com`, `us5.datadoghq.com`, and `ddog-gov.com`. The default is `datadoghq.com`.
 
 ### DD_LOG_LEVEL
 


### PR DESCRIPTION
Mention the us5 datacenter in the README. It looks like it's already been added to datadog-agent.