### PR TITLE
Add a check_layer_consistency_command

### DIFF
--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -124,7 +124,7 @@ jobs:
          --layer-name "Datadog-Extension" \
          --layer-suffix "${{ inputs.layerSuffix }}" \
          --key ${{ secrets.GH_ACTION_PUBLISHER_AEM_KEY }} \
-         --regions "${{ join(steps.prepare-artifact.outputs.AWS_REGIONS, ',' }}""
+         --regions "${{ join(steps.prepare-artifact.outputs.AWS_REGIONS, ',') }}"
 
       - id: deploy
         if: ${{ github.event.inputs.region != 'all' }}

--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -95,8 +95,6 @@ jobs:
           AWS_SESSION_TOKEN: ${{ steps.auth.outputs.AWS_SESSION_TOKEN }}
         name: Check layer version consistency
         run: |
-         echo "check layer version consistenty"
-         echo ${{ steps.list_region.outputs.AWS_REGIONS }}
          ./build-tools/bin/build_tools \
          check_layer_version_consistency \
          --layer-name "Datadog-Extension" \

--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -53,7 +53,9 @@ jobs:
           echo ::add-mask::"8"
           echo ::add-mask::"9"
           echo ::add-mask::"|"
-      - uses: actions/checkout@v3
+
+      - name: checkout
+        uses: actions/checkout@v3
 
       - id: auth
         env:
@@ -66,7 +68,8 @@ jobs:
           --mfa-code ${{ inputs.mfaCode }} \
           --key ${{ secrets.GH_ACTION_PUBLISHER_AEM_KEY }}
 
-      - uses: actions/checkout@v3
+      - name: checkout the agent
+        uses: actions/checkout@v3
         with:
           repository: DataDog/datadog-agent
           ref: refs/heads/${{ inputs.agentBranch }}
@@ -94,13 +97,12 @@ jobs:
         run: |
          echo "check layer version consistenty"
          echo ${{ steps.list_region.outputs.AWS_REGIONS }}
-         echo ${{ join(steps.list_region.outputs.AWS_REGIONS, ',') }}
          ./build-tools/bin/build_tools \
          check_layer_version_consistency \
          --layer-name "Datadog-Extension" \
          --layer-suffix "${{ inputs.layerSuffix }}" \
          --key ${{ secrets.GH_ACTION_PUBLISHER_AEM_KEY }} \
-         --regions "${{ join(steps.prepare-artifact.outputs.AWS_REGIONS, ',') }}"
+         --regions "${{ join(steps.list_region.outputs.AWS_REGIONS, ',') }}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2.1.0

--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -124,7 +124,7 @@ jobs:
          --layer-name "Datadog-Extension" \
          --layer-suffix "${{ inputs.layerSuffix }}" \
          --key ${{ secrets.GH_ACTION_PUBLISHER_AEM_KEY }} \
-         --regions ${{ fromJson(steps.prepare-artifact.outputs.AWS_REGIONS) }}
+         --regions "${{ join(steps.prepare-artifact.outputs.AWS_REGIONS, ',' }}""
 
       - id: deploy
         if: ${{ github.event.inputs.region != 'all' }}

--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -42,17 +42,16 @@ jobs:
     steps:
       - name: mask numbers
         run: |
-          echo ::add-mask::"0"
-          echo ::add-mask::"1"
-          echo ::add-mask::"2"
-          echo ::add-mask::"3"
-          echo ::add-mask::"4"
-          echo ::add-mask::"5"
-          echo ::add-mask::"6"
-          echo ::add-mask::"7"
-          echo ::add-mask::"8"
-          echo ::add-mask::"9"
-          echo ::add-mask::"|"
+          echo ::add-mask::"0|"
+          echo ::add-mask::"1|"
+          echo ::add-mask::"2|"
+          echo ::add-mask::"3|"
+          echo ::add-mask::"4|"
+          echo ::add-mask::"5|"
+          echo ::add-mask::"6|"
+          echo ::add-mask::"7|"
+          echo ::add-mask::"8|"
+          echo ::add-mask::"9|"
 
       - name: checkout
         uses: actions/checkout@v3
@@ -161,17 +160,16 @@ jobs:
     steps:
       - name: mask numbers
         run: |
