### PR TITLE
Re-enable the otlp build tag.

### DIFF
--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -22,6 +22,13 @@ on:
         options:
         - amd64
         - arm64
+      buildTags:
+        type: choice
+        description: Build tags
+        default: 'serverless otlp'
+        options:
+          - 'serverless otlp'
+          - 'serverless'
       agentBranch:
         type: string
         description: Datadog agent branch name (default main)
@@ -80,6 +87,7 @@ jobs:
          --context-path "${GITHUB_WORKSPACE}" \
          --destination-path "${GITHUB_WORKSPACE}/tmp" \
          --docker-path "scripts_v2/Dockerfile.build" \
+         --build-tags "${{ inputs.buildTags }}" \
          --artifact-name "datadog_extension.zip"
       - name: Sign the layer
         env:

--- a/build-tools/src/commands/build_command.rs
+++ b/build-tools/src/commands/build_command.rs
@@ -23,6 +23,8 @@ pub struct BuildOptions {
     artifact_name: String,
     #[structopt(long)]
     docker_path: String,
+    #[structopt(long, default_value = "serverless otlp")]
+    build_tags: String,
 }
 
 pub fn build(args: &BuildOptions) -> Result<()> {
@@ -60,6 +62,7 @@ fn build_image(args: &BuildOptions, cmd_path: &str, dockerfile_path: &str) -> Re
     let extension_version_build_arg = format!("EXTENSION_VERSION={}", args.version);
     let agent_version_build_arg = format!("AGENT_VERSION={}", args.agent_version);
     let cmd_path_build_arg = format!("CMD_PATH={}", cmd_path);
+    let build_tags_build_arg = format!("BUILD_TAGS={}", args.build_tags);
 
     let docker_args = [
         "buildx",
@@ -76,6 +79,8 @@ fn build_image(args: &BuildOptions, cmd_path: &str, dockerfile_path: &str) -> Re
         agent_version_build_arg.as_str(),
         "--build-arg",
         cmd_path_build_arg.as_str(),
+        "--build-arg",
+        build_tags_build_arg.as_str(),
         args.context_path.as_str(),
         "--load",
     ];

--- a/scripts/Dockerfile.alpine.build
+++ b/scripts/Dockerfile.alpine.build
@@ -4,6 +4,7 @@ FROM alpine:3.16 as builder
 ARG EXTENSION_VERSION
 ARG AGENT_VERSION
 ARG CMD_PATH
+ARG BUILD_TAGS
 
 RUN apk add --no-cache git make musl-dev go gcc
 ENV GOROOT /usr/lib/go
@@ -30,12 +31,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     if [ -z "$AGENT_VERSION" ]; then \
         go build -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
-        -tags serverless -o datadog-agent; \
+        -tags "${BUILD_TAGS}" -o datadog-agent; \
     else \
         go build -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION \
         -X github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault=$AGENT_VERSION" \
-        -tags serverless -o datadog-agent; \
+        -tags "${BUILD_TAGS}" -o datadog-agent; \
     fi
 
 RUN go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault' || \

--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -4,6 +4,7 @@ FROM golang:1.19 as builder
 ARG EXTENSION_VERSION
 ARG AGENT_VERSION
 ARG CMD_PATH
+ARG BUILD_TAGS
 RUN mkdir -p /tmp/dd/datadog-agent
 
 # cache dependencies
@@ -23,12 +24,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     if [ -z "$AGENT_VERSION" ]; then \
         go build -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
-        -tags serverless -o datadog-agent; \
+        -tags "${BUILD_TAGS}" -o datadog-agent; \
     else \
         go build -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION \
         -X github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault=$AGENT_VERSION" \
-        -tags serverless -o datadog-agent; \
+        -tags "${BUILD_TAGS}" -o datadog-agent; \
     fi
 
 RUN go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault' || \

--- a/scripts/Dockerfile.race.build
+++ b/scripts/Dockerfile.race.build
@@ -4,6 +4,7 @@ FROM golang:1.19 as builder
 ARG EXTENSION_VERSION
 ARG ENABLE_RACE_DETECTION
 ARG AGENT_VERSION
+ARG BUILD_TAGS
 RUN mkdir -p /tmp/dd/datadog-agent
 
 # cache dependsencies
@@ -23,12 +24,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     if [ -z "$AGENT_VERSION" ]; then \
         go build -race -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
-        -tags serverless -o datadog-agent; \
+        -tags "${BUILD_TAGS}" -o datadog-agent; \
     else \
         go build -race -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION \
         -X github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault=$AGENT_VERSION" \
-        -tags serverless -o datadog-agent; \
+        -tags "${BUILD_TAGS}" -o datadog-agent; \
     fi
 
 RUN go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault' || \

--- a/scripts/build_binary_and_layer_dockerized.sh
+++ b/scripts/build_binary_and_layer_dockerized.sh
@@ -21,8 +21,10 @@ fi
 
 if [ -z "$CLOUD_RUN" ]; then
     CMD_PATH="cmd/serverless"
+    BUILD_TAGS="serverless otlp"
 else
     CMD_PATH="cmd/serverless-init"
+    BUILD_TAGS="serverless"
 fi
 
 AGENT_PATH="../datadog-agent"
@@ -68,6 +70,7 @@ function docker_build_zip {
         --build-arg EXTENSION_VERSION="${VERSION}" \
         --build-arg AGENT_VERSION="${AGENT_VERSION}" \
         --build-arg CMD_PATH="${CMD_PATH}" \
+        --build-arg BUILD_TAGS="${BUILD_TAGS}" \
         . --load
     dockerId=$(docker create datadog/build-lambda-extension-${arch}:$VERSION)
     docker cp $dockerId:/datadog_extension.zip $TARGET_DIR/datadog_extension-${arch}${suffix}.zip

--- a/scripts_v2/Dockerfile.build
+++ b/scripts_v2/Dockerfile.build
@@ -4,6 +4,7 @@ FROM golang:1.19 as builder
 ARG EXTENSION_VERSION
 ARG AGENT_VERSION
 ARG CMD_PATH
+ARG BUILD_TAGS
 
 RUN mkdir -p /tmp/dd
 
@@ -18,12 +19,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     if [ -z "$AGENT_VERSION" ]; then \
         go build -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
-        -tags serverless -o datadog-agent; \
+        -tags "${BUILD_TAGS}" -o datadog-agent; \
     else \
         go build -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION \
         -X github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault=$AGENT_VERSION" \
-        -tags serverless -o datadog-agent; \
+        -tags "${BUILD_TAGS}" -o datadog-agent; \
     fi
 
 RUN go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault' || \


### PR DESCRIPTION
This PR replaces #130 (Revert Revert Revert Revert). As it adds new functionality which is required for releasing the extension using the github action.

This PR also fixes an issue which was incorrectly adding build tags when releasing from the github action. Because I didn't realize that the action uses the v2 scripts, I didn't do all that was required to add the `otlp` build tag.

Therefore, in previous iterations of our attempts to add the `otlp` build tag, when releasing from the github action, instead of `-tags "serverless otlp"`, it was getting `-tags ""`.