### PR TITLE
Build with go 1.18 instead of 1.17 (sync with agent)

### DIFF
--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:experimental
 
-FROM golang:1.17 as builder
+FROM golang:1.18 as builder
 ARG EXTENSION_VERSION
 ARG AGENT_VERSION
 ARG CMD_PATH


### PR DESCRIPTION
The agent is currently built with go 1.18.8 (https://github.com/DataDog/datadog-agent/blob/main/.go-version). This repo most likely should be kept in sync.