### PR TITLE
Aj/description optional for publish workflow

### DIFF
--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -30,6 +30,10 @@ on:
         type: string
         description: Suffix to be appended to the layer name (default empty)
         default: ""
+      description:
+        type: string
+        description: Optional description to add to the layer (default empty)
+        default: ""
 
 jobs:
   prepare-artifact:
@@ -122,7 +126,8 @@ jobs:
           --layer-name "Datadog-Extension" \
           --layer-suffix "${{ inputs.layerSuffix }}" \
           --region ${{ github.event.inputs.region }} \
-          --key ${{ secrets.GH_ACTION_PUBLISHER_AEM_KEY }}
+          --key ${{ secrets.GH_ACTION_PUBLISHER_AEM_KEY }} \
+          --description "${{ inputs.description }}"
 
   deploy-artifact:
     if: ${{ github.event.inputs.region == 'all' }}
@@ -164,4 +169,5 @@ jobs:
           --layer-name "Datadog-Extension" \
           --layer-suffix "${{ inputs.layerSuffix }}" \
           --region ${{ matrix.aws_region }} \
-          --key ${{ secrets.GH_ACTION_PUBLISHER_AEM_KEY }}
+          --key ${{ secrets.GH_ACTION_PUBLISHER_AEM_KEY }} \
+          --description "${{ inputs.description }}"

--- a/build-tools/src/commands/auth_command.rs
+++ b/build-tools/src/commands/auth_command.rs
@@ -15,7 +15,7 @@ pub struct AuthOptions {
     key: String,
 }
 
