### PR TITLE
Disable function inlining, to reduce executable size

### DIFF
--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -22,14 +22,14 @@ WORKDIR /tmp/dd/datadog-agent/"${CMD_PATH}"
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     if [ -z "$AGENT_VERSION" ]; then \
-        go build -ldflags="-w \
-        -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
-        -tags "${BUILD_TAGS}" -o datadog-agent; \
+    go build -gcflags=all=-l -ldflags="-w \
+    -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
+    -tags "${BUILD_TAGS}" -o datadog-agent; \
     else \
-        go build -ldflags="-w \
-        -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION \
-        -X github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault=$AGENT_VERSION" \
-        -tags "${BUILD_TAGS}" -o datadog-agent; \
+    go build -gcflags=all=-l -ldflags="-w \
+    -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION \
+    -X github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault=$AGENT_VERSION" \
+    -tags "${BUILD_TAGS}" -o datadog-agent; \
     fi
 
 RUN go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault' || \

--- a/scripts_v2/Dockerfile.build
+++ b/scripts_v2/Dockerfile.build
@@ -17,14 +17,14 @@ WORKDIR /tmp/dd/datadog-agent/"${CMD_PATH}"
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \ 
     if [ -z "$AGENT_VERSION" ]; then \
-        go build -ldflags="-w \
-        -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
-        -tags "${BUILD_TAGS}" -o datadog-agent; \
+    go build -gcflags=all=-l  -ldflags="-w \
+    -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
+    -tags "${BUILD_TAGS}" -o datadog-agent; \
     else \
-        go build -ldflags="-w \
-        -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION \
-        -X github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault=$AGENT_VERSION" \
-        -tags "${BUILD_TAGS}" -o datadog-agent; \
+    go build -gcflags=all=-l -ldflags="-w \
+    -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION \
+    -X github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault=$AGENT_VERSION" \
+    -tags "${BUILD_TAGS}" -o datadog-agent; \
     fi
 
 RUN go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault' || \


### PR DESCRIPTION
Disables function inlining, which in practice sees about a 3mb reduction in build size, or a ~11% reduction.