### PR TITLE
fix golang sha1

### DIFF
--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -1,6 +1,8 @@
 # syntax = docker/dockerfile:experimental
 
-FROM golang:1.19 as builder
+# this fixes the version of the golang image to avoid breaking changes in glibc
+# sha1 comes from https://github.com/docker-library/repo-info/blob/b939681d85e36bae10eabe53b913f1d05e972f1f/repos/golang/remote/1.19.md
+FROM golang@sha256:2dde7ccba42da98d45e0f38f23f1c0d1474a779e4089faf665f9af0dd3f844db as builder
 ARG EXTENSION_VERSION
 ARG AGENT_VERSION
 ARG CMD_PATH

--- a/scripts_v2/Dockerfile.build
+++ b/scripts_v2/Dockerfile.build
@@ -1,6 +1,8 @@
 # syntax = docker/dockerfile:experimental
 
-FROM golang:1.19 as builder
+# this fixes the version of the golang image to avoid breaking changes in glibc
+# sha1 comes from https://github.com/docker-library/repo-info/blob/b939681d85e36bae10eabe53b913f1d05e972f1f/repos/golang/remote/1.19.md
+FROM golang@sha256:2dde7ccba42da98d45e0f38f23f1c0d1474a779e4089faf665f9af0dd3f844db as builder
 ARG EXTENSION_VERSION
 ARG AGENT_VERSION
 ARG CMD_PATH


### PR DESCRIPTION
This PR fixes the SHA1 for golang 1.19 to make sure glibc version is still compatible with lambda
<img width="1138" alt="Screenshot 2023-06-26 at 5 48 28 PM" src="https://github.com/DataDog/datadog-lambda-extension/assets/864493/588135c8-fff1-4bc1-a782-d0fb3b851ed6">