-          echo ::add-mask::"0"
-          echo ::add-mask::"1"
-          echo ::add-mask::"2"
-          echo ::add-mask::"3"
-          echo ::add-mask::"4"
-          echo ::add-mask::"5"
-          echo ::add-mask::"6"
-          echo ::add-mask::"7"
-          echo ::add-mask::"8"
-          echo ::add-mask::"9"
-          echo ::add-mask::"|"
+          echo ::add-mask::"0|"
+          echo ::add-mask::"1|"
+          echo ::add-mask::"2|"
+          echo ::add-mask::"3|"
+          echo ::add-mask::"4|"
+          echo ::add-mask::"5|"
+          echo ::add-mask::"6|"
+          echo ::add-mask::"7|"
+          echo ::add-mask::"8|"
+          echo ::add-mask::"9|"
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -124,7 +124,7 @@ jobs:
          --layer-name "Datadog-Extension" \
          --layer-suffix "${{ inputs.layerSuffix }}" \
          --key ${{ secrets.GH_ACTION_PUBLISHER_AEM_KEY }} \
-         --regions ${{ fromJson(needs.prepare-artifact.outputs.AWS_REGIONS) }}
+         --regions ${{ fromJson(steps.prepare-artifact.outputs.AWS_REGIONS) }}
 
       - id: deploy
         if: ${{ github.event.inputs.region != 'all' }}

--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -121,6 +121,8 @@ jobs:
         run: |
          ./build-tools/bin/build_tools \
          check_layer_version_consistency \
+         --layer-name "Datadog-Extension" \
+         --layer-suffix "${{ inputs.layerSuffix }}" \
          --key ${{ secrets.GH_ACTION_PUBLISHER_AEM_KEY }} \
          --regions ${{ fromJson(needs.prepare-artifact.outputs.AWS_REGIONS) }}
 

--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -102,7 +102,7 @@ jobs:
          --layer-name "Datadog-Extension" \
          --layer-suffix "${{ inputs.layerSuffix }}" \
          --key ${{ secrets.GH_ACTION_PUBLISHER_AEM_KEY }} \
-         --regions "${{ join(steps.list_region.outputs.AWS_REGIONS, ',') }}"
+         --regions "${{ steps.list_region.outputs.AWS_REGIONS }}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2.1.0

--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -65,39 +65,12 @@ jobs:
           --mfa-arn ${{ secrets.GH_ACTION_PUBLISHER_MFA_DEVICE_ARN }} \
           --mfa-code ${{ inputs.mfaCode }} \
           --key ${{ secrets.GH_ACTION_PUBLISHER_AEM_KEY }}
+
       - uses: actions/checkout@v3
         with:
           repository: DataDog/datadog-agent
           ref: refs/heads/${{ inputs.agentBranch }}
           path: datadog-agent
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2.1.0
-      - run: |
-         ./build-tools/bin/build_tools \
-         build \
-         --version 1 \
-         --agent-version 1 \
-         --architecture "${{ inputs.architecture }}" \
-         --context-path "${GITHUB_WORKSPACE}" \
-         --destination-path "${GITHUB_WORKSPACE}/tmp" \
-         --docker-path "scripts_v2/Dockerfile.build" \
-         --artifact-name "datadog_extension.zip"
-      - name: Sign the layer
-        env:
-          AWS_ACCESS_KEY_ID: ${{ steps.auth.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.auth.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.auth.outputs.AWS_SESSION_TOKEN }}
-        run: |
-         ./build-tools/bin/build_tools \
-         sign \
-         --layer-path ./tmp/datadog_extension.zip \
-         --destination-path ./tmp/datadog_extension_signed.zip \
-         --key ${{ secrets.GH_ACTION_PUBLISHER_AEM_KEY }}
-      - uses: actions/upload-artifact@v3.1.1
-        with:
-          name: datadog-extension
-          path: ./tmp/datadog_extension_signed.zip
-          retention-days: 5
 
       - id: list_region
         if: ${{ github.event.inputs.region == 'all' }}
@@ -119,12 +92,47 @@ jobs:
           AWS_SESSION_TOKEN: ${{ steps.auth.outputs.AWS_SESSION_TOKEN }}
         name: Check layer version consistency
         run: |
