### PR TITLE
Build binaries with otlp enabled.

### DIFF
--- a/scripts/Dockerfile.alpine.build
+++ b/scripts/Dockerfile.alpine.build
@@ -4,6 +4,7 @@ FROM alpine:3.16 as builder
 ARG EXTENSION_VERSION
 ARG AGENT_VERSION
 ARG CMD_PATH
+ARG BUILD_TAGS
 
 RUN apk add --no-cache git make musl-dev go gcc
 ENV GOROOT /usr/lib/go
@@ -30,12 +31,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     if [ -z "$AGENT_VERSION" ]; then \
         go build -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
-        -tags serverless -o datadog-agent; \
+        -tags "${BUILD_TAGS}" -o datadog-agent; \
     else \
         go build -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION \
         -X github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault=$AGENT_VERSION" \
-        -tags serverless -o datadog-agent; \
+        -tags "${BUILD_TAGS}" -o datadog-agent; \
     fi
 
 RUN go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault' || \

--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -4,6 +4,7 @@ FROM golang:1.19 as builder
 ARG EXTENSION_VERSION
 ARG AGENT_VERSION
 ARG CMD_PATH
+ARG BUILD_TAGS
 RUN mkdir -p /tmp/dd/datadog-agent
 
 # cache dependencies
@@ -23,12 +24,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     if [ -z "$AGENT_VERSION" ]; then \
         go build -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
-        -tags serverless -o datadog-agent; \
+        -tags "${BUILD_TAGS}" -o datadog-agent; \
     else \
         go build -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION \
         -X github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault=$AGENT_VERSION" \
-        -tags serverless -o datadog-agent; \
+        -tags "${BUILD_TAGS}" -o datadog-agent; \
     fi
 
 RUN go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault' || \

--- a/scripts/Dockerfile.race.build
+++ b/scripts/Dockerfile.race.build
@@ -4,6 +4,7 @@ FROM golang:1.19 as builder
 ARG EXTENSION_VERSION
 ARG ENABLE_RACE_DETECTION
 ARG AGENT_VERSION
+ARG BUILD_TAGS
 RUN mkdir -p /tmp/dd/datadog-agent
 
 # cache dependsencies
@@ -23,12 +24,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     if [ -z "$AGENT_VERSION" ]; then \
         go build -race -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
-        -tags serverless -o datadog-agent; \
+        -tags "${BUILD_TAGS}" -o datadog-agent; \
     else \
         go build -race -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION \
         -X github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault=$AGENT_VERSION" \
-        -tags serverless -o datadog-agent; \
+        -tags "${BUILD_TAGS}" -o datadog-agent; \
     fi
 
 RUN go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault' || \

--- a/scripts/build_binary_and_layer_dockerized.sh
+++ b/scripts/build_binary_and_layer_dockerized.sh
@@ -21,8 +21,10 @@ fi
 
 if [ -z "$CLOUD_RUN" ]; then
     CMD_PATH="cmd/serverless"
+    BUILD_TAGS="serverless otlp"
 else
     CMD_PATH="cmd/serverless-init"
+    BUILD_TAGS="serverless"
 fi
 
 AGENT_PATH="../datadog-agent"
@@ -68,6 +70,7 @@ function docker_build_zip {
         --build-arg EXTENSION_VERSION="${VERSION}" \
         --build-arg AGENT_VERSION="${AGENT_VERSION}" \
         --build-arg CMD_PATH="${CMD_PATH}" \
+        --build-arg BUILD_TAGS="${BUILD_TAGS}" \
         . --load
     dockerId=$(docker create datadog/build-lambda-extension-${arch}:$VERSION)
     docker cp $dockerId:/datadog_extension.zip $TARGET_DIR/datadog_extension-${arch}${suffix}.zip

--- a/scripts_v2/Dockerfile.build
+++ b/scripts_v2/Dockerfile.build
@@ -4,6 +4,7 @@ FROM golang:1.19 as builder
 ARG EXTENSION_VERSION
 ARG AGENT_VERSION
 ARG CMD_PATH
+ARG BUILD_TAGS
 
 RUN mkdir -p /tmp/dd
 
@@ -18,12 +19,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     if [ -z "$AGENT_VERSION" ]; then \
         go build -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
-        -tags serverless -o datadog-agent; \
+        -tags "${BUILD_TAGS}" -o datadog-agent; \
     else \
         go build -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION \
         -X github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault=$AGENT_VERSION" \
-        -tags serverless -o datadog-agent; \
+        -tags "${BUILD_TAGS}" -o datadog-agent; \
     fi
 
 RUN go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault' || \


### PR DESCRIPTION
Enabling OTLP endpoints in the lambda extension will require us to include the go build tag `"otlp"`. This pull request adds this tag when building `cmd/serverless` but not when building `cmd/serverless-init`.