### PR TITLE
Remove buildx (now integrated with Docker)

### DIFF
--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:experimental
+# syntax=docker/dockerfile:1.2
 
 FROM golang:1.17 as builder
 ARG EXTENSION_VERSION

--- a/scripts/build_binary_and_layer_dockerized.sh
+++ b/scripts/build_binary_and_layer_dockerized.sh
@@ -53,13 +53,13 @@ fi
 
 function docker_build_zip {
     arch=$1
-
-    docker buildx build --platform linux/${arch} \
+    DOCKER_BUILDKIT=1
+    docker build --platform linux/${arch} \
         -t datadog/build-lambda-extension-${arch}:$VERSION \
         -f ./scripts/$BUILD_FILE \
         --build-arg EXTENSION_VERSION="${VERSION}" \
         --build-arg AGENT_VERSION="${AGENT_VERSION}" \
-        . --load
+        .
     dockerId=$(docker create datadog/build-lambda-extension-${arch}:$VERSION)
     docker cp $dockerId:/datadog_extension.zip $TARGET_DIR/datadog_extension-${arch}.zip
     unzip $TARGET_DIR/datadog_extension-${arch}.zip -d $TARGET_DIR/datadog_extension-${arch}


### PR DESCRIPTION
Since Docker `18.09` Buildx is bundled with Docker (Source : https://docs.docker.com/develop/develop-images/build_enhancements/)