+         echo "check layer version consistenty"
+         echo ${{ steps.list_region.outputs.AWS_REGIONS }}
+         echo ${{ join(steps.list_region.outputs.AWS_REGIONS, ',') }}
          ./build-tools/bin/build_tools \
          check_layer_version_consistency \
          --layer-name "Datadog-Extension" \
          --layer-suffix "${{ inputs.layerSuffix }}" \
          --key ${{ secrets.GH_ACTION_PUBLISHER_AEM_KEY }} \
          --regions "${{ join(steps.prepare-artifact.outputs.AWS_REGIONS, ',') }}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+  
+      - name: build
+        run: |
+         ./build-tools/bin/build_tools \
+         build \
+         --version 1 \
+         --agent-version 1 \
+         --architecture "${{ inputs.architecture }}" \
+         --context-path "${GITHUB_WORKSPACE}" \
+         --destination-path "${GITHUB_WORKSPACE}/tmp" \
+         --docker-path "scripts_v2/Dockerfile.build" \
+         --artifact-name "datadog_extension.zip"
+
+      - name: Sign the layer
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.auth.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.auth.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ steps.auth.outputs.AWS_SESSION_TOKEN }}
+        run: |
+         ./build-tools/bin/build_tools \
+         sign \
+         --layer-path ./tmp/datadog_extension.zip \
+         --destination-path ./tmp/datadog_extension_signed.zip \
+         --key ${{ secrets.GH_ACTION_PUBLISHER_AEM_KEY }}
+      - uses: actions/upload-artifact@v3.1.1
+        with:
+          name: datadog-extension
+          path: ./tmp/datadog_extension_signed.zip
+          retention-days: 5
 
       - id: deploy
         if: ${{ github.event.inputs.region != 'all' }}

--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -54,6 +54,7 @@ jobs:
           echo ::add-mask::"9"
           echo ::add-mask::"|"
       - uses: actions/checkout@v3
+
       - id: auth
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.GH_ACTION_PUBLISHER_AWS_ACCESS_KEY_ID }}
@@ -97,6 +98,7 @@ jobs:
           name: datadog-extension
           path: ./tmp/datadog_extension_signed.zip
           retention-days: 5
+
       - id: list_region
         if: ${{ github.event.inputs.region == 'all' }}
         env:
@@ -108,6 +110,20 @@ jobs:
          ./build-tools/bin/build_tools \
          list_region \
          --key ${{ secrets.GH_ACTION_PUBLISHER_AEM_KEY }}
+
+      - id: check_layer_version_consistency
+        if: ${{ github.event.inputs.region == 'all' }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.auth.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.auth.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ steps.auth.outputs.AWS_SESSION_TOKEN }}
+        name: Check layer version consistency
+        run: |
+         ./build-tools/bin/build_tools \
+         check_layer_version_consistency \
+         --key ${{ secrets.GH_ACTION_PUBLISHER_AEM_KEY }} \
+         --regions ${{ fromJson(needs.prepare-artifact.outputs.AWS_REGIONS) }}
+
       - id: deploy
         if: ${{ github.event.inputs.region != 'all' }}
         env:
@@ -151,6 +167,7 @@ jobs:
         with:
           name: datadog-extension
           path: ./tmp
+
       - id: deploy
         env:
           AWS_ACCESS_KEY_ID: ${{ needs.prepare-artifact.outputs.AWS_ACCESS_KEY_ID }}

--- a/build-tools/Dockerfile
+++ b/build-tools/Dockerfile
@@ -1,20 +1,27 @@
-FROM rust as builder
-WORKDIR /usr/src/app
-COPY Cargo.toml .
-COPY Cargo.lock .
-RUN mkdir ./src && echo 'fn main() { println!("Dummy!"); }' > ./src/main.rs
-RUN cargo build --release
-RUN rm -rf ./src
-COPY src ./src
-RUN touch -a -m ./src/main.rs
-RUN cargo build --release
+# syntax=docker/dockerfile:1.3-labs
+
+FROM rust AS build
+
+RUN cargo new /app/build-tools
+COPY Cargo.toml /app/build-tools
+
+WORKDIR /app/build-tools
+RUN --mount=type=cache,target=/usr/local/cargo/registry cargo build --release
+
+COPY ./src /app/build-tools/src
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry <<EOF
+  set -e
+  touch /app/build-tools/src/main.rs
+  cargo build --release
+EOF
 
 FROM ubuntu:jammy as compresser
 RUN apt-get update
 RUN apt-get install -y zip
 RUN mkdir -p /bin
 WORKDIR /bin
