### PR TITLE
Fix cloud run build script (go 1.19)

### DIFF
--- a/scripts/Dockerfile.alpine.build
+++ b/scripts/Dockerfile.alpine.build
@@ -6,7 +6,9 @@ ARG AGENT_VERSION
 ARG CMD_PATH
 ARG BUILD_TAGS
 
-RUN apk add --no-cache git make musl-dev go gcc
+RUN apk add --no-cache git make musl-dev gcc
+COPY --from=golang:1.19-alpine /usr/local/go/ /usr/lib/go
+
 ENV GOROOT /usr/lib/go
 ENV GOPATH /go
 ENV PATH /go/bin:$PATH
@@ -28,18 +30,11 @@ WORKDIR /tmp/dd/datadog-agent/"${CMD_PATH}"
 
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \ 
-    if [ -z "$AGENT_VERSION" ]; then \
-        go build -ldflags="-w \
+    /usr/lib/go/bin/go build -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
-        -tags "${BUILD_TAGS}" -o datadog-agent; \
-    else \
-        go build -ldflags="-w \
-        -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION \
-        -X github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault=$AGENT_VERSION" \
-        -tags "${BUILD_TAGS}" -o datadog-agent; \
-    fi
+        -tags "${BUILD_TAGS}" -o datadog-agent;
 
-RUN go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault' || \
+RUN /usr/lib/go/bin/go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault' || \
     (echo "agentVersionDefault variable doesn't exist" && exit 1)
 
 # zip the extension

--- a/scripts/build_binary_and_layer_dockerized.sh
+++ b/scripts/build_binary_and_layer_dockerized.sh
@@ -26,11 +26,7 @@ else
 fi
 
 if [ -z "$BUILD_TAGS" ]; then
-    if [ -z "$CLOUD_RUN" ]; then
-        BUILD_TAGS="serverless otlp"
-    else
-        BUILD_TAGS="serverless"
-    fi
+    BUILD_TAGS="serverless otlp"
 fi
 
 AGENT_PATH="../datadog-agent"

--- a/scripts/build_binary_and_layer_dockerized.sh
+++ b/scripts/build_binary_and_layer_dockerized.sh
@@ -81,11 +81,9 @@ function docker_build_zip {
 
 if [ "$CLOUD_RUN" == "true" ]; then
     echo "Building for cloud run (both arch + alpine)"
-    docker_build_zip amd64
-    docker_build_zip arm64
+    #docker_build_zip amd64
     BUILD_FILE=Dockerfile.alpine.build
     docker_build_zip amd64 -alpine
-    docker_build_zip arm64 -alpine
 elif [ "$ARCHITECTURE" == "amd64" ]; then
     echo "Building for amd64 only"
     docker_build_zip amd64

--- a/scripts/build_binary_and_layer_dockerized.sh
+++ b/scripts/build_binary_and_layer_dockerized.sh
@@ -81,7 +81,7 @@ function docker_build_zip {
 
 if [ "$CLOUD_RUN" == "true" ]; then
     echo "Building for cloud run (both arch + alpine)"
-    #docker_build_zip amd64
+    docker_build_zip amd64
     BUILD_FILE=Dockerfile.alpine.build
     docker_build_zip amd64 -alpine
 elif [ "$ARCHITECTURE" == "amd64" ]; then

--- a/scripts/build_cloud_run.sh
+++ b/scripts/build_cloud_run.sh
@@ -5,7 +5,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-# Usage: VERSION=5 ARCHITECTURE=[amd64|arm64] ./scripts/build_cloud_run.sh
+# Usage: AGENT_VERSION=7.43.0 VERSION=5 ARCHITECTURE=[amd64|arm64] ./scripts/build_cloud_run.sh
 
 # Optional environment variables:
 # VERSION - Use a specific version number
@@ -16,4 +16,4 @@ set -e
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $SCRIPTS_DIR/..
 
-VERSION=$VERSION ARCHITECTURE=$ARCHITECTURE CLOUD_RUN=true ./scripts/build_binary_and_layer_dockerized.sh
+AGENT_VERSION=$AGENT_VERSION VERSION=$VERSION ARCHITECTURE=$ARCHITECTURE CLOUD_RUN=true ./scripts/build_binary_and_layer_dockerized.sh


### PR DESCRIPTION
- Fix cloud run build script (go 1.19)
- Propagate AGENT_VERSION variable
- Don't build serverless-init for arm64 arch