### PR TITLE
Revert "Build binaries with otlp enabled."

### DIFF
--- a/scripts/Dockerfile.alpine.build
+++ b/scripts/Dockerfile.alpine.build
@@ -4,7 +4,6 @@ FROM alpine:3.16 as builder
 ARG EXTENSION_VERSION
 ARG AGENT_VERSION
 ARG CMD_PATH
-ARG BUILD_TAGS
 
 RUN apk add --no-cache git make musl-dev go gcc
 ENV GOROOT /usr/lib/go
@@ -31,12 +30,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     if [ -z "$AGENT_VERSION" ]; then \
         go build -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
-        -tags "${BUILD_TAGS}" -o datadog-agent; \
+        -tags serverless -o datadog-agent; \
     else \
         go build -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION \
         -X github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault=$AGENT_VERSION" \
-        -tags "${BUILD_TAGS}" -o datadog-agent; \
+        -tags serverless -o datadog-agent; \
     fi
 
 RUN go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault' || \

--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -4,7 +4,6 @@ FROM golang:1.19 as builder
 ARG EXTENSION_VERSION
 ARG AGENT_VERSION
 ARG CMD_PATH
-ARG BUILD_TAGS
 RUN mkdir -p /tmp/dd/datadog-agent
 
 # cache dependencies
@@ -24,12 +23,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     if [ -z "$AGENT_VERSION" ]; then \
         go build -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
-        -tags "${BUILD_TAGS}" -o datadog-agent; \
+        -tags serverless -o datadog-agent; \
     else \
         go build -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION \
         -X github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault=$AGENT_VERSION" \
-        -tags "${BUILD_TAGS}" -o datadog-agent; \
+        -tags serverless -o datadog-agent; \
     fi
 
 RUN go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault' || \

--- a/scripts/Dockerfile.race.build
+++ b/scripts/Dockerfile.race.build
@@ -4,7 +4,6 @@ FROM golang:1.19 as builder
 ARG EXTENSION_VERSION
 ARG ENABLE_RACE_DETECTION
 ARG AGENT_VERSION
-ARG BUILD_TAGS
 RUN mkdir -p /tmp/dd/datadog-agent
 
 # cache dependsencies
@@ -24,12 +23,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     if [ -z "$AGENT_VERSION" ]; then \
         go build -race -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
-        -tags "${BUILD_TAGS}" -o datadog-agent; \
+        -tags serverless -o datadog-agent; \
     else \
         go build -race -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION \
         -X github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault=$AGENT_VERSION" \
-        -tags "${BUILD_TAGS}" -o datadog-agent; \
+        -tags serverless -o datadog-agent; \
     fi
 
 RUN go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault' || \

--- a/scripts/build_binary_and_layer_dockerized.sh
+++ b/scripts/build_binary_and_layer_dockerized.sh
@@ -21,10 +21,8 @@ fi
 
 if [ -z "$CLOUD_RUN" ]; then
     CMD_PATH="cmd/serverless"
-    BUILD_TAGS="serverless otlp"
 else
     CMD_PATH="cmd/serverless-init"
-    BUILD_TAGS="serverless"
 fi
 
 AGENT_PATH="../datadog-agent"
@@ -70,7 +68,6 @@ function docker_build_zip {
         --build-arg EXTENSION_VERSION="${VERSION}" \
         --build-arg AGENT_VERSION="${AGENT_VERSION}" \
         --build-arg CMD_PATH="${CMD_PATH}" \
-        --build-arg BUILD_TAGS="${BUILD_TAGS}" \
         . --load
     dockerId=$(docker create datadog/build-lambda-extension-${arch}:$VERSION)
     docker cp $dockerId:/datadog_extension.zip $TARGET_DIR/datadog_extension-${arch}${suffix}.zip

--- a/scripts_v2/Dockerfile.build
+++ b/scripts_v2/Dockerfile.build
@@ -4,7 +4,6 @@ FROM golang:1.19 as builder
 ARG EXTENSION_VERSION
 ARG AGENT_VERSION
 ARG CMD_PATH
-ARG BUILD_TAGS
 
 RUN mkdir -p /tmp/dd
 
@@ -19,12 +18,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     if [ -z "$AGENT_VERSION" ]; then \
         go build -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
-        -tags "${BUILD_TAGS}" -o datadog-agent; \
+        -tags serverless -o datadog-agent; \
     else \
         go build -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION \
         -X github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault=$AGENT_VERSION" \
-        -tags "${BUILD_TAGS}" -o datadog-agent; \
+        -tags serverless -o datadog-agent; \
     fi
 
 RUN go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault' || \


### PR DESCRIPTION
Reverts DataDog/datadog-lambda-extension#114

We should only have merged this PR after otlp has been enabled in the extension with https://github.com/DataDog/datadog-agent/pull/15321.