### PR TITLE
To find dotNet profilers from all possible directories

### DIFF
--- a/scripts/datadog_wrapper
+++ b/scripts/datadog_wrapper
@@ -32,9 +32,30 @@ then
   then
     echo "Configuring for the .NET runtime!"
   fi
+  # Handle the CORECLR_PROFILER_PATH
+  DEFAULT_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
+  ARM64_PATH=/opt/datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so
+  X64_PATH=/opt/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so
+  MUSL_X64_PATH=/opt/datadog/linux-musl-x64/Datadog.Trace.ClrProfiler.Native.so
+  PROFILER_PATHS=("${DEFAULT_PATH}" "${ARM64_PATH}" "${X64_PATH}" "${MUSL_X64_PATH}")
+  PROFILER_FOUND=false
+  ## Search from all possible places
+  for PROFILER_PATH in "${PROFILER_PATHS[@]}"
+  do
+  if [ -f "$PROFILER_PATH" ]
+  then
+    export CORECLR_PROFILER_PATH="$PROFILER_PATH"
+    PROFILER_FOUND=true
+    break
+  fi
+  done
+  if [ $PROFILER_FOUND == false ]
+  then
+    echo "CLR Profiler file not found. Function profiling may not work correctly"
+  fi
+  # Other env variables for .NET
   export CORECLR_ENABLE_PROFILING="1"
   export CORECLR_PROFILER="{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
-  export CORECLR_PROFILER_PATH="/opt/datadog/Datadog.Trace.ClrProfiler.Native.so"
   export DD_DOTNET_TRACER_HOME="/opt/datadog"
 fi
 

--- a/scripts/datadog_wrapper
+++ b/scripts/datadog_wrapper
@@ -36,8 +36,7 @@ then
   DEFAULT_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
   ARM64_PATH=/opt/datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so
   X64_PATH=/opt/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so
-  MUSL_X64_PATH=/opt/datadog/linux-musl-x64/Datadog.Trace.ClrProfiler.Native.so
-  PROFILER_PATHS=("${DEFAULT_PATH}" "${ARM64_PATH}" "${X64_PATH}" "${MUSL_X64_PATH}")
+  PROFILER_PATHS=("${DEFAULT_PATH}" "${ARM64_PATH}" "${X64_PATH}")
   PROFILER_FOUND=false
   ## Search from all possible places
   for PROFILER_PATH in "${PROFILER_PATHS[@]}"


### PR DESCRIPTION
What does this PR do?
To search .NET profiler from all possible directories.
The new dd-extension will support .NET running on arm64, while the profiler file may reside in a new different directory other than before.
This PR is to handle such scenario.

Motivation:
https://datadoghq.atlassian.net/browse/SLS-2190

Describe how to test/QA your changes
Manual e2e test