### PR TITLE
Tools for visualizing the size of the extension.

### DIFF
--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -4,6 +4,7 @@ FROM golang:1.19 as builder
 ARG EXTENSION_VERSION
 ARG AGENT_VERSION
 ARG CMD_PATH
+ARG BUILD_TAGS
 RUN mkdir -p /tmp/dd/datadog-agent
 
 # cache dependencies
@@ -19,16 +20,16 @@ WORKDIR /tmp/dd/datadog-agent/"${CMD_PATH}"
 # add the current version number to the tags package before compilation
 
 RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \ 
+    --mount=type=cache,target=/root/.cache/go-build \
     if [ -z "$AGENT_VERSION" ]; then \
         go build -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
-        -tags serverless -o datadog-agent; \
+        -tags "${BUILD_TAGS}" -o datadog-agent; \
     else \
         go build -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION \
         -X github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault=$AGENT_VERSION" \
-        -tags serverless -o datadog-agent; \
+        -tags "${BUILD_TAGS}" -o datadog-agent; \
     fi
 
 RUN go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault' || \

--- a/scripts/Dockerfile.race.build
+++ b/scripts/Dockerfile.race.build
@@ -4,6 +4,7 @@ FROM golang:1.19 as builder
 ARG EXTENSION_VERSION
 ARG ENABLE_RACE_DETECTION
 ARG AGENT_VERSION
+ARG BUILD_TAGS
 RUN mkdir -p /tmp/dd/datadog-agent
 
 # cache dependsencies
@@ -23,12 +24,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     if [ -z "$AGENT_VERSION" ]; then \
         go build -race -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
-        -tags serverless -o datadog-agent; \
+        -tags "${BUILD_TAGS}" -o datadog-agent; \
     else \
         go build -race -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION \
         -X github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault=$AGENT_VERSION" \
-        -tags serverless -o datadog-agent; \
+        -tags "${BUILD_TAGS}" -o datadog-agent; \
     fi
 
 RUN go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault' || \

--- a/scripts/build_binary_and_layer_dockerized.sh
+++ b/scripts/build_binary_and_layer_dockerized.sh
@@ -57,6 +57,10 @@ if [ "$RACE_DETECTION_ENABLED" = "true" ]; then
     BUILD_FILE=Dockerfile.race.build
 fi
 
+if [ -z "$BUILD_TAGS" ]; then
+    BUILD_TAGS="serverless"
+fi
+
 function docker_build_zip {
     arch=$1
     suffix=$2
@@ -68,6 +72,7 @@ function docker_build_zip {
         --build-arg EXTENSION_VERSION="${VERSION}" \
         --build-arg AGENT_VERSION="${AGENT_VERSION}" \
         --build-arg CMD_PATH="${CMD_PATH}" \
+        --build-arg BUILD_TAGS="${BUILD_TAGS}" \
         . --load
     dockerId=$(docker create datadog/build-lambda-extension-${arch}:$VERSION)
     docker cp $dockerId:/datadog_extension.zip $TARGET_DIR/datadog_extension-${arch}${suffix}.zip

--- a/scripts/visualize_size.sh
+++ b/scripts/visualize_size.sh
@@ -115,6 +115,38 @@ for pkg, size in sorted(packages.items(), key=lambda a: a[1], reverse=True):
     print(size,"\t",urllib.parse.unquote(pkg))'
 }
 
+function print_usage() {
+    echo "visualize_size.sh: tools for debugging and visualizing binary sizes
+    usage: ./scripts/visualize_size.sh TOOL_NAME
+
+    Where TOOL_NAME is one of the following:
+        list_symbols    prints a list of all dependencies of the extension
+                        and the aggregated size of each
+
+        size            prints the size of the extension binary in bytes as
+                        built for production
+
+        package_size    prints the size in bytes of all symbols that match
+                        PACKAGE, requires that PACKAGE be given
+
+        graph           save a a dependency graph to .layers/graph.svg. Shows
+                        all paths to package PACKAGE, requires that PACKAGE be
+                        given
+
+        go_binsize_viz  view relative sizes of packages visually in the browser
+
+    These additional variables are available:
+        PACKAGE         the name of the package to debug, requires full package
+                        name as would be used in an import statement
+
+        CMD_PATH        the path to the entrypoint of the binary to be
+                        visualized, defaults to cmd/serverless
+
+        BUILD_TAGS      go build tags to use when building the extension,
+                        defaults to serverless
+    "
+}
+
 subcommand=$1
 case $subcommand in
     list_symbols)
@@ -136,8 +168,12 @@ case $subcommand in
         graph_package
         ;;
 
+    go_binsize_viz)
+        go_binsize_viz
+        ;;
+
     *)
