### PR TITLE
feat: pass compatible architectures

### DIFF
--- a/scripts/publish_layers.sh
+++ b/scripts/publish_layers.sh
@@ -96,8 +96,14 @@ publish_layer() {
     region=$1
     layer=$2
     file=$3
+    if [ "$layer" == "Datadog-Extension-ARM" ]; then
+      architecture="arm64"
+    else
+      architecture="x86_64"
+    fi
     version_nbr=$(aws lambda publish-layer-version --layer-name "${layer}" \
         --description "Datadog Lambda Extension" \
+        --compatible-architectures $architecture \
         --zip-file "fileb://${file}" \
         --region $region | jq -r '.Version')
 
@@ -134,7 +140,7 @@ do
 
             # This shouldn't happen unless someone manually deleted the latest version, say 28, and
             # then tries to republish 28 again. The published version would actually be 29, because
-            # Lambda layers are immutable and AWS will skip deleted version and use the next number. 
+            # Lambda layers are immutable and AWS will skip deleted version and use the next number.
             if [ $latest_version -gt $VERSION ]; then
                 echo "ERROR: Published version $latest_version is greater than the desired version $VERSION!"
                 echo "Exiting"


### PR DESCRIPTION
Pass arm64 or x86_64 to the compatible architectures flag, to prevent inadvertently instrumenting functions with the wrong architecture version of the extension.