### PR TITLE
Fix metric data loss from Java universal instrumentation 

### DIFF
--- a/scripts/datadog_wrapper
+++ b/scripts/datadog_wrapper
@@ -46,6 +46,7 @@ then
     echo "Configuring for the Java runtime!"
   fi
   export DD_JMXFETCH_ENABLED="false"
+  export DD_RUNTIME_METRICS_ENABLED="false"
   DD_Agent_Jar=/opt/java/lib/dd-java-agent.jar
   if [ -f "$DD_Agent_Jar" ] 
   then


### PR DESCRIPTION
This PR adds `DD_RUNTIME_METRICS_ENABLED` and set it to `false` to prevent any conflict between the extension dogstatsd server and the java tracer one.

Tests:

- Using `load-test-extension-checker` dashboard, we can now see 100% of the enhanced metrics being sent.
- No more `com.timgroup.statsd.StatsDClientException: Failed to start StatsD client` could be found in logs





