### PR TITLE
Fix ARM build

### DIFF
--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -1,13 +1,23 @@
 # syntax = docker/dockerfile:experimental
 
-# this fixes the version of the golang image to avoid breaking changes in glibc
-# sha1 comes from https://github.com/docker-library/repo-info/blob/b939681d85e36bae10eabe53b913f1d05e972f1f/repos/golang/remote/1.19.md
-FROM golang@sha256:2dde7ccba42da98d45e0f38f23f1c0d1474a779e4089faf665f9af0dd3f844db as builder
+FROM public.ecr.aws/lambda/provided:al2 as builder
 ARG EXTENSION_VERSION
 ARG AGENT_VERSION
 ARG CMD_PATH
 ARG BUILD_TAGS
 RUN mkdir -p /tmp/dd/datadog-agent
+
+# install go 1.19
+RUN yum install -y wget tar gzip gcc
+RUN arch="$(uname -m)"; \
+    if [ "${arch}" = 'aarch64' ]; then \
+        arch='arm64'; \
+    fi; \
+    if [ "${arch}" = 'x86_64' ]; then \
+        arch='amd64'; \
+    fi; \
+    wget -O go1.19.10.linux-${arch}.tar.gz https://go.dev/dl/go1.19.10.linux-${arch}.tar.gz; \
+    tar -C /usr/local -xzf go1.19.10.linux-${arch}.tar.gz
 
 # cache dependencies
 COPY ./scripts/.cache/go.mod /tmp/dd/datadog-agent
@@ -24,17 +34,17 @@ WORKDIR /tmp/dd/datadog-agent/"${CMD_PATH}"
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     if [ -z "$AGENT_VERSION" ]; then \
-        go build -ldflags="-w \
+        /usr/local/go/bin/go build -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
         -tags "${BUILD_TAGS}" -o datadog-agent; \
     else \
-        go build -ldflags="-w \
+        /usr/local/go/bin/go build -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION \
         -X github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault=$AGENT_VERSION" \
         -tags "${BUILD_TAGS}" -o datadog-agent; \
     fi
 
-RUN go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault' || \
+RUN /usr/local/go/bin/go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault' || \
     (echo "agentVersionDefault variable doesn't exist" && exit 1)
 
 # zip the extension

--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -1,6 +1,8 @@
 # syntax = docker/dockerfile:experimental
 
-FROM golang:1.19 as builder
+# this fixes the version of the golang image to avoid breaking changes in glibc
+# sha1 comes from https://github.com/docker-library/repo-info/blob/b939681d85e36bae10eabe53b913f1d05e972f1f/repos/golang/remote/1.19.md
+FROM golang@sha256:2dde7ccba42da98d45e0f38f23f1c0d1474a779e4089faf665f9af0dd3f844db as builder
 ARG EXTENSION_VERSION
 ARG AGENT_VERSION
 ARG CMD_PATH

--- a/scripts_v2/Dockerfile.build
+++ b/scripts_v2/Dockerfile.build
@@ -1,12 +1,22 @@
 # syntax = docker/dockerfile:experimental
 
-# this fixes the version of the golang image to avoid breaking changes in glibc
-# sha1 comes from https://github.com/docker-library/repo-info/blob/b939681d85e36bae10eabe53b913f1d05e972f1f/repos/golang/remote/1.19.md
-FROM golang@sha256:2dde7ccba42da98d45e0f38f23f1c0d1474a779e4089faf665f9af0dd3f844db as builder
+FROM public.ecr.aws/lambda/provided:al2 as builder
 ARG EXTENSION_VERSION
 ARG AGENT_VERSION
 ARG CMD_PATH
 ARG BUILD_TAGS
+
+# install go 1.19
+RUN yum install -y wget tar gzip gcc
+RUN arch="$(uname -m)"; \
+    if [ "${arch}" = 'aarch64' ]; then \
+        arch='arm64'; \
+    fi; \
+    if [ "${arch}" = 'x86_64' ]; then \
+        arch='amd64'; \
+    fi; \
+    wget -O go1.19.10.linux-${arch}.tar.gz https://go.dev/dl/go1.19.10.linux-${arch}.tar.gz; \
+    tar -C /usr/local -xzf go1.19.10.linux-${arch}.tar.gz
 
 RUN mkdir -p /tmp/dd
 
@@ -19,17 +29,17 @@ WORKDIR /tmp/dd/datadog-agent/"${CMD_PATH}"
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \ 
     if [ -z "$AGENT_VERSION" ]; then \
-        go build -ldflags="-w \
+        /usr/local/go/bin/go build -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
         -tags "${BUILD_TAGS}" -o datadog-agent; \
     else \
-        go build -ldflags="-w \
+        /usr/local/go/bin/go build -ldflags="-w \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION \
         -X github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault=$AGENT_VERSION" \
         -tags "${BUILD_TAGS}" -o datadog-agent; \
     fi
 
-RUN go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault' || \
+RUN /usr/local/go/bin/go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault' || \
     (echo "agentVersionDefault variable doesn't exist" && exit 1)
 
 # zip the extension

--- a/scripts_v2/Dockerfile.build
+++ b/scripts_v2/Dockerfile.build
@@ -1,6 +1,8 @@
 # syntax = docker/dockerfile:experimental
 
-FROM golang:1.19 as builder
+# this fixes the version of the golang image to avoid breaking changes in glibc
+# sha1 comes from https://github.com/docker-library/repo-info/blob/b939681d85e36bae10eabe53b913f1d05e972f1f/repos/golang/remote/1.19.md
+FROM golang@sha256:2dde7ccba42da98d45e0f38f23f1c0d1474a779e4089faf665f9af0dd3f844db as builder
 ARG EXTENSION_VERSION
 ARG AGENT_VERSION
 ARG CMD_PATH


### PR DESCRIPTION
https://github.com/DataDog/datadog-lambda-extension/pull/145 introduced an issue where the SHA1 specified is no more compatible with multi-arch docker

This PRs use the AWS Lambda provided image + install go lang to avoid any issue with GLIBC + respect the multi arch