-COPY --from=builder /usr/src/app/target/release/build_tools /bin/build_tools
+COPY --from=build /app/build-tools/target/release/build_tools /bin/build_tools
 RUN zip -r build_tools.zip /bin/build_tools
 
 #keep the smallest possible docker image

--- a/build-tools/Dockerfile
+++ b/build-tools/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1.3-labs
-
 FROM rust AS build
 
 RUN cargo new /app/build-tools

--- a/build-tools/src/commands/check_layer_consistency_command.rs
+++ b/build-tools/src/commands/check_layer_consistency_command.rs
@@ -1,9 +1,11 @@
-use std::{io::Result, fmt::Display};
+use std::{fmt::Display, io::Result};
 use structopt::StructOpt;
 
 use aws_sdk_lambda as lambda;
 
-use crate::security::{build_config};
+use crate::security::build_config;
+
+use super::common::{build_layer_name, BuildArchitecture};
 
 pub struct RegionVersion {
     region: String,
@@ -30,28 +32,43 @@ pub struct CheckLayerConsistencyOptions {
     key: Option<String>,
     #[structopt(long)]
     layer_name: String,
+    #[structopt(long, possible_values = &BuildArchitecture::variants(), case_insensitive = true, default_value = "amd64")]
+    architecture: BuildArchitecture,
+    #[structopt(long)]
+    layer_suffix: Option<String>,
 }
 
-pub async fn get_layer_version(key: &Option<String>, layer_name: &str, region: &str) -> RegionVersion {
+pub async fn get_layer_version(
+    key: &Option<String>,
+    layer_name: String,
+    region: &str,
+) -> RegionVersion {
     let config = build_config(&key, region).await;
     let lambda_client = lambda::Client::new(&config);
     let result = lambda_client
-    .get_layer_version()
-    .set_layer_name(Some(String::from(layer_name)))
-    .send()
-    .await
-    .expect("could not get layer version");
+        .get_layer_version()
+        .set_layer_name(Some(layer_name))
+        .send()
+        .await
+        .expect("could not get layer version");
     return RegionVersion::new(String::from(region), result.version());
 }
 
 pub async fn check_consistency(args: &CheckLayerConsistencyOptions) -> Result<()> {
     let mut last_checked_version: Option<RegionVersion> = None;
+    let layer_name = build_layer_name(&args.layer_name, &args.architecture, &args.layer_suffix);
     for region in args.regions.iter() {
-        let current_version = get_layer_version(&args.key, &args.layer_name, &region).await;
+        let current_version = get_layer_version(&args.key, layer_name.clone(), &region).await;
         if let Some(checked_version) = last_checked_version {
             if checked_version.version != current_version.version {
-                let error_message = format!("layer version mismatch: {} and {}", checked_version, current_version);
-                return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, error_message))
+                let error_message = format!(
+                    "layer version mismatch: {} and {}",
+                    checked_version, current_version
+                );
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    error_message,
+                ));
             }
             last_checked_version = Some(checked_version);
         }

--- a/build-tools/src/commands/check_layer_consistency_command.rs
+++ b/build-tools/src/commands/check_layer_consistency_command.rs
@@ -9,6 +9,14 @@ use super::common::{build_layer_name, BuildArchitecture};
 
 #[derive(Debug)]
 struct RegionArgs(Vec<String>);
