### PR TITLE
Build docker image using arm64 when on an M1 chip.

### DIFF
--- a/local_tests/build-docker-python.sh
+++ b/local_tests/build-docker-python.sh
@@ -2,26 +2,35 @@
 
 set -e
 
+# Determine architecture, M1 requires arm64 while Intel chip requires amd64
+if [ `uname -m` == "arm64" ]; then
+    LAYER_NAME=Datadog-Python39-ARM
+    ARCHITECTURE=arm64
+else
+    LAYER_NAME=Datadog-Python39
+    ARCHITECTURE=amd64
+fi
+
 # Save the current path
 CURRENT_PATH=$(pwd)
 
 # Build the extension
-ARCHITECTURE=amd64 VERSION=1 ./scripts/build_binary_and_layer_dockerized.sh
+VERSION=1 ./scripts/build_binary_and_layer_dockerized.sh
 
 # Move to the local_tests repo
 cd ./local_tests
 
 # Copy the newly built extension in the same folder as the Dockerfile
-cp ../.layers/datadog_extension-amd64/extensions/datadog-agent .
+cp ../.layers/datadog_extension-$ARCHITECTURE/extensions/datadog-agent .
 
 # Build the recorder extension which will act as a man-in-a-middle to intercept payloads sent to Datadog
 cd ../../datadog-agent/test/integration/serverless/recorder-extension
-GOOS=linux GOARCH=amd64 go build -o "$CURRENT_PATH/local_tests/recorder-extension" main.go
+GOOS=linux GOARCH=$ARCHITECTURE go build -o "$CURRENT_PATH/local_tests/recorder-extension" main.go
 cd "$CURRENT_PATH/local_tests"
 
 # Get the latest available version
 LATEST_AVAILABLE_VERSION=$(aws-vault exec sandbox-account-admin \
--- aws lambda list-layer-versions --layer-name Datadog-Python39 --region sa-east-1 --max-items 1 \
+-- aws lambda list-layer-versions --layer-name $LAYER_NAME --region sa-east-1 --max-items 1 \
 | jq -r ".LayerVersions | .[0] |  .Version")
 
 # If not yet downloaded, download and unzip
@@ -32,7 +41,7 @@ if test -f "$PYTHON_LAYER"; then
 else 
     echo "Downloading the latest Python layer (version $LATEST_AVAILABLE_VERSION)"
     URL=$(aws-vault exec sandbox-account-admin \
-        -- aws lambda get-layer-version --layer-name Datadog-Python39 --version-number $LATEST_AVAILABLE_VERSION \
+        -- aws lambda get-layer-version --layer-name $LAYER_NAME --version-number $LATEST_AVAILABLE_VERSION \
         --query Content.Location --region sa-east-1 --output text)
     curl $URL -o "$PYTHON_LAYER"
     rm -rf $CURRENT_PATH/local_tests/META_INF


### PR DESCRIPTION
For those using the new M1 macbooks, the extension and layer must be built with `arm64` architecture instead of `amd64`. We can determine this dynamically using the `uname -m` command which will return `arm64` if on an M1.

Note I have not tested this on a non M1 computer. I would like to ask someone to do this before I merge.