### PR TITLE
fix: unset aws_vault env variable to avoid warning and flaky runs

### DIFF
--- a/scripts/publish_sandbox.sh
+++ b/scripts/publish_sandbox.sh
@@ -14,6 +14,8 @@
 
 set -e
 
+unset AWS_VAULT
+
 if [ -z $ARCHITECTURE ]; then
     echo "No architecture specified, defaulting to amd64"
     ARCHITECTURE="amd64"


### PR DESCRIPTION
If `aws-vault` already set the AWS_VAULT from the script caller, it would cause the error
```
aws-vault: error: exec: aws-vault sessions should be nested with care, unset AWS_VAULT to force
```
and might create conflicts of aws profiles used running the script