+
+impl std::str::FromStr for RegionArgs {
+    type Err = Box<dyn std::error::Error>;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        Ok(RegionArgs(s.split(",").map(|x| x.trim().to_owned()).collect()))
+    }
+}
+
 pub struct RegionVersion {
     region: String,
     version: i64,
@@ -38,13 +46,6 @@ pub struct CheckLayerConsistencyOptions {
     architecture: BuildArchitecture,
     #[structopt(long)]
     layer_suffix: Option<String>,
-}
-
-impl std::str::FromStr for RegionArgs {
-    type Err = Box<dyn std::error::Error>;
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        Ok(RegionArgs(s.split(",").map(|x| x.trim().to_owned()).collect()))
-    }
 }
 
 pub async fn get_latest_layer_version(

--- a/build-tools/src/commands/check_layer_consistency_command.rs
+++ b/build-tools/src/commands/check_layer_consistency_command.rs
@@ -56,6 +56,7 @@ pub async fn get_latest_layer_version(
     region: &str,
 ) -> RegionVersion {
     let region = sanitize(region);
+    println!("sanitized region = >{}<", region);
     let config = build_config(key, &region).await;
     let lambda_client = lambda::Client::new(&config);
     let result = lambda_client

--- a/build-tools/src/commands/check_layer_consistency_command.rs
+++ b/build-tools/src/commands/check_layer_consistency_command.rs
@@ -1,0 +1,60 @@
+use std::{io::Result, fmt::Display};
+use structopt::StructOpt;
+
+use aws_sdk_lambda as lambda;
+
+use crate::security::{build_config};
+
+pub struct RegionVersion {
+    region: String,
+    version: i64,
+}
+
+impl RegionVersion {
+    fn new(region: String, version: i64) -> Self {
+        RegionVersion { region, version }
+    }
+}
+
+impl Display for RegionVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[Region:{} Version:{}]", self.region, self.version)
+    }
+}
+
+#[derive(Debug, StructOpt)]
+pub struct CheckLayerConsistencyOptions {
+    #[structopt(long)]
+    regions: Vec<String>,
+    #[structopt(long)]
+    key: Option<String>,
+    #[structopt(long)]
+    layer_name: String,
+}
+
+pub async fn get_layer_version(key: &Option<String>, layer_name: &str, region: &str) -> RegionVersion {
+    let config = build_config(&key, region).await;
+    let lambda_client = lambda::Client::new(&config);
+    let result = lambda_client
+    .get_layer_version()
+    .set_layer_name(Some(String::from(layer_name)))
+    .send()
+    .await
+    .expect("could not get layer version");
+    return RegionVersion::new(String::from(region), result.version());
+}
+
+pub async fn check_consistency(args: &CheckLayerConsistencyOptions) -> Result<()> {
+    let mut last_checked_version: Option<RegionVersion> = None;
+    for region in args.regions.iter() {
+        let current_version = get_layer_version(&args.key, &args.layer_name, &region).await;
+        if let Some(checked_version) = last_checked_version {
+            if checked_version.version != current_version.version {
+                let error_message = format!("layer version mismatch: {} and {}", checked_version, current_version);
+                return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, error_message))
+            }
+            last_checked_version = Some(checked_version);
+        }
+    }
+    Ok(())
+}