-        echo "unknown subcommand: ${subcommand}"
+        print_usage
         exit 1
         ;;
 esac

--- a/scripts/visualize_size.sh
+++ b/scripts/visualize_size.sh
@@ -5,9 +5,10 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2020 Datadog, Inc.
 
-# Publish the datadog lambda layer across regions, using the AWS CLI
-# Usage: VERSION=5 REGIONS=us-east-1 publish_layers.sh
-# VERSION is required.
+# Required tools for drawing graphs:
+#   digraph: https://pkg.go.dev/golang.org/x/tools/cmd/digraph
+#   graphviz: https://graphviz.org/download/
+
 set -e -o pipefail
 
 # Move into the root directory, so this script can be called from any directory

--- a/scripts/visualize_size.sh
+++ b/scripts/visualize_size.sh
@@ -96,11 +96,30 @@ for line in sys.stdin:
 print("}")' | dot -Tsvg -o "output.svg"
 }
 
+function aggregate_sizes() {
+    python3 -c '
+import sys, urllib.parse
+packages = {}
+for line in sys.stdin.readlines():
+    pkg = line.strip().split()
+    if len(pkg) != 4:
+        continue
+    _, size, _, name = pkg
+    size = int(size)
+    namesplit = name.split("/")
+    path = "/".join(namesplit[:-1])
+    package = namesplit[-1].split(".")[0]
+    newname = f"{path}/{package}" if path else package
+    packages[newname] = packages.get(newname, 0) + size
+for pkg, size in sorted(packages.items(), key=lambda a: a[1], reverse=True):
+    print(size,"\t",urllib.parse.unquote(pkg))'
+}
+
 subcommand=$1
 case $subcommand in
     list_symbols)
         build_with_symbols
-        list_symbols
+        list_symbols | aggregate_sizes
         ;;
 
     size)

--- a/scripts/visualize_size.sh
+++ b/scripts/visualize_size.sh
@@ -5,10 +5,6 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2020 Datadog, Inc.
 
-# Required tools for drawing graphs:
-#   digraph: https://pkg.go.dev/golang.org/x/tools/cmd/digraph
-#   graphviz: https://graphviz.org/download/
-
 set -e -o pipefail
 
 # Move into the root directory, so this script can be called from any directory
@@ -144,6 +140,10 @@ function print_usage() {
 
         BUILD_TAGS      go build tags to use when building the extension,
                         defaults to serverless
+
+    Tools required for drawing graphs:
+        digraph         https://pkg.go.dev/golang.org/x/tools/cmd/digraph
+        graphviz        https://graphviz.org/download/
     "
 }
 

--- a/scripts/visualize_size.sh
+++ b/scripts/visualize_size.sh
@@ -40,6 +40,11 @@ function build_with_symbols() {
     fi
 }
 
+function build_prod() {
+    BUILD_TAGS="$BUILD_TAGS" ARCHITECTURE=amd64 VERSION=1 \
+        ./scripts/build_binary_and_layer_dockerized.sh
+}
+
 function go_binsize_viz() {
     cd .layers/datadog_extension-amd64/extensions/
 
@@ -60,7 +65,7 @@ function list_symbols() {
 }
 
 function binary_size() {
-    size=$(stat -c "%s"  "$BINARY_FILE")
+    size=$(stat -c "%s" "$BINRAY_DIR/datadog_extension-amd64/extensions/datadog-agent")
     echo "size of binary is ${size}"
 }
 
@@ -98,7 +103,7 @@ case $subcommand in
         ;;
 
     size)
-        build_with_symbols
+        build_prod
         binary_size
         ;;
 

--- a/scripts/visualize_size.sh
+++ b/scripts/visualize_size.sh
@@ -13,7 +13,7 @@ EXTENSION_DIR="$DIR/.."
 cd "$EXTENSION_DIR"
 
 if [ -z "$BUILD_TAGS" ]; then
-    BUILD_TAGS="serverless"
+    BUILD_TAGS="serverless otlp"
 fi
 
 if [ -z "$CMD_PATH" ]; then
