### PR TITLE
Include tiered compilation for Java in wrapper script

### DIFF
--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -29,8 +29,8 @@ RUN apt-get install -y zip
 RUN mkdir /extensions
 WORKDIR /extensions
 COPY --from=builder /tmp/dd/datadog-agent/cmd/serverless/datadog-agent /extensions/datadog-agent
-COPY ./scripts/boot.sh /boot.sh
-RUN  zip -r datadog_extension.zip /extensions /boot.sh
+COPY ./scripts/datadog_wrapper.sh /datadog_wrapper.sh
+RUN  zip -r datadog_extension.zip /extensions /datadog_wrapper.sh
 
 # keep the smallest possible docker image
 FROM scratch

--- a/scripts/datadog_wrapper.sh
+++ b/scripts/datadog_wrapper.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 args=("$@")
 
-# lowercase DD_LOG_LEVEL
+# lowercase environment variables
 DD_LOG_LEVEL=$(echo "$DD_LOG_LEVEL" | tr '[:upper:]' '[:lower:]')
+DD_EXPERIMENTAL_ENABLE_PROXY=$(echo "$DD_EXPERIMENTAL_ENABLE_PROXY" | tr '[:upper:]' '[:lower:]')
+DD_OPTIMIZE_COLD_START=$(echo "$DD_OPTIMIZE_COLD_START" | tr '[:upper:]' '[:lower:]')
 
 if [ "$DD_EXPERIMENTAL_ENABLE_PROXY" == "true" ]
 then
@@ -19,4 +21,12 @@ then
     echo "[bootstrap] rerouting AWS_LAMBDA_RUNTIME_API to $AWS_LAMBDA_RUNTIME_API"
   fi
 fi
+
+# Optimize cold start performance for Java functions
+if [ "$DD_OPTIMIZE_COLD_START" != "false" ]
+then
+  # Stopping tiered compilation at level 1 reduces the time the JVM spends optimizing code
+  export _JAVA_OPTIONS="-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+fi
+
 exec "${args[@]}"


### PR DESCRIPTION
- Rename the wrapper script from `boot.sh` to `datadog_wrapper.sh` (the wrapper script hasn't been used by customers yet so this is not a breaking change)
- By default, set the `_JAVA_OPTIONS` environment variable to `-XX:+TieredCompilation -XX:TieredStopAtLevel=1` in the wrapper script. This will [stop tiered compilation at level 1](https://aws.amazon.com/blogs/compute/increasing-performance-of-java-aws-lambda-functions-using-tiered-compilation/), which will cause the JVM to spend less time optimizing the customer code. As a result, cold starts will take less time, though some functions that are called an extremely high number of times might see a negative performance impact.
- Add an environment variable `DD_OPTIMIZE_COLD_START` that can be set to `false` to disable the tiered compilation optimization. I don't think we should document this but if any customer wants to disable the optimization they will be able to do.

**NOTE:** The Java runtime will log `Picked up _JAVA_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1` on cold start when this optimization is applied.