--- a/build-tools/src/commands/check_layer_consistency_command.rs
+++ b/build-tools/src/commands/check_layer_consistency_command.rs
@@ -62,14 +62,21 @@ pub async fn get_latest_layer_version(
         .await
         .expect("could not get layer version");
     let layer_versions = result.layer_versions().expect("could not list layer versions");
-    let latest = layer_versions.get(0).expect("could not get the latest layer");
-    RegionVersion::new(String::from(region), latest.version())
+    
+    let latest_version = match layer_versions.get(0) {
+        Some(layer_version) => layer_version.version(),
+        None => 0
+    };
+    RegionVersion::new(String::from(region), latest_version)
 }
 
 pub async fn check_consistency(args: &CheckLayerConsistencyOptions) -> Result<()> {
     let mut last_checked_version: Option<RegionVersion> = None;
     let layer_name = build_layer_name(&args.layer_name, &args.architecture, &args.layer_suffix);
+    println!("layer name = {}", layer_name);
+    println!("regions = {:?}", args.regions.0);
     for region in args.regions.0.iter() {
+        println!("single region = {}", region);
         let current_version = get_latest_layer_version(&args.key, layer_name.clone(), region).await;
         if let Some(checked_version) = last_checked_version {
             if checked_version.version != current_version.version {

--- a/build-tools/src/commands/check_layer_consistency_command.rs
+++ b/build-tools/src/commands/check_layer_consistency_command.rs
@@ -43,7 +43,7 @@ pub async fn get_layer_version(
     layer_name: String,
     region: &str,
 ) -> RegionVersion {
-    let config = build_config(&key, region).await;
+    let config = build_config(key, region).await;
     let lambda_client = lambda::Client::new(&config);
     let result = lambda_client
         .get_layer_version()
@@ -51,14 +51,14 @@ pub async fn get_layer_version(
         .send()
         .await
         .expect("could not get layer version");
-    return RegionVersion::new(String::from(region), result.version());
+    RegionVersion::new(String::from(region), result.version())
 }
 
 pub async fn check_consistency(args: &CheckLayerConsistencyOptions) -> Result<()> {
     let mut last_checked_version: Option<RegionVersion> = None;
     let layer_name = build_layer_name(&args.layer_name, &args.architecture, &args.layer_suffix);
     for region in args.regions.iter() {
-        let current_version = get_layer_version(&args.key, layer_name.clone(), &region).await;
+        let current_version = get_layer_version(&args.key, layer_name.clone(), region).await;
         if let Some(checked_version) = last_checked_version {
             if checked_version.version != current_version.version {
                 let error_message = format!(

--- a/build-tools/src/commands/check_layer_consistency_command.rs
+++ b/build-tools/src/commands/check_layer_consistency_command.rs
@@ -14,7 +14,7 @@ impl std::str::FromStr for RegionArgs {
     type Err = Box<dyn std::error::Error>;
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         Ok(RegionArgs(
-            s.split(",").map(|x| x.trim().to_owned()).collect(),
+            s.split(',').map(|x| x.trim().to_owned()).collect(),
         ))
     }
 }
@@ -72,7 +72,7 @@ pub async fn get_latest_layer_version(
         Some(layer_version) => layer_version.version(),
         None => 0,
     };
-    RegionVersion::new(String::from(region), latest_version)
+    RegionVersion::new(region, latest_version)
 }
 
 pub async fn check_consistency(args: &CheckLayerConsistencyOptions) -> Result<()> {
@@ -102,8 +102,8 @@ pub async fn check_consistency(args: &CheckLayerConsistencyOptions) -> Result<()
 
 fn sanitize(region: &str) -> String {
     // making sure that the list param from github action does not contain any invalid chars
-    let region = region.replace("[", "");
-    let region = region.replace("]", "");
-    let region = region.replace(",", "");
+    let region = region.replace('[', "");
+    let region = region.replace(']', "");
+    let region = region.replace(',', "");
     region.trim().to_string()
 }

--- a/build-tools/src/commands/check_layer_consistency_command.rs
+++ b/build-tools/src/commands/check_layer_consistency_command.rs
@@ -53,10 +53,8 @@ pub struct CheckLayerConsistencyOptions {
 pub async fn get_latest_layer_version(
     key: &Option<String>,
     layer_name: String,
-    region: &str,
+    region: String,
 ) -> RegionVersion {
-    let region = sanitize(region);
-    println!("sanitized region = >{}<", region);
     let config = build_config(key, &region).await;
     let lambda_client = lambda::Client::new(&config);
     let result = lambda_client
@@ -79,10 +77,9 @@ pub async fn get_latest_layer_version(
 pub async fn check_consistency(args: &CheckLayerConsistencyOptions) -> Result<()> {
     let mut last_checked_version: Option<RegionVersion> = None;
     let layer_name = build_layer_name(&args.layer_name, &args.architecture, &args.layer_suffix);
-    println!("layer name = {}", layer_name);
-    println!("regions = {:?}", args.regions.0);
     for region in args.regions.0.iter() {
-        println!("single region = {}", region);
+        let region = sanitize(region);
+        println!("sanitized region = >{}<", region);
         let current_version = get_latest_layer_version(&args.key, layer_name.clone(), region).await;
         if let Some(checked_version) = last_checked_version {
             if checked_version.version != current_version.version {

--- a/build-tools/src/commands/common.rs
+++ b/build-tools/src/commands/common.rs
@@ -18,3 +18,67 @@ pub fn get_file_as_vec(filename: &String) -> Blob {
     f.read_exact(&mut buffer).expect("buffer error");
     Blob::new(buffer)
 }
+
+pub fn build_layer_name(
+    layer_name: &str,
+    architecture: &BuildArchitecture,
+    layer_suffix: &Option<String>,
+) -> String {
+    let layer_with_suffix = if let Some(suffix) = layer_suffix {
+        match suffix.len() {
+            0 => String::from(layer_name),
+            _ => String::from(layer_name) + "-" + suffix,
+        }
+    } else {
+        String::from(layer_name)
+    };
+    let layer = match architecture {
+        BuildArchitecture::Amd64 => layer_with_suffix,
+        BuildArchitecture::Arm64 => layer_with_suffix + "-ARM",
+    };
+    layer.replace('.', "") //layer cannot contain dots
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn build_layer_name_test() {
+        //ARM64
+        assert_eq!(
+            "layer-suffix-ARM",
+            build_layer_name(
+                "layer",
+                &BuildArchitecture::Arm64,
+                &Some("suffix".to_string())
+            )
+        );
+        assert_eq!(
+            "layer-ARM",
+            build_layer_name("layer", &BuildArchitecture::Arm64, &Some("".to_string()))
+        );
+        assert_eq!(
+            "layer-ARM",
+            build_layer_name("layer", &BuildArchitecture::Arm64, &None)
+        );
+        //AMD64
+        assert_eq!(
+            "layer-suffix",
+            build_layer_name(
+                "layer",
+                &BuildArchitecture::Amd64,
+                &Some("suffix".to_string())
+            )
+        );
+        assert_eq!(
+            "layer",
+            build_layer_name("layer", &BuildArchitecture::Amd64, &Some("".to_string()))
+        );
+        assert_eq!(
+            "layer",
+            build_layer_name("layer", &BuildArchitecture::Amd64, &None)
+        );
+    }
+}

--- a/build-tools/src/commands/deploy_command.rs
+++ b/build-tools/src/commands/deploy_command.rs
@@ -5,6 +5,7 @@ use aws_sdk_lambda as lambda;
 
 use crate::security::build_config;
 
+use super::common::build_layer_name;
 use super::common::get_file_as_vec;
 use super::common::BuildArchitecture;
 
@@ -43,68 +44,4 @@ pub async fn deploy(args: &DeployOptions) -> Result<()> {
         .await
         .expect("error while publishing the layer");
     Ok(())
-}
-
-fn build_layer_name(
-    layer_name: &str,
-    architecture: &BuildArchitecture,
-    layer_suffix: &Option<String>,
-) -> String {
-    let layer_with_suffix = if let Some(suffix) = layer_suffix {
-        match suffix.len() {
-            0 => String::from(layer_name),
-            _ => String::from(layer_name) + "-" + suffix,
-        }
-    } else {
-        String::from(layer_name)
-    };
-    let layer = match architecture {
-        BuildArchitecture::Amd64 => layer_with_suffix,
-        BuildArchitecture::Arm64 => layer_with_suffix + "-ARM",
-    };
-    layer.replace('.', "") //layer cannot contain dots
-}
-
-#[cfg(test)]
-mod tests {
-
-    use super::*;
-
-    #[test]
-    fn build_layer_name_test() {
-        //ARM64
-        assert_eq!(
-            "layer-suffix-ARM",
-            build_layer_name(
-                "layer",
-                &BuildArchitecture::Arm64,
-                &Some("suffix".to_string())
-            )
-        );
-        assert_eq!(
-            "layer-ARM",
-            build_layer_name("layer", &BuildArchitecture::Arm64, &Some("".to_string()))
-        );
-        assert_eq!(
-            "layer-ARM",
-            build_layer_name("layer", &BuildArchitecture::Arm64, &None)
-        );
-        //AMD64
-        assert_eq!(
-            "layer-suffix",
-            build_layer_name(
-                "layer",
-                &BuildArchitecture::Amd64,
-                &Some("suffix".to_string())
-            )
-        );
-        assert_eq!(
-            "layer",
-            build_layer_name("layer", &BuildArchitecture::Amd64, &Some("".to_string()))
-        );
-        assert_eq!(
-            "layer",
-            build_layer_name("layer", &BuildArchitecture::Amd64, &None)
-        );
-    }
 }

--- a/build-tools/src/commands/mod.rs
+++ b/build-tools/src/commands/mod.rs
@@ -2,9 +2,9 @@ pub mod common;
 
 pub mod auth_command;
 pub mod build_command;
+pub mod check_layer_consistency_command;
 pub mod deploy_command;
 pub mod deploy_function_command;
 pub mod invoke_function_command;
 pub mod list_region_command;
 pub mod sign_command;
-pub mod check_layer_consistency_command;

--- a/build-tools/src/commands/mod.rs
+++ b/build-tools/src/commands/mod.rs
@@ -7,3 +7,4 @@ pub mod deploy_function_command;
 pub mod invoke_function_command;
 pub mod list_region_command;
 pub mod sign_command;
+pub mod check_layer_consistency_command;

--- a/build-tools/src/main.rs
+++ b/build-tools/src/main.rs
@@ -1,7 +1,7 @@
 use commands::{
-    auth_command::auth, build_command::build, deploy_command::deploy,
-    deploy_function_command::deploy_function, invoke_function_command::invoke_function,
-    list_region_command::list_region, sign_command::sign, check_layer_consistency_command::check_consistency,
+    auth_command::auth, build_command::build, check_layer_consistency_command::check_consistency,
+    deploy_command::deploy, deploy_function_command::deploy_function,
+    invoke_function_command::invoke_function, list_region_command::list_region, sign_command::sign,
 };
 use std::io::Result;
 use structopt::StructOpt;
@@ -25,8 +25,13 @@ enum SubCommand {
     DeployLambdaFunction(commands::deploy_function_command::DeployFunctionOptions),
     #[structopt(name = "invoke_lambda", about = "Invoke AWS Lambda Function")]
     InvokeLambdaFunction(commands::invoke_function_command::InvokeFunctionOptions),
-    #[structopt(name = "check_layer_version_consistency", about = "Check if a layer is at the same version in all regions")]
-    CheckLayerVersionConsistency(commands::check_layer_consistency_command::CheckLayerConsistencyOptions),
+    #[structopt(
+        name = "check_layer_version_consistency",
+        about = "Check if a layer is at the same version in all regions"
+    )]
+    CheckLayerVersionConsistency(
+        commands::check_layer_consistency_command::CheckLayerConsistencyOptions,
+    ),
 }
 
 #[derive(Debug, StructOpt)]

--- a/build-tools/src/main.rs
+++ b/build-tools/src/main.rs
@@ -1,7 +1,7 @@
 use commands::{
     auth_command::auth, build_command::build, deploy_command::deploy,
     deploy_function_command::deploy_function, invoke_function_command::invoke_function,
-    list_region_command::list_region, sign_command::sign,
+    list_region_command::list_region, sign_command::sign, check_layer_consistency_command::check_consistency,
 };
 use std::io::Result;
 use structopt::StructOpt;
@@ -25,6 +25,8 @@ enum SubCommand {
     DeployLambdaFunction(commands::deploy_function_command::DeployFunctionOptions),
     #[structopt(name = "invoke_lambda", about = "Invoke AWS Lambda Function")]
     InvokeLambdaFunction(commands::invoke_function_command::InvokeFunctionOptions),
+    #[structopt(name = "check_layer_version_consistency", about = "Check if a layer is at the same version in all regions")]
+    CheckLayerVersionConsistency(commands::check_layer_consistency_command::CheckLayerConsistencyOptions),
 }
 
 #[derive(Debug, StructOpt)]
@@ -49,5 +51,6 @@ async fn main() -> Result<()> {
         SubCommand::ListRegion(opt) => list_region(&opt).await,
         SubCommand::DeployLambdaFunction(opt) => deploy_function(&opt).await,
         SubCommand::InvokeLambdaFunction(opt) => invoke_function(&opt).await,
+        SubCommand::CheckLayerVersionConsistency(opt) => check_consistency(&opt).await,
     }
 }


### PR DESCRIPTION
Before deploying a new layer version to all regions, we need to make sure that the version is the same everywhere.
This will be useful when a new region will pop for instance

This PRs also 

- moves the `build_layer_name` as it's now used by two different commands
- better uses the OCI layering mechanism to speed up the build process

Example when layer version does not match:
<img width="1133" alt="Screenshot 2023-02-28 at 3 18 12 PM" src="https://user-images.githubusercontent.com/864493/221968846-f9dc9238-f2ad-4ba1-a7c8-79bc7cdd2e0f.png">
