### PR TITLE
Do not log from bootstrap script unless DD_LOG_LEVEL is DEBUG

### DIFF
--- a/scripts/boot.sh
+++ b/scripts/boot.sh
@@ -2,9 +2,17 @@
 args=("$@")
 if [ "$DD_EXPERIMENTAL_ENABLE_PROXY" == "true" ]
 then
-  echo "[bootstrap] DD_EXPERIMENTAL_ENABLE_PROXY is true"
-  echo "[bootstrap] orignal AWS_LAMBDA_RUNTIME_API $AWS_LAMBDA_RUNTIME_API"
+  if [ fgrep -ix "$DD_LOG_LEVEL" <<< "debug" ]
+  then
+    echo "[bootstrap] DD_EXPERIMENTAL_ENABLE_PROXY is true"
+    echo "[bootstrap] original AWS_LAMBDA_RUNTIME_API value is $AWS_LAMBDA_RUNTIME_API"
+  fi
+
   export AWS_LAMBDA_RUNTIME_API="127.0.0.1:9000"
-  echo "[bootstrap] rerouting to $AWS_LAMBDA_RUNTIME_API"
+
+  if [ fgrep -ix "$DD_LOG_LEVEL" <<< "debug" ]
+  then
+    echo "[bootstrap] rerouting AWS_LAMBDA_RUNTIME_API to $AWS_LAMBDA_RUNTIME_API"
+  fi
 fi
 exec "${args[@]}"

--- a/scripts/boot.sh
+++ b/scripts/boot.sh
@@ -2,7 +2,7 @@
 args=("$@")
 if [ "$DD_EXPERIMENTAL_ENABLE_PROXY" == "true" ]
 then
-  if [ fgrep -ix "$DD_LOG_LEVEL" <<< "debug" ]
+  if [ grep -ix "$DD_LOG_LEVEL" <<< "debug" ]
   then
     echo "[bootstrap] DD_EXPERIMENTAL_ENABLE_PROXY is true"
     echo "[bootstrap] original AWS_LAMBDA_RUNTIME_API value is $AWS_LAMBDA_RUNTIME_API"

--- a/scripts/boot.sh
+++ b/scripts/boot.sh
@@ -10,7 +10,7 @@ then
 
   export AWS_LAMBDA_RUNTIME_API="127.0.0.1:9000"
 
-  if [ fgrep -ix "$DD_LOG_LEVEL" <<< "debug" ]
+  if [ grep -ix "$DD_LOG_LEVEL" <<< "debug" ]
   then
     echo "[bootstrap] rerouting AWS_LAMBDA_RUNTIME_API to $AWS_LAMBDA_RUNTIME_API"
   fi


### PR DESCRIPTION
Right now the bootstrap script always logs debug information. We should only do this if DD_LOG_LEVEL is set to DEBUG.