### PR TITLE
[build tools] deploy + invoke function commands

### DIFF
--- a/build-tools/Cargo.lock
+++ b/build-tools/Cargo.lock
@@ -520,6 +520,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
 name = "base64-simd"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +561,8 @@ dependencies = [
  "aws-sdk-signer",
  "aws-sdk-sts",
  "rand",
+ "reqwest",
+ "serde",
  "structopt",
  "tokio",
 ]
@@ -699,6 +707,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +729,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -736,6 +768,12 @@ name = "futures-core"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+
+[[package]]
+name = "futures-io"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-macro"
@@ -767,8 +805,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -937,6 +977,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,6 +1026,12 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "itoa"
@@ -1036,6 +1095,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
 name = "mio"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,6 +1110,24 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1089,10 +1172,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openssl"
+version = "0.10.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "outref"
@@ -1160,6 +1282,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "polyval"
@@ -1278,6 +1406,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
+dependencies = [
+ "base64 0.21.0",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1331,7 +1505,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -1397,9 +1571,46 @@ checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "sha1"
@@ -1510,13 +1721,27 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]
@@ -1598,6 +1823,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -1776,6 +2011,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1826,6 +2067,18 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1998,6 +2251,15 @@ name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "xmlparser"

--- a/build-tools/Cargo.lock
+++ b/build-tools/Cargo.lock
@@ -1204,6 +1204,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.24.0+1.1.1s"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3498f259dab01178c6228c6b00dcef0ed2a2d5e20d648c017861227773ea4abd"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,6 +1221,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/build-tools/Cargo.lock
+++ b/build-tools/Cargo.lock
@@ -74,10 +74,11 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-config"
-version = "0.51.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56a636c44c77fa18bdba56126a34d30cfe5538fe88f7d34988fa731fee143ddd"
+checksum = "741327a7f70e6e639bdb5061964c66250460c70ad3f59c3fe2a3a64ac1484e33"
 dependencies = [
+ "aws-credential-types",
  "aws-http",
  "aws-sdk-sso",
  "aws-sdk-sts",
@@ -101,10 +102,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-endpoint"
-version = "0.51.0"
+name = "aws-credential-types"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ca8f374874f6459aaa88dc861d7f5d834ca1ff97668eae190e97266b5f6c3fb"
+checksum = "5f99dd587a46af58f8cf37773687ecec19d0373a5954942d7e0f405751fe2369"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-endpoint"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13fdfc00c57d95e10bcf83d2331c4ae9ca460ca84dc983b2cdd692de87640389"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -116,10 +130,11 @@ dependencies = [
 
 [[package]]
 name = "aws-http"
-version = "0.51.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78d41e19e779b73463f5f0c21b3aacc995f4ba783ab13a7ae9f5dfb159a551b4"
+checksum = "74cdac70481d144bf7001c27884b95ee12c8f62e61db90320d59b673ae121cb8"
 dependencies = [
+ "aws-credential-types",
  "aws-smithy-http",
  "aws-smithy-types",
  "aws-types",
@@ -134,10 +149,11 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ec2"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77e41e0567b874c884661a1eb777f006679464110e6f95c7bafafe0fb607e10"
+checksum = "09012ebcb0456e7876db6a3b1aa82dc815a734976f91d12863bdabb4839e0b75"
 dependencies = [
+ "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
@@ -145,6 +161,7 @@ dependencies = [
  "aws-smithy-client",
  "aws-smithy-http",
  "aws-smithy-http-tower",
+ "aws-smithy-json",
  "aws-smithy-query",
  "aws-smithy-types",
  "aws-smithy-xml",
@@ -152,16 +169,19 @@ dependencies = [
  "bytes",
  "fastrand",
  "http",
+ "regex",
  "tokio-stream",
  "tower",
+ "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-lambda"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42af7ca02993f9960ab32d18121eb80772e7b64f089852f365d1e59b73e5cd6e"
+checksum = "76920987023931bb62faa01800ea9b68e15209b5aa176c7bb20834bb66c95e46"
 dependencies = [
+ "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
@@ -174,16 +194,20 @@ dependencies = [
  "aws-types",
  "bytes",
  "http",
+ "regex",
  "tokio-stream",
  "tower",
+ "tracing",
+ "url",
 ]
 
 [[package]]
 name = "aws-sdk-s3"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f08665c8e03aca8cb092ef01e617436ebfa977fddc1240e1b062488ab5d48a"
+checksum = "5ae411cb03ea6df0d4c4340a0d3c15cab7b19715d091f76c5629f31acd6403f3"
 dependencies = [
+ "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
@@ -194,24 +218,31 @@ dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-http",
  "aws-smithy-http-tower",
+ "aws-smithy-json",
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
  "bytes",
  "bytes-utils",
+ "fastrand",
  "http",
  "http-body",
+ "once_cell",
+ "percent-encoding",
+ "regex",
  "tokio-stream",
  "tower",
  "tracing",
+ "url",
 ]
 
 [[package]]
 name = "aws-sdk-signer"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "340cb33dba03017cf01b2f14e0e49d90cb54e79c4b0c06c672e24b2abd28fb33"
+checksum = "50b2a5f138904754ebe9594502e1a96a1c3ea99466e2f714af2cce40a727b793"
 dependencies = [
+ "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
@@ -225,16 +256,19 @@ dependencies = [
  "bytes",
  "fastrand",
  "http",
+ "regex",
  "tokio-stream",
  "tower",
+ "url",
 ]
 
 [[package]]
 name = "aws-sdk-sso"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86dcb1cb71aa8763b327542ead410424515cff0cde5b753eedd2917e09c63734"
+checksum = "d5d2fb56182ac693a19364cc0bde22d95aef9be3663bf9b906ffbd0ab0a7c7d1"
 dependencies = [
+ "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
@@ -247,16 +281,19 @@ dependencies = [
  "aws-types",
  "bytes",
  "http",
+ "regex",
  "tokio-stream",
  "tower",
+ "url",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdfcf584297c666f6b472d5368a78de3bc714b6e0a53d7fbf76c3e347c292ab1"
+checksum = "a70adf3e9518c8d6d14f1239f6af04c019ffd260ab791e17deb11f1bce6a9f76"
 dependencies = [
+ "aws-credential-types",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
@@ -264,21 +301,26 @@ dependencies = [
  "aws-smithy-client",
  "aws-smithy-http",
  "aws-smithy-http-tower",
+ "aws-smithy-json",
  "aws-smithy-query",
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
  "bytes",
  "http",
+ "regex",
  "tower",
+ "tracing",
+ "url",
 ]
 
 [[package]]
 name = "aws-sig-auth"
-version = "0.51.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cbe7b2be9e185c1fbce27fc9c41c66b195b32d89aa099f98768d9544221308"
+checksum = "22af7f6515f8b51dabef87df1d901c9734e4e367791c6d0e1082f9f31528120e"
 dependencies = [
+ "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-eventstream",
  "aws-smithy-http",
@@ -289,29 +331,30 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "0.51.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ff4cff8c4a101962d593ba94e72cd83891aecd423f0c6e3146bff6fb92c9e3"
+checksum = "eee0d796882321e91ca7b991ab6193864e04b605be3a6c18adb9134a90d5a860"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-http",
  "bytes",
  "form_urlencoded",
  "hex",
+ "hmac",
  "http",
  "once_cell",
  "percent-encoding",
  "regex",
- "ring",
+ "sha2",
  "time",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-async"
-version = "0.51.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b3442b4c5d3fc39891a2e5e625735fba6b24694887d49c6518460fde98247a9"
+checksum = "d8b9900be224962d65a626072d8777f847ae5406c07547f0dc14c60048978c4b"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -321,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.51.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc227e36e346f45298288359f37123e1a92628d1cec6b11b5eb335553278bd9e"
+checksum = "85e9e4d3c2296bcec2c03f9f769ac9b2424d972c2fe7afc0b59235447ac3a5c3"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -342,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-client"
-version = "0.51.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff28d553714f8f54cd921227934fc13a536a1c03f106e56b362fd57e16d450ad"
+checksum = "710ca0f8dacddda5fbcaf5c3cd9d02da7913fd463a2ee9555b617bf168bedacb"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -365,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.51.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ea0df7161ce65b5c8ca6eb709a1a907376fa18226976e41c748ce02ccccf24"
+checksum = "8d1ff11ee22de3581114b60d4ae8e700638dacb5b5bbe6769726e251e6c3f20a"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -376,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.51.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf58ed4fefa61dbf038e5421a521cbc2c448ef69deff0ab1d915d8a10eda5664"
+checksum = "29dcab29afbea7726f5c10c7be0c38666d7eb07db551580b3b26ed7cfb5d1935"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-types",
@@ -399,11 +442,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-tower"
-version = "0.51.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c96d7bd35e7cf96aca1134b2f81b1b59ffe493f7c6539c051791cbbf7a42d3"
+checksum = "f5856d2f1063c0f726a85f32dcd2a9f5a1d994eb27b156abccafc7260f3f471d"
 dependencies = [
  "aws-smithy-http",
+ "aws-smithy-types",
  "bytes",
  "http",
  "http-body",
@@ -414,18 +458,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.51.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8324ba98c8a94187723cc16c37aefa09504646ee65c3d2c3af495bab5ea701b"
+checksum = "dfb33659b68480495b5f906b946c8642928440118b1d7e26a25a067303ca01a5"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.51.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83834ed2ff69ea6f6657baf205267dc2c0abe940703503a3e5d60ce23be3d306"
+checksum = "9c4b21ee0e30ff046e87c7b7e017b99d445b42a81fe52c6e5139b23b795a98ae"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -433,10 +477,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "0.51.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b02e06ea63498c43bc0217ea4d16605d4e58d85c12fc23f6572ff6d0a840c61"
+checksum = "2013465a070decdeb3e85ceb3370ae85ba05f56f914abfd89858d7281c4f12c3"
 dependencies = [
+ "base64-simd",
  "itoa",
  "num-integer",
  "ryu",
@@ -445,19 +490,20 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.51.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246e9f83dd1fdf5d347fa30ae4ad30a9d1d42ce4cd74a93d94afa874646f94cd"
+checksum = "6d27bfaa164aa94aac721726a83aa78abe708a275e88a573e103b4961c5f0ede"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "0.51.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05701d32da168b44f7ee63147781aed8723e792cc131cb9b18363b5393f17f70"
+checksum = "61f00f4b0cdd345686e6389f3343a3020f93232d20040802b87673ddc2d02956"
 dependencies = [
+ "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-client",
  "aws-smithy-http",
@@ -465,7 +511,6 @@ dependencies = [
  "http",
  "rustc_version",
  "tracing",
- "zeroize",
 ]
 
 [[package]]
@@ -473,6 +518,15 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64-simd"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "781dd20c3aff0bd194fe7d2a977dd92f21c173891f3a03b677359e5fa457e5d5"
+dependencies = [
+ "simd-abstraction",
+]
 
 [[package]]
 name = "bitflags"
@@ -635,6 +689,7 @@ checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -800,6 +855,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "http"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,6 +934,16 @@ dependencies = [
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -1019,6 +1093,12 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "outref"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
 
 [[package]]
 name = "parking_lot"
@@ -1353,6 +1433,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-abstraction"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cadb29c57caadc51ff8346233b5cec1d240b68ce55cf1afc764818791876987"
+dependencies = [
+ "outref",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,6 +1553,21 @@ checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
 dependencies = [
  "time-core",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
@@ -1606,10 +1710,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -1638,6 +1757,17 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "urlencoding"

--- a/build-tools/Cargo.toml
+++ b/build-tools/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 
 [dependencies]
 aes-gcm = "0.10.1"
-aws-config = "0.51.0"
-aws-sdk-ec2 = "0.21.0"
-aws-sdk-lambda = "0.21.0"
-aws-sdk-s3 = "0.21.0"
-aws-sdk-signer = "0.21.0"
-aws-sdk-sts = "0.21.0"
+aws-config = "0.53.0"
+aws-sdk-ec2 = "0.23.0"
+aws-sdk-lambda = "0.23.0"
+aws-sdk-s3 = "0.23.0"
+aws-sdk-signer = "0.23.0"
+aws-sdk-sts = "0.23.0"
 rand = "0.8.5"
 structopt = "0.3.26"
 tokio = { version = "1", features = ["full"] }

--- a/build-tools/Cargo.toml
+++ b/build-tools/Cargo.toml
@@ -12,5 +12,7 @@ aws-sdk-s3 = "0.23.0"
 aws-sdk-signer = "0.23.0"
 aws-sdk-sts = "0.23.0"
 rand = "0.8.5"
+reqwest = { version = "0.11.14", features = ["json", "blocking"] }
+serde = { version = "1.0.152", features = ["derive"] }
 structopt = "0.3.26"
 tokio = { version = "1", features = ["full"] }

--- a/build-tools/Cargo.toml
+++ b/build-tools/Cargo.toml
@@ -12,7 +12,7 @@ aws-sdk-s3 = "0.23.0"
 aws-sdk-signer = "0.23.0"
 aws-sdk-sts = "0.23.0"
 rand = "0.8.5"
-reqwest = { version = "0.11.14", features = ["json", "blocking"] }
+reqwest = { version = "0.11.14", features = ["json", "blocking","native-tls-vendored"] }
 serde = { version = "1.0.152", features = ["derive"] }
 structopt = "0.3.26"
 tokio = { version = "1", features = ["full"] }

--- a/build-tools/Dockerfile
+++ b/build-tools/Dockerfile
@@ -9,7 +9,7 @@ COPY src ./src
 RUN touch -a -m ./src/main.rs
 RUN cargo build --release
 
-FROM ubuntu:bionic as compresser
+FROM ubuntu:jammy as compresser
 RUN apt-get update
 RUN apt-get install -y zip
 RUN mkdir -p /bin

--- a/build-tools/src/commands/common.rs
+++ b/build-tools/src/commands/common.rs
@@ -1,3 +1,6 @@
+use std::{fs::File, io::Read};
+
+use aws_sdk_ec2::types::Blob;
 use structopt::clap::arg_enum;
 
 arg_enum! {
@@ -6,4 +9,12 @@ arg_enum! {
         Arm64,
         Amd64
     }
+}
+
+pub fn get_file_as_vec(filename: &String) -> Blob {
+    let mut f = File::open(filename).expect("could not find the zip");
+    let metadata = std::fs::metadata(filename).expect("unable to read metadata");
+    let mut buffer = vec![0; metadata.len() as usize];
+    f.read_exact(&mut buffer).expect("buffer error");
+    Blob::new(buffer)
 }

--- a/build-tools/src/commands/deploy_command.rs
+++ b/build-tools/src/commands/deploy_command.rs
@@ -20,7 +20,7 @@ pub struct DeployOptions {
     #[structopt(long)]
     layer_suffix: Option<String>,
     #[structopt(long)]
-    key: String,
+    key: Option<String>,
     #[structopt(long, default_value = "sa-east-1")]
     region: String,
 }

--- a/build-tools/src/commands/deploy_command.rs
+++ b/build-tools/src/commands/deploy_command.rs
@@ -1,5 +1,3 @@
-use std::fs::File;
-use std::io::Read;
 use std::io::Result;
 use structopt::StructOpt;
 
@@ -7,6 +5,7 @@ use aws_sdk_lambda as lambda;
 
 use crate::security::build_config;
 
+use super::common::get_file_as_vec;
 use super::common::BuildArchitecture;
 
 #[derive(Debug, StructOpt)]
@@ -31,8 +30,7 @@ pub async fn deploy(args: &DeployOptions) -> Result<()> {
 
     // build the content object
     let content = aws_sdk_lambda::model::LayerVersionContentInput::builder();
-    let blob = get_file_as_vec(&args.layer_path);
-    let lambda_blob = aws_sdk_lambda::types::Blob::new(blob);
+    let lambda_blob = get_file_as_vec(&args.layer_path);
 
     let layer_name = build_layer_name(&args.layer_name, &args.architecture, &args.layer_suffix);
 
@@ -65,14 +63,6 @@ fn build_layer_name(
         BuildArchitecture::Arm64 => layer_with_suffix + "-ARM",
     };
     layer.replace(".", "") //layer cannot contain dots
-}
-
-fn get_file_as_vec(filename: &String) -> Vec<u8> {
-    let mut f = File::open(filename).expect("could not find the zip");
-    let metadata = std::fs::metadata(filename).expect("unable to read metadata");
-    let mut buffer = vec![0; metadata.len() as usize];
-    f.read_exact(&mut buffer).expect("buffer error");
-    buffer
 }
 
 #[cfg(test)]

--- a/build-tools/src/commands/deploy_command.rs
+++ b/build-tools/src/commands/deploy_command.rs
@@ -62,7 +62,7 @@ fn build_layer_name(
         BuildArchitecture::Amd64 => layer_with_suffix,
         BuildArchitecture::Arm64 => layer_with_suffix + "-ARM",
     };
-    layer.replace(".", "") //layer cannot contain dots
+    layer.replace('.', "") //layer cannot contain dots
 }
 
 #[cfg(test)]

--- a/build-tools/src/commands/deploy_command.rs
+++ b/build-tools/src/commands/deploy_command.rs
@@ -60,10 +60,11 @@ fn build_layer_name(
     } else {
         String::from(layer_name)
     };
-    match architecture {
+    let layer = match architecture {
         BuildArchitecture::Amd64 => layer_with_suffix,
         BuildArchitecture::Arm64 => layer_with_suffix + "-ARM",
-    }
+    };
+    layer.replace(".", "") //layer cannot contain dots
 }
 
 fn get_file_as_vec(filename: &String) -> Vec<u8> {

--- a/build-tools/src/commands/deploy_function_command.rs
+++ b/build-tools/src/commands/deploy_function_command.rs
@@ -1,0 +1,20 @@
+use std::env;
+use std::io::Result;
+use std::process::Command;
+use structopt::StructOpt;
+
+use super::common::BuildArchitecture;
+
+#[derive(Debug, StructOpt)]
+pub struct DeployFunctionOptions {
+    #[structopt(long)]
+    layer_name: String,
+    #[structopt(long)]
+    layer_version: i32,
+    #[structopt(long)]
+    runtime: String,
+}
+
+pub async fn deploy_function(args: &DeployFunctionOptions) -> Result<()> {
+    Ok(())
+}

--- a/build-tools/src/commands/deploy_function_command.rs
+++ b/build-tools/src/commands/deploy_function_command.rs
@@ -1,8 +1,41 @@
+use lambda::model::{Environment, FunctionCode, Runtime};
+use std::collections::HashMap;
 use std::io::Result;
 use std::io::{Error, ErrorKind};
+use std::time::SystemTime;
 use structopt::StructOpt;
 
 use aws_sdk_lambda as lambda;
+
+use super::common::get_file_as_vec;
+
+struct RuntimeConfig {
+    handler: String,
+    dd_handler: String,
+    package_path: String,
+    runtime: Runtime,
+}
+
+impl RuntimeConfig {
+    fn new(handler: String, dd_handler: String, package_path: String, runtime: Runtime) -> Self {
+        RuntimeConfig {
+            handler,
+            dd_handler,
+            package_path,
+            runtime,
+        }
+    }
+    fn generate_function_name(&self) -> String {
+        let current_timestamp = SystemTime::now()
+            .elapsed()
+            .expect("could not get the current timestamp");
+        format!(
+            "serverless-perf-test-{}-{}",
+            self.runtime.as_str(),
+            current_timestamp.as_secs()
+        )
+    }
+}
 
 #[derive(Debug, StructOpt)]
 pub struct DeployFunctionOptions {
@@ -12,19 +45,57 @@ pub struct DeployFunctionOptions {
     runtime: String,
     #[structopt(long)]
     region: String,
+    #[structopt(long)]
+    role: String,
+    #[structopt(long)]
+    extension_arn: String,
+    #[structopt(long)]
+    api_key: String,
 }
 
 pub async fn deploy_function(args: &DeployFunctionOptions) -> Result<()> {
-    let latest_layer_version = get_latest_version(&args.layer_name, &args.region).await?;
-
+    std::env::set_var("AWS_REGION", &args.region);
+    let config = aws_config::load_from_env().await;
+    let lambda_client = lambda::Client::new(&config);
+    let layer_arn = get_latest_arn(&lambda_client, &args.layer_name).await?;
+    create_function(&lambda_client, &args, layer_arn).await?;
     Ok(())
 }
 
-async fn get_latest_version(layer_name: &str, region: &str) -> Result<i64> {
-    std::env::set_var("AWS_REGION", region);
-    let config = aws_config::load_from_env().await;
-    let lambda_client = lambda::Client::new(&config);
-    let result = lambda_client
+async fn create_function(
+    client: &lambda::Client,
+    args: &DeployFunctionOptions,
+    layer_arn: String,
+) -> Result<()> {
+    let runtime_config = get_config_from_runtime(&args.runtime)?;
+    let function_name = runtime_config.generate_function_name();
+    let mut env_map = HashMap::new();
+    env_map.insert(String::from("DD_LAMBDA_HANDLER"), runtime_config.dd_handler);
+    env_map.insert(String::from("DD_API_KEY"), args.api_key.clone());
+    let environment = Environment::builder().set_variables(Some(env_map)).build();
+
+    let lambda_blob = get_file_as_vec(&runtime_config.package_path);
+    let function_code = FunctionCode::builder()
+        .set_zip_file(Some(lambda_blob))
+        .build();
+
+    client
+        .create_function()
+        .set_role(Some(args.role.clone()))
+        .set_function_name(Some(function_name))
+        .set_code(Some(function_code))
+        .set_runtime(Some(runtime_config.runtime))
+        .set_handler(Some(runtime_config.handler))
+        .set_layers(Some(vec![layer_arn, args.extension_arn.clone()]))
+        .set_environment(Some(environment))
+        .send()
+        .await
+        .expect("could not deploy the function");
+    Ok(())
+}
+
+async fn get_latest_arn(client: &lambda::Client, layer_name: &str) -> Result<String> {
+    let result = client
         .list_layer_versions()
         .set_layer_name(Some(String::from(layer_name)))
         .set_max_items(Some(1))
@@ -34,12 +105,54 @@ async fn get_latest_version(layer_name: &str, region: &str) -> Result<i64> {
 
     let layer_versions = match result.layer_versions() {
         Some(layer_versions) => layer_versions,
-        None => return Err(Error::new(ErrorKind::InvalidData, "could not get layer versions")),
+        None => {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                "could not get layer versions",
+            ))
+        }
     };
-    
+
     let latest_version = match layer_versions.first() {
-        Some(latest_version) => latest_version,
-        None => return Err(Error::new(ErrorKind::InvalidData, "could not get layer versions")),
+        Some(latest_version) => latest_version.layer_version_arn(),
+        None => {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                "could not get layer versions",
+            ))
+        }
     };
-    Ok(latest_version.version())
+    match latest_version {
+        Some(version) => Ok(version.to_string()),
+        None => {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                "could not get layer versions",
+            ))
+        }
+    }
+}
+
+fn get_config_from_runtime(runtime: &str) -> Result<RuntimeConfig> {
+    match runtime {
+        "nodejs14.x" => Ok(RuntimeConfig::new(
+            String::from("app.handler"),
+            String::from("/opt/nodejs/node_modules/datadog-lambda-js/handler.handler"),
+            String::from("functions/nodejs.zip"),
+            lambda::model::Runtime::Nodejs14x,
+        )),
+        "nodejs16.x" => Ok(RuntimeConfig::new(
+            String::from("app.handler"),
+            String::from("/opt/nodejs/node_modules/datadog-lambda-js/handler.handler"),
+            String::from("functions/nodejs.zip"),
+            lambda::model::Runtime::Nodejs16x,
+        )),
+        "nodejs18.x" => Ok(RuntimeConfig::new(
+            String::from("app.handler"),
+            String::from("/opt/nodejs/node_modules/datadog-lambda-js/handler.handler"),
+            String::from("functions/nodejs.zip"),
+            lambda::model::Runtime::Nodejs18x,
+        )),
+        _ => Err(Error::new(ErrorKind::InvalidData, "invalid runtime")),
+    }
 }

--- a/build-tools/src/commands/deploy_function_command.rs
+++ b/build-tools/src/commands/deploy_function_command.rs
@@ -1,20 +1,45 @@
-use std::env;
 use std::io::Result;
-use std::process::Command;
+use std::io::{Error, ErrorKind};
 use structopt::StructOpt;
 
-use super::common::BuildArchitecture;
+use aws_sdk_lambda as lambda;
 
 #[derive(Debug, StructOpt)]
 pub struct DeployFunctionOptions {
     #[structopt(long)]
     layer_name: String,
     #[structopt(long)]
-    layer_version: i32,
-    #[structopt(long)]
     runtime: String,
+    #[structopt(long)]
+    region: String,
 }
 
 pub async fn deploy_function(args: &DeployFunctionOptions) -> Result<()> {
+    let latest_layer_version = get_latest_version(&args.layer_name, &args.region).await?;
+
     Ok(())
+}
+
+async fn get_latest_version(layer_name: &str, region: &str) -> Result<i64> {
+    std::env::set_var("AWS_REGION", region);
+    let config = aws_config::load_from_env().await;
+    let lambda_client = lambda::Client::new(&config);
+    let result = lambda_client
+        .list_layer_versions()
+        .set_layer_name(Some(String::from(layer_name)))
+        .set_max_items(Some(1))
+        .send()
+        .await
+        .expect("could not list layer versions");
+
+    let layer_versions = match result.layer_versions() {
+        Some(layer_versions) => layer_versions,
+        None => return Err(Error::new(ErrorKind::InvalidData, "could not get layer versions")),
+    };
+    
+    let latest_version = match layer_versions.first() {
+        Some(latest_version) => latest_version,
+        None => return Err(Error::new(ErrorKind::InvalidData, "could not get layer versions")),
+    };
+    Ok(latest_version.version())
 }

--- a/build-tools/src/commands/deploy_function_command.rs
+++ b/build-tools/src/commands/deploy_function_command.rs
@@ -167,22 +167,21 @@ fn get_config_from_runtime(runtime: &str) -> Result<RuntimeConfig> {
 }
 
 fn get_latest_extension_arn(region: &str) -> String {
-    let version = get_latest_extension();
+    let version = fetch_extension_version_from_github();
     format!(
         "arn:aws:lambda:{}:464622532012:layer:Datadog-Extension:{}",
         version, region
     )
 }
 
-fn get_latest_extension() -> String {
+fn fetch_extension_version_from_github() -> String {
     let client = reqwest::blocking::Client::new();
     let result = match client.post(LATEST_RELEASE).send() {
         Ok(result) => result,
         Err(_) => return FALLBACK_LATEST_EXTESION_VERSION.to_string(),
     };
-    let result = match result.json::<GithubRelease>() {
-        Ok(result) => result,
-        Err(_) => return FALLBACK_LATEST_EXTESION_VERSION.to_string(),
-    };
-    result.tag_name.replace(['v', '.'], "").trim().to_string()
+    match result.json::<GithubRelease>() {
+        Ok(result) => result.tag_name.replace(['.', 'v'], "").trim().to_string(),
+        Err(_) => FALLBACK_LATEST_EXTESION_VERSION.to_string(),
+    }
 }

--- a/build-tools/src/commands/deploy_function_command.rs
+++ b/build-tools/src/commands/deploy_function_command.rs
@@ -135,7 +135,7 @@ async fn get_latest_arn(client: &lambda::Client, layer_name: &str) -> Result<Str
     let layer_name = layer_name.replace('.', ""); // layers cannot contain dots
     let result = client
         .list_layer_versions()
-        .set_layer_name(Some(String::from(layer_name)))
+        .set_layer_name(Some(layer_name))
         .set_max_items(Some(1))
         .send()
         .await

--- a/build-tools/src/commands/deploy_function_command.rs
+++ b/build-tools/src/commands/deploy_function_command.rs
@@ -58,7 +58,7 @@ pub async fn deploy_function(args: &DeployFunctionOptions) -> Result<()> {
     let config = aws_config::load_from_env().await;
     let lambda_client = lambda::Client::new(&config);
     let layer_arn = get_latest_arn(&lambda_client, &args.layer_name).await?;
-    create_function(&lambda_client, &args, layer_arn).await?;
+    create_function(&lambda_client, args, layer_arn).await?;
     Ok(())
 }
 
@@ -124,12 +124,10 @@ async fn get_latest_arn(client: &lambda::Client, layer_name: &str) -> Result<Str
     };
     match latest_version {
         Some(version) => Ok(version.to_string()),
-        None => {
-            return Err(Error::new(
-                ErrorKind::InvalidData,
-                "could not get layer versions",
-            ))
-        }
+        None => Err(Error::new(
+            ErrorKind::InvalidData,
+            "could not get layer versions",
+        )),
     }
 }
 

--- a/build-tools/src/commands/deploy_function_command.rs
+++ b/build-tools/src/commands/deploy_function_command.rs
@@ -184,10 +184,5 @@ fn get_latest_extension() -> String {
         Ok(result) => result,
         Err(_) => return FALLBACK_LATEST_EXTESION_VERSION.to_string(),
     };
-    result
-        .tag_name
-        .replace('v', "")
-        .replace('.', "")
-        .trim()
-        .to_string()
+    result.tag_name.replace(['v', '.'], "").trim().to_string()
 }

--- a/build-tools/src/commands/invoke_function_command.rs
+++ b/build-tools/src/commands/invoke_function_command.rs
@@ -38,7 +38,7 @@ pub async fn invoke_function(args: &InvokeFunctionOptions) -> Result<()> {
             .send()
             .await
             .expect("could not update the function");
-        timeout = timeout + 1;
+        timeout += 1;
         thread::sleep(Duration::from_secs(5));
     }
     if args.remove_after {

--- a/build-tools/src/commands/invoke_function_command.rs
+++ b/build-tools/src/commands/invoke_function_command.rs
@@ -39,7 +39,7 @@ pub async fn invoke_function(args: &InvokeFunctionOptions) -> Result<()> {
             .await
             .expect("could not update the function");
         timeout += 1;
-        thread::sleep(Duration::from_secs(5));
+        thread::sleep(Duration::from_secs(15));
     }
     if args.remove_after {
         remove_function(&lambda_client, args.arn.clone()).await;

--- a/build-tools/src/commands/invoke_function_command.rs
+++ b/build-tools/src/commands/invoke_function_command.rs
@@ -1,0 +1,57 @@
+use std::{io::Result, thread, time::Duration};
+use structopt::StructOpt;
+
+use aws_sdk_lambda as lambda;
+
+#[derive(Debug, StructOpt)]
+pub struct InvokeFunctionOptions {
+    #[structopt(long)]
+    pub region: String,
+    #[structopt(long)]
+    pub arn: String,
+    #[structopt(long)]
+    pub nb: i32,
+    #[structopt(long)]
+    pub remove_after: bool,
+}
+
+pub async fn invoke_function(args: &InvokeFunctionOptions) -> Result<()> {
+    std::env::set_var("AWS_REGION", &args.region);
+    let config = aws_config::load_from_env().await;
+    let lambda_client = lambda::Client::new(&config);
+    let mut timeout = 15;
+    for _ in 0..args.nb {
+        for _ in 0..2 {
+            // doing thiw twice to make sure metrics are flushed
+            lambda_client
+                .invoke()
+                .set_function_name(Some(args.arn.clone()))
+                .send()
+                .await
+                .expect("could not invoke the function");
+        }
+        // update some configuration to make sure next invocation will be a cold start
+        lambda_client
+            .update_function_configuration()
+            .set_timeout(Some(timeout))
+            .set_function_name(Some(args.arn.clone()))
+            .send()
+            .await
+            .expect("could not update the function");
+        timeout = timeout + 1;
+        thread::sleep(Duration::from_secs(5));
+    }
+    if args.remove_after {
+        remove_function(&lambda_client, args.arn.clone()).await;
+    }
+    Ok(())
+}
+
+async fn remove_function(client: &lambda::Client, arn: String) {
+    client
+        .delete_function()
+        .set_function_name(Some(arn))
+        .send()
+        .await
+        .expect("could not remove the function");
+}

--- a/build-tools/src/commands/list_region_command.rs
+++ b/build-tools/src/commands/list_region_command.rs
@@ -10,7 +10,7 @@ use crate::security::build_config;
 #[derive(Debug, StructOpt)]
 pub struct ListRegionOptions {
     #[structopt(long)]
-    key: String,
+    key: Option<String>,
 }
 
 pub async fn list_region(args: &ListRegionOptions) -> Result<()> {

--- a/build-tools/src/commands/mod.rs
+++ b/build-tools/src/commands/mod.rs
@@ -4,5 +4,6 @@ pub mod auth_command;
 pub mod build_command;
 pub mod deploy_command;
 pub mod deploy_function_command;
+pub mod invoke_function_command;
 pub mod list_region_command;
 pub mod sign_command;

--- a/build-tools/src/commands/mod.rs
+++ b/build-tools/src/commands/mod.rs
@@ -5,3 +5,4 @@ pub mod build_command;
 pub mod deploy_command;
 pub mod list_region_command;
 pub mod sign_command;
+pub mod deploy_function_command;

--- a/build-tools/src/commands/mod.rs
+++ b/build-tools/src/commands/mod.rs
@@ -3,6 +3,6 @@ pub mod common;
 pub mod auth_command;
 pub mod build_command;
 pub mod deploy_command;
+pub mod deploy_function_command;
 pub mod list_region_command;
 pub mod sign_command;
-pub mod deploy_function_command;

--- a/build-tools/src/commands/sign_command.rs
+++ b/build-tools/src/commands/sign_command.rs
@@ -25,7 +25,7 @@ pub struct SignOptions {
     #[structopt(long)]
     destination_path: String,
     #[structopt(long)]
-    key: String,
+    key: Option<String>,
 }
 
 pub async fn sign(args: &SignOptions) -> Result<()> {

--- a/build-tools/src/main.rs
+++ b/build-tools/src/main.rs
@@ -1,6 +1,7 @@
 use commands::{
     auth_command::auth, build_command::build, deploy_command::deploy,
-    deploy_function_command::deploy_function, list_region_command::list_region, sign_command::sign,
+    deploy_function_command::deploy_function, invoke_function_command::invoke_function,
+    list_region_command::list_region, sign_command::sign,
 };
 use std::io::Result;
 use structopt::StructOpt;
@@ -22,6 +23,8 @@ enum SubCommand {
     ListRegion(commands::list_region_command::ListRegionOptions),
     #[structopt(name = "deploy_lambda", about = "Deploy AWS Lambda Function")]
     DeployLambdaFunction(commands::deploy_function_command::DeployFunctionOptions),
+    #[structopt(name = "invoke_lambda", about = "Invoke AWS Lambda Function")]
+    InvokeLambdaFunction(commands::invoke_function_command::InvokeFunctionOptions),
 }
 
 #[derive(Debug, StructOpt)]
@@ -45,5 +48,6 @@ async fn main() -> Result<()> {
         SubCommand::Sign(opt) => sign(&opt).await,
         SubCommand::ListRegion(opt) => list_region(&opt).await,
         SubCommand::DeployLambdaFunction(opt) => deploy_function(&opt).await,
+        SubCommand::InvokeLambdaFunction(opt) => invoke_function(&opt).await,
     }
 }

--- a/build-tools/src/main.rs
+++ b/build-tools/src/main.rs
@@ -1,7 +1,6 @@
 use commands::{
     auth_command::auth, build_command::build, deploy_command::deploy,
-    list_region_command::list_region, sign_command::sign, deploy_function_command::deploy_function,
-
+    deploy_function_command::deploy_function, list_region_command::list_region, sign_command::sign,
 };
 use std::io::Result;
 use structopt::StructOpt;

--- a/build-tools/src/main.rs
+++ b/build-tools/src/main.rs
@@ -1,6 +1,7 @@
 use commands::{
     auth_command::auth, build_command::build, deploy_command::deploy,
-    list_region_command::list_region, sign_command::sign,
+    list_region_command::list_region, sign_command::sign, deploy_function_command::deploy_function,
+
 };
 use std::io::Result;
 use structopt::StructOpt;
@@ -20,6 +21,8 @@ enum SubCommand {
     Sign(commands::sign_command::SignOptions),
     #[structopt(name = "list_region", about = "List AWS Region")]
     ListRegion(commands::list_region_command::ListRegionOptions),
+    #[structopt(name = "deploy_lambda", about = "Deploy AWS Lambda Function")]
+    DeployLambdaFunction(commands::deploy_function_command::DeployFunctionOptions),
 }
 
 #[derive(Debug, StructOpt)]
@@ -42,5 +45,6 @@ async fn main() -> Result<()> {
         SubCommand::Deploy(opt) => deploy(&opt).await,
         SubCommand::Sign(opt) => sign(&opt).await,
         SubCommand::ListRegion(opt) => list_region(&opt).await,
+        SubCommand::DeployLambdaFunction(opt) => deploy_function(&opt).await,
     }
 }

--- a/build-tools/src/security.rs
+++ b/build-tools/src/security.rs
@@ -49,19 +49,22 @@ pub fn encrypt_credentials_to_output(key: &str, credentials: &Credentials) -> Re
     Ok(())
 }
 
-pub async fn build_config(key: &str, region: &str) -> SdkConfig {
-    std::env::set_var(
-        "AWS_ACCESS_KEY_ID",
-        decrypt_env_var(key, "AWS_ACCESS_KEY_ID"),
-    );
-    std::env::set_var(
-        "AWS_SECRET_ACCESS_KEY",
-        decrypt_env_var(key, "AWS_SECRET_ACCESS_KEY"),
-    );
-    std::env::set_var(
-        "AWS_SESSION_TOKEN",
-        decrypt_env_var(key, "AWS_SESSION_TOKEN"),
-    );
+pub async fn build_config(key: &Option<String>, region: &str) -> SdkConfig {
+    // if the key is not set, AWS_* env vars have to be set
+    if let Some(key) = key {
+        std::env::set_var(
+            "AWS_ACCESS_KEY_ID",
+            decrypt_env_var(key, "AWS_ACCESS_KEY_ID"),
+        );
+        std::env::set_var(
+            "AWS_SECRET_ACCESS_KEY",
+            decrypt_env_var(key, "AWS_SECRET_ACCESS_KEY"),
+        );
+        std::env::set_var(
+            "AWS_SESSION_TOKEN",
+            decrypt_env_var(key, "AWS_SESSION_TOKEN"),
+        );
+    }
     std::env::set_var("AWS_REGION", region);
     aws_config::load_from_env().await
 }

--- a/build-tools/src/security.rs
+++ b/build-tools/src/security.rs
@@ -86,7 +86,7 @@ fn build_nonce() -> String {
     std::env::var("GITHUB_RUN_ID").expect("could not find run id") + "XX"
 }
 
-fn friendly_env_cipher(env_name: &str, ciphertext: &Vec<u8>) -> String {
+fn friendly_env_cipher(env_name: &str, ciphertext: &[u8]) -> String {
     let mut final_env = String::new();
     for (i, value) in ciphertext.iter().enumerate() {
         if i != 0 {


### PR DESCRIPTION
- Add a `deploy_function` command
- Update the `key` parameter for an optional one


Indeed when we want to deploy a layer in a non-matrixed job, there is no need to share credentials, we could use env variable directly

This feature is used in the POC to computed cold start duration for each PR in dd-trace-*

