### PR TITLE
Add the option to use go -race 

### DIFF
--- a/scripts/Dockerfile.race.build
+++ b/scripts/Dockerfile.race.build
@@ -1,0 +1,38 @@
+# syntax = docker/dockerfile:experimental
+
+FROM golang:1.16.5 as builder
+ARG EXTENSION_VERSION
+ARG ENABLE_RACE_DETECTION
+RUN mkdir -p /tmp/dd/datadog-agent
+
+# cache dependsencies
+COPY ./scripts/.cache/go.mod /tmp/dd/datadog-agent
+COPY ./scripts/.cache/go.sum /tmp/dd/datadog-agent
+WORKDIR /tmp/dd/datadog-agent
+
+# copy source files (/tgz gets unzip automatically by Docker)
+ADD ./scripts/.src/datadog-agent.tgz /tmp/dd
+
+# build the extension
+WORKDIR /tmp/dd/datadog-agent/cmd/serverless
+# add the current version number to the tags package before compilation
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -race -ldflags="-w -s \
+    -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
+    -tags serverless -o datadog-agent
+
+# zip the extension
+FROM ubuntu:latest as compresser
+RUN apt-get update
+RUN apt-get install -y zip
+RUN mkdir /extensions
+WORKDIR /extensions
+COPY --from=builder /tmp/dd/datadog-agent/cmd/serverless/datadog-agent /extensions/datadog-agent
+RUN  zip -r datadog_extension.zip /extensions
+
+# keep the smallest possible docker image
+FROM scratch
+COPY --from=compresser /extensions/datadog_extension.zip /
+ENTRYPOINT ["/datadog_extension.zip"]

--- a/scripts/build_binary_and_layer_dockerized.sh
+++ b/scripts/build_binary_and_layer_dockerized.sh
@@ -44,7 +44,6 @@ cd $AGENT_PATH/..
 tar --exclude=.git -czf $ROOT_DIR/scripts/.src/datadog-agent.tgz datadog-agent
 cd $ROOT_DIR
 
-# Make sure to use the right build file if we want race detection enabled
 BUILD_FILE=Dockerfile.build
 if [ "$RACE_DETECTION_ENABLED" = "true" ]; then
     BUILD_FILE=Dockerfile.race.build

--- a/scripts/build_binary_and_layer_dockerized.sh
+++ b/scripts/build_binary_and_layer_dockerized.sh
@@ -5,9 +5,9 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-# Usage examples : 
-# ARCHITECTURE=amd64 VERSION=100 ./scripts/build_binary_and_layer_dockerized.sh
-# or 
+# Usage examples :
+# ARCHITECTURE=amd64 VERSION=100 RACE_DETECTION_ENABLED=true ./scripts/build_binary_and_layer_dockerized.sh
+# or
 # VERSION=100 ./scripts/build_binary_and_layer_dockerized.sh
 
 if [ -z "$VERSION" ]; then
@@ -20,7 +20,7 @@ fi
 AGENT_PATH="../datadog-agent"
 
 # Move into the root directory, so this script can be called from any directory
-SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 ROOT_DIR=$SCRIPTS_DIR/..
 cd $ROOT_DIR
 
@@ -28,7 +28,7 @@ EXTENSION_DIR=".layers"
 TARGET_DIR=$(pwd)/$EXTENSION_DIR
 
 # Make sure the folder does not exist
-rm -rf $EXTENSION_DIR 2> /dev/null
+rm -rf $EXTENSION_DIR 2>/dev/null
 
 mkdir -p $EXTENSION_DIR
 
@@ -44,19 +44,24 @@ cd $AGENT_PATH/..
 tar --exclude=.git -czf $ROOT_DIR/scripts/.src/datadog-agent.tgz datadog-agent
 cd $ROOT_DIR
 
+# Make sure to use the right build file if we want race detection enabled
+BUILD_FILE=Dockerfile.build
+if [ "$RACE_DETECTION_ENABLED" = "true" ]; then
+    BUILD_FILE=Dockerfile.race.build
+fi
+
 function docker_build_zip {
     arch=$1
 
     docker buildx build --platform linux/${arch} \
         -t datadog/build-lambda-extension-${arch}:$VERSION \
-        -f ./scripts/Dockerfile.build \
+        -f ./scripts/$BUILD_FILE \
         --build-arg EXTENSION_VERSION="${VERSION}" . \
         --load
     dockerId=$(docker create datadog/build-lambda-extension-${arch}:$VERSION)
     docker cp $dockerId:/datadog_extension.zip $TARGET_DIR/datadog_extension-${arch}.zip
     unzip $TARGET_DIR/datadog_extension-${arch}.zip -d $TARGET_DIR/datadog_extension-${arch}
 }
-
 
 if [ "$ARCHITECTURE" == "amd64" ]; then
     echo "Building for amd64 only"


### PR DESCRIPTION
Created a secondary docker file, `Docker.race.build`, that will be used when `RACE_DETECTION_ENABLED` is set as `true`. It can be enabled with integration tests from the agent repo or when running the binary and layer build script individually.