@@ -39,7 +39,7 @@ function build_with_symbols() {
 
 function build_prod() {
     BUILD_TAGS="$BUILD_TAGS" ARCHITECTURE=amd64 VERSION=1 \
-        ./scripts/build_binary_and_layer_dockerized.sh
+        ./scripts/build_binary_and_layer_dockerized.sh 1>&2
 }
 
 function go_binsize_viz() {
@@ -62,8 +62,7 @@ function list_symbols() {
 }
 
 function binary_size() {
-    size=$(stat -c "%s" "$BINRAY_DIR/datadog_extension-amd64/extensions/datadog-agent")
-    echo "size of binary is ${size}"
+    stat -c "%s" "$BINRAY_DIR/datadog_extension-amd64/extensions/datadog-agent"
 }
 
 function package_size() {

--- a/scripts/visualize_size.sh
+++ b/scripts/visualize_size.sh
@@ -8,22 +8,111 @@
 # Publish the datadog lambda layer across regions, using the AWS CLI
 # Usage: VERSION=5 REGIONS=us-east-1 publish_layers.sh
 # VERSION is required.
-set -e
+set -e -o pipefail
 
 # Move into the root directory, so this script can be called from any directory
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-cd $DIR/..
+EXTENSION_DIR="$DIR/.."
+cd "$EXTENSION_DIR"
 
-./scripts/build_binary_and_layer_dockerized.sh
-cd ./extensions/
+if [ -z "$BUILD_TAGS" ]; then
+    BUILD_TAGS="serverless"
+fi
 
-echo "Analyzing go binary"
-go tool nm -size datadog-agent | c++filt > ../scripts/go-binsize-viz/agent.txt
-cd ../scripts/go-binsize-viz/
+if [ -z "$CMD_PATH" ]; then
+    CMD_PATH="cmd/serverless"
+fi
 
-echo "Converting data to json"
-python3 tab2pydic.py agent.txt > out.py
-python3 simplify.py out.py > data.js
+BINRAY_DIR="$EXTENSION_DIR/.layers"
+BINARY_NAME="datadog-agent"
+BINARY_FILE="$BINRAY_DIR/$BINARY_NAME"
+rm -rf "$BINRAY_DIR"
+mkdir -p "$BINRAY_DIR"
 
-echo "Open http://localhost:8000/treemap_v3.html"
-python3 -m http.server
+AGENT_DIR="$EXTENSION_DIR/../datadog-agent"
+
+function build_with_symbols() {
+    if [ "$BUILD_EXTENSION" != "false" ]; then
+        cd "$AGENT_DIR/$CMD_PATH"
+        go build -tags "$BUILD_TAGS" -o "$BINARY_NAME" || cd "$EXTENSION_DIR"
+        mv "$BINARY_NAME" "$BINRAY_DIR"
+        cd "$EXTENSION_DIR"
+    fi
+}
+
+function go_binsize_viz() {
+    cd .layers/datadog_extension-amd64/extensions/
+
+    echo "Analyzing go binary"
+    go tool nm -size datadog-agent | c++filt > ../scripts/go-binsize-viz/agent.txt
+    cd ../scripts/go-binsize-viz/
+
+    echo "Converting data to json"
+    python3 tab2pydic.py agent.txt > out.py
+    python3 simplify.py out.py > data.js
+
+    echo "Open http://localhost:8000/treemap_v3.html"
+    python3 -m http.server
+}
+
+function list_symbols() {
+    go tool nm -size -sort size "${BINARY_FILE}"
+}
+
+function binary_size() {
+    size=$(stat -c "%s"  "$BINARY_FILE")
+    echo "size of binary is ${size}"
+}
+
+function package_size() {
+    size=$(list_symbols | grep "$PACKAGE" | awk '{print $2}' | paste -sd+ | bc)
+    echo "size of ${PACKAGE} is ${size}"
+}
+
+function graph_package() {
+    cd "$AGENT_DIR"
+    deps=$(go list -tags "$BUILD_TAGS" -f '{{ .ImportPath }} {{ join .Imports " " }}' -deps "./$CMD_PATH")
+    graphed=$(echo "$deps" | digraph allpaths "github.com/DataDog/datadog-agent/$CMD_PATH" "$PACKAGE")
+    echo "$graphed" | draw_digraph
+    mv "output.svg" "$BINRAY_DIR"
+    cd "$EXTENSION_DIR"
+    echo "graph saved to .layers/output.svg"
+}
+
+function draw_digraph() {
+    python3 -c '
+import sys
+print("digraph {")
+for line in sys.stdin:
+    print("\"", end="")
+    print("\" -> \"".join(line.strip().split()), end="")
+    print("\"")
+print("}")' | dot -Tsvg -o "output.svg"
+}
+
+subcommand=$1
+case $subcommand in
+    list_symbols)
+        build_with_symbols
+        list_symbols
+        ;;
+
+    size)
+        build_with_symbols
+        binary_size
+        ;;
+
+    package_size)
+        build_with_symbols
+        package_size
+        ;;
+
+    graph)
+        graph_package
+        ;;
+
+    *)
+        echo "unknown subcommand: ${subcommand}"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
This pull request updates the `scripts/visualize_size.sh` to include several more helpful tools. See the help menu included in the script for more details on each of these.

Also added is a `BUILD_TAGS` variable which allows for configuration of the go build tags used when building the extension. It defaults to `serverless`, so by default the build script will act just as it did before this change.