### PR TITLE
feat: custom layer names

### DIFF
--- a/scripts/publish_layers.sh
+++ b/scripts/publish_layers.sh
@@ -136,6 +136,9 @@ for region in $REGIONS
 do
     echo "Starting publishing layers for region $region..."
     for layer_name in "${LAYERS[@]}"; do
+        if [ ! -z "$SUFFIX" ]; then
+            layer_name+="-$SUFFIX"
+        fi
         latest_version=$(aws lambda list-layer-versions --region $region --layer-name "${layer_name}" --query 'LayerVersions[0].Version || `0`')
         if [ $latest_version -ge $VERSION ]; then
             echo "Layer $layer_name  version $VERSION already exists in region $region, skipping..."

--- a/scripts/publish_sandbox.sh
+++ b/scripts/publish_sandbox.sh
@@ -32,7 +32,7 @@ if [ "$ARCHITECTURE" == "arm64" ]; then
 fi
 
 if [ ! -z "$SUFFIX" ]; then
-   LAYER_NAME+="$SUFFIX"
+   LAYER_NAME+="-$SUFFIX"
 fi
 
 REGION="sa-east-1"

--- a/scripts/publish_sandbox.sh
+++ b/scripts/publish_sandbox.sh
@@ -31,6 +31,10 @@ if [ "$ARCHITECTURE" == "arm64" ]; then
     LAYER_NAME="Datadog-Extension-ARM"
 fi
 
+if [ ! -z "$SUFFIX" ]; then
+   LAYER_NAME+="$SUFFIX"
+fi
+
 REGION="sa-east-1"
 if [ "$RELEASE_CANDIDATE" == "true" ]; then
     echo "Will publish as a release candidate to us-east-1"


### PR DESCRIPTION
This PR is a redux of https://github.com/DataDog/datadog-lambda-extension/pull/26/files, but basically just adds a SUFFIX to layer names. Usage is like so:
`SUFFIX=aj-`
thus:
![image](https://user-images.githubusercontent.com/1598537/195174407-0ee4b8f0-1ff4-4119-a002-0f167922bd94.png)
