### PR TITLE
Fix extension size

### DIFF
--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -36,10 +36,11 @@ RUN go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/ver
 # zip the extension
 FROM ubuntu:latest as compresser
 RUN apt-get update
-RUN apt-get install -y zip
+RUN apt-get install -y zip binutils
 RUN mkdir /extensions
 WORKDIR /extensions
 COPY --from=builder /tmp/dd/datadog-agent/cmd/serverless/datadog-agent /extensions/datadog-agent
+RUN strip /extensions/datadog-agent
 
 ARG DATADOG_WRAPPER=datadog_wrapper
 COPY ./scripts/$DATADOG_WRAPPER /$DATADOG_WRAPPER


### PR DESCRIPTION
In https://github.com/DataDog/datadog-lambda-extension/pull/55
the `-s` flag was removed

This flag was useful to reduce the binary size : 
```
-s : Omit the symbol table and debug information.
```
 (source: https://pkg.go.dev/cmd/link)

We cannot put it back since we need the symbol table to inject the agent-version (see screenshot)
![Screen Shot 2022-06-20 at 2 07 40 PM](https://user-images.githubusercontent.com/864493/174659071-ef77e0e5-d3a5-45a7-b9f1-17e15036d884.png)

The proposed solution is to use a tool AFTER the build `strip` to get rid of this symbol table after we've used it to inject the information : https://sourceware.org/binutils/docs/binutils/strip.html




