### PR TITLE
Bump the builder docker image to go 1.17

### DIFF
--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:experimental
 
-FROM golang:1.16.5 as builder
+FROM golang:1.17 as builder
 ARG EXTENSION_VERSION
 RUN mkdir -p /tmp/dd/datadog-agent
 


### PR DESCRIPTION
Since the agent is now built with 1.17 (https://github.com/DataDog/datadog-agent/pull/10689/files) this PR bumps our building image