### PR TITLE
Add bootstrap script for proxy

### DIFF
--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -29,7 +29,8 @@ RUN apt-get install -y zip
 RUN mkdir /extensions
 WORKDIR /extensions
 COPY --from=builder /tmp/dd/datadog-agent/cmd/serverless/datadog-agent /extensions/datadog-agent
-RUN  zip -r datadog_extension.zip /extensions
+COPY ./scripts/boot.sh /boot.sh
+RUN  zip -r datadog_extension.zip /extensions /boot.sh
 
 # keep the smallest possible docker image
 FROM scratch

--- a/scripts/boot.sh
+++ b/scripts/boot.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+args=("$@")
+if [ "$DD_EXPERIMENTAL_ENABLE_PROXY" == "true" ]
+then
+  echo "[bootstrap] DD_EXPERIMENTAL_ENABLE_PROXY is true"
+  echo "[bootstrap] orignal AWS_LAMBDA_RUNTIME_API $AWS_LAMBDA_RUNTIME_API"
+  export AWS_LAMBDA_RUNTIME_API="127.0.0.1:9000"
+  echo "[bootstrap] rerouting to $AWS_LAMBDA_RUNTIME_API"
+fi
+exec "${args[@]}"


### PR DESCRIPTION
This PR adds the bootstrap script (referenced by `AWS_LAMBDA_EXEC_WRAPPER`) to enable the proxy.
This script is embed at the root level of the extension layer `/opt`