### PR TITLE
make boot.sh executable

### DIFF
--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -41,6 +41,7 @@ RUN mkdir /extensions
 WORKDIR /extensions
 COPY --from=builder /tmp/dd/datadog-agent/cmd/serverless/datadog-agent /extensions/datadog-agent
 COPY ./scripts/boot.sh /boot.sh
+RUN chmod +x /boot.sh
 RUN  zip -r datadog_extension.zip /extensions /boot.sh
 
 # keep the smallest possible docker image


### PR DESCRIPTION
make boot.sh executable
(integration test are now passing with this branch here : https://github.com/DataDog/datadog-agent/pull/11831)