### PR TITLE
Pass architecture to build script.

### DIFF
--- a/local_tests/build-docker-python.sh
+++ b/local_tests/build-docker-python.sh
@@ -15,7 +15,7 @@ fi
 CURRENT_PATH=$(pwd)
 
 # Build the extension
-VERSION=1 ./scripts/build_binary_and_layer_dockerized.sh
+ARCHITECTURE=$ARCHITECTURE VERSION=1 ./scripts/build_binary_and_layer_dockerized.sh
 
 # Move to the local_tests repo
 cd ./local_tests


### PR DESCRIPTION
This was erroneous removed as part of https://github.com/DataDog/datadog-lambda-extension/pull/73. Without this variable the `scripts/build_binary_and_layer_dockerized.sh` script will always build for both `arm64` and `amd64`.