-pub async fn auth(args: &AuthOptions) -> Result<()> {
+pub async fn auth(args: AuthOptions) -> Result<()> {
     // set a random AWS_REGION as sts in region-agnostic
     std::env::set_var("AWS_REGION", "us-east-1");
 

--- a/build-tools/src/commands/build_command.rs
+++ b/build-tools/src/commands/build_command.rs
@@ -25,10 +25,10 @@ pub struct BuildOptions {
     docker_path: String,
 }
 
-pub fn build(args: &BuildOptions) -> Result<()> {
+pub fn build(args: BuildOptions) -> Result<()> {
     match args.cloudrun {
         true => build_cloud_run(),
-        false => build_extension("cmd/serverless", args),
+        false => build_extension("cmd/serverless", &args),
     }
 }
 

--- a/build-tools/src/commands/deploy_command.rs
+++ b/build-tools/src/commands/deploy_command.rs
@@ -26,7 +26,7 @@ pub struct DeployOptions {
     description: String,
 }
 
-pub async fn deploy(args: &DeployOptions) -> Result<()> {
+pub async fn deploy(args: DeployOptions) -> Result<()> {
     let config = build_config(&args.key, &args.region).await;
     let lambda_client = lambda::Client::new(&config);
 
@@ -36,13 +36,12 @@ pub async fn deploy(args: &DeployOptions) -> Result<()> {
 
     let layer_name = build_layer_name(&args.layer_name, &args.architecture, &args.layer_suffix);
 
-    let description = String::from(&args.description);
     // publish layer
     let builder = lambda_client.publish_layer_version();
     builder
         .set_layer_name(Some(layer_name))
         .set_content(Some(content.set_zip_file(Some(lambda_blob)).build()))
-        .set_description(Some(description))
+        .set_description(Some(args.description))
         .send()
         .await
         .expect("error while publishing the layer");

--- a/build-tools/src/commands/deploy_command.rs
+++ b/build-tools/src/commands/deploy_command.rs
@@ -22,6 +22,8 @@ pub struct DeployOptions {
     key: Option<String>,
     #[structopt(long, default_value = "sa-east-1")]
     region: String,
+    #[structopt(long)]
+    description: String,
 }
 
 pub async fn deploy(args: &DeployOptions) -> Result<()> {
@@ -34,11 +36,13 @@ pub async fn deploy(args: &DeployOptions) -> Result<()> {
 
     let layer_name = build_layer_name(&args.layer_name, &args.architecture, &args.layer_suffix);
 
+    let description = String::from(&args.description);
     // publish layer
     let builder = lambda_client.publish_layer_version();
     builder
         .set_layer_name(Some(layer_name))
         .set_content(Some(content.set_zip_file(Some(lambda_blob)).build()))
+        .set_description(Some(description))
         .send()
         .await
         .expect("error while publishing the layer");

--- a/build-tools/src/commands/deploy_function_command.rs
+++ b/build-tools/src/commands/deploy_function_command.rs
@@ -68,13 +68,13 @@ pub struct DeployFunctionOptions {
     should_invoke: bool,
 }
 
-pub async fn deploy_function(args: &DeployFunctionOptions) -> Result<()> {
+pub async fn deploy_function(args: DeployFunctionOptions) -> Result<()> {
     let api_key = std::env::var("DD_API_KEY").expect("could not find DD_API_KEY env");
     std::env::set_var("AWS_REGION", &args.region);
     let config = aws_config::load_from_env().await;
     let lambda_client = lambda::Client::new(&config);
     let layer_arn = get_latest_arn(&lambda_client, &args.layer_name).await?;
-    let deployed_arn = create_function(&lambda_client, args, layer_arn, api_key).await?;
+    let deployed_arn = create_function(&lambda_client, &args, layer_arn, api_key).await?;
     if args.should_invoke {
         thread::sleep(Duration::from_secs(15));
         let invoke_args = InvokeFunctionOptions {
@@ -83,7 +83,7 @@ pub async fn deploy_function(args: &DeployFunctionOptions) -> Result<()> {
             nb: 5, // to make sure enhanced metrics are flushed
             remove_after: true,
         };
-        invoke_function_command::invoke_function(&invoke_args).await?;
+        invoke_function_command::invoke_function(invoke_args).await?;
     }
     Ok(())
 }

--- a/build-tools/src/commands/invoke_function_command.rs
+++ b/build-tools/src/commands/invoke_function_command.rs
@@ -15,7 +15,7 @@ pub struct InvokeFunctionOptions {
     pub remove_after: bool,
 }
 
-pub async fn invoke_function(args: &InvokeFunctionOptions) -> Result<()> {
+pub async fn invoke_function(args: InvokeFunctionOptions) -> Result<()> {
     std::env::set_var("AWS_REGION", &args.region);
     let config = aws_config::load_from_env().await;
     let lambda_client = lambda::Client::new(&config);

--- a/build-tools/src/commands/list_region_command.rs
+++ b/build-tools/src/commands/list_region_command.rs
@@ -13,7 +13,7 @@ pub struct ListRegionOptions {
     key: Option<String>,
 }
 
-pub async fn list_region(args: &ListRegionOptions) -> Result<()> {
+pub async fn list_region(args: ListRegionOptions) -> Result<()> {
     // set a random AWS_REGION as ec2:DescribeRgions in region-agnostic
     let config = build_config(&args.key, "us-east-1").await;
     let ec2_client = ec2::Client::new(&config);

--- a/build-tools/src/commands/sign_command.rs
+++ b/build-tools/src/commands/sign_command.rs
@@ -28,15 +28,15 @@ pub struct SignOptions {
     key: Option<String>,
 }
 
-pub async fn sign(args: &SignOptions) -> Result<()> {
+pub async fn sign(args: SignOptions) -> Result<()> {
     let config = build_config(&args.key, "sa-east-1").await; // TODO fixeme when ready for production
     let s3_client = s3::Client::new(&config);
     let signer_client = signer::Client::new(&config);
     let key = build_s3_key();
-    upload_object(args, &key, &s3_client).await?;
+    upload_object(&args, &key, &s3_client).await?;
     let job_id = sign_object(&key, &signer_client).await?;
     verify(&job_id, &signer_client).await?;
-    download_object(args, &job_id, &s3_client).await?;
+    download_object(&args, &job_id, &s3_client).await?;
     delete_object(&job_id, &s3_client).await?;
     delete_object(&key, &s3_client).await?;
     Ok(())

--- a/build-tools/src/main.rs
+++ b/build-tools/src/main.rs
@@ -42,12 +42,12 @@ struct BuildTools {
 async fn main() -> Result<()> {
     let args = BuildTools::from_args();
     match args.cmd {
-        SubCommand::Auth(opt) => auth(&opt).await,
-        SubCommand::Build(opt) => build(&opt),
-        SubCommand::Deploy(opt) => deploy(&opt).await,
-        SubCommand::Sign(opt) => sign(&opt).await,
-        SubCommand::ListRegion(opt) => list_region(&opt).await,
-        SubCommand::DeployLambdaFunction(opt) => deploy_function(&opt).await,
-        SubCommand::InvokeLambdaFunction(opt) => invoke_function(&opt).await,
+        SubCommand::Auth(opt) => auth(opt).await,
+        SubCommand::Build(opt) => build(opt),
+        SubCommand::Deploy(opt) => deploy(opt).await,
+        SubCommand::Sign(opt) => sign(opt).await,
+        SubCommand::ListRegion(opt) => list_region(opt).await,
+        SubCommand::DeployLambdaFunction(opt) => deploy_function(opt).await,
+        SubCommand::InvokeLambdaFunction(opt) => invoke_function(opt).await,
     }
 }


### PR DESCRIPTION
- Optionally add a description to the layer, useful for tracking branch names for RCs, agent version numbers, and potentially useful for production builds
- Passes ownership of args to commands, as they are not reused by `main`.