### PR TITLE
Add performance optimization for Java

### DIFF
--- a/scripts/datadog_wrapper
+++ b/scripts/datadog_wrapper
@@ -72,17 +72,17 @@ then
   DD_Agent_Jar=/opt/java/lib/dd-java-agent.jar
   if [ -f "$DD_Agent_Jar" ]
   then
-    # Remove the -XX:-TieredCompilation flag from the java command passed through from the Lambda runtime.
-    # The -XX:-TieredCompilation flag causes the JVM by default to optimize to the C2 compiler, which uses
-    # more memory and is slower on cold start. Snapstarting doesn't improve performance in this case, because
-    # compilation continues asynchronously in the background after the Lambda function has been frozen.
-    # Instead we want to use the C1 compiler and Interpreter, which is faster on cold start and uses less memory.
+    # Removes the -XX:-TieredCompilation flag from the java command passed 
+    # through from the Lambda runtime. Allows the JVM to use the C1 compiler
+    # and Interpreter, which is much faster on cold start and 
+    # uses less memory.
     START_COMMAND=${args[0]}
     REMAINDER_ARGS=("${args[@]:1}")
     for index in "${!REMAINDER_ARGS[@]}" ; do
       [[ ${REMAINDER_ARGS[$index]} == "-XX:-TieredCompilation" ]] && unset -v 'REMAINDER_ARGS[$index]' ;
     done
     REMAINDER_ARGS="${REMAINDER_ARGS[@]}"
+    # -XX:TieredStopAtLevel=1 tells the compiler to stop at the C1 compiler
     args=($START_COMMAND -javaagent:$DD_Agent_Jar -XX:TieredStopAtLevel=1 ${REMAINDER_ARGS[@]})
 
   else

--- a/scripts/datadog_wrapper
+++ b/scripts/datadog_wrapper
@@ -67,10 +67,24 @@ then
   fi
   export DD_JMXFETCH_ENABLED="false"
   export DD_RUNTIME_METRICS_ENABLED="false"
+  export DD_REMOTE_CONFIG_ENABLED="false"
+
   DD_Agent_Jar=/opt/java/lib/dd-java-agent.jar
   if [ -f "$DD_Agent_Jar" ]
   then
-    export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -javaagent:$DD_Agent_Jar -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+    # Remove the -XX:-TieredCompilation flag from the java command passed through from the Lambda runtime.
+    # The -XX:-TieredCompilation flag causes the JVM by default to optimize to the C2 compiler, which uses
+    # more memory and is slower on cold start. Snapstarting doesn't improve performance in this case, because
+    # compilation continues asynchronously in the background after the Lambda function has been frozen.
+    # Instead we want to use the C1 compiler and Interpreter, which is faster on cold start and uses less memory.
+    START_COMMAND=${args[0]}
+    REMAINDER_ARGS=("${args[@]:1}")
+    for index in "${!REMAINDER_ARGS[@]}" ; do
+      [[ ${REMAINDER_ARGS[$index]} == "-XX:-TieredCompilation" ]] && unset -v 'REMAINDER_ARGS[$index]' ;
+    done
+    REMAINDER_ARGS="${REMAINDER_ARGS[@]}"
+    args=($START_COMMAND -javaagent:$DD_Agent_Jar -XX:TieredStopAtLevel=1 ${REMAINDER_ARGS[@]})
+
   else
     echo "File $DD_Agent_Jar does not exist!"
   fi


### PR DESCRIPTION
From testing, it appears using the wrapper script was causing the JAVA_TOOLS_OPTIONS to be partially ignored. When launching Java, the Lambda runtime uses the following args:
```
/var/lang/bin/java -XX:MaxHeapSize=222823k -XX:MaxMetaspaceSize=26214k -XX:ReservedCodeCacheSize=13107k -XX:+UseSerialGC -javaagent:/var/runtime/amzn-log4j-security-jdk11-0.1alpha.jar -XX:-TieredCompilation -Djava.net.preferIPv4Stack=true -Dorg.crac.Core.Compat=org.crac.inmemory -classpath /var/runtime/lib/aws-lambda-java-core-1.2.0.jar:/var/runtime/lib/aws-lambda-java-runtime-0.2.0.jar:/var/runtime/lib/aws-lambda-java-serialization-0.2.0.jar:/var/runtime/lib/org-crac-inmemory-0.1.0.jar lambdainternal.AWSLambda
```
The -XX:-TieredCompilation was conflicting with our '-XX:+TieredCompilation' setting, (-XX:-TieredCompilation is the default). The mechanics of compilation in the JVM are [fairly complicated](https://www.baeldung.com/jvm-tiered-compilation), but basically the result was forcing all code to compile to the C1 level, skipping the interpreter level. This slowed down cold start, and consumed significantly more memory.

I've also added an env var to disable remote configuration with the java tracer, since we currently can't use it with Lambda