### PR TITLE
Adds a manual dispatch action to deploy serverless-init

### DIFF
--- a/.github/workflows/release-serverless-init.yml
+++ b/.github/workflows/release-serverless-init.yml
@@ -1,0 +1,110 @@
+name: Release serverless-init
+
+on:
+  workflow_dispatch:
+    inputs:
+      buildTags:
+        type: choice
+        description: Build tags
+        default: "serverless otlp"
+        options:
+          - "serverless otlp"
+          - "serverless"
+      tag:
+        type: string
+        description: Docker image tag name, eg. (beta11, beta12-rc1, etc.)
+      latestTag:
+        type: choice
+        description: Additionally, tag this as latest? Only use this if releasing a new production version.
+        default: "no"
+        options:
+          - "yes"
+          - "no"
+      agentVersion:
+        type: string
+        description: Datadog agent version
+      agentBranch:
+        type: string
+        description: Datadog agent branch name (default main)
+        default: "main"
+
+env:
+  IMAGE_NAME: datadog/serverless-init
+
+jobs:
+  release-serverless-init:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/checkout@v3
+        with:
+          repository: DataDog/datadog-agent
+          ref: refs/heads/${{ inputs.agentBranch }}
+          path: datadog-agent
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build binaries
+        working-directory: ./scripts
+        run: ./build_serverless_init.sh
+        env:
+          AGENT_PATH: datadog-agent
+          VERSION: ${{ inputs.tag }}
+          SERVERLESS_INIT: true
+          AGENT_VERSION: ${{ inputs.agentVersion }}
+
+      - name: Set up build directory and copy binaries
+        run: |
+          mkdir ./scripts/bin
+          cp .layers/datadog_extension-amd64/extensions/datadog-agent ./scripts/bin/datadog-agent
+          cp .layers/datadog_extension-amd64-alpine/extensions/datadog-agent ./scripts/bin/datadog-agent-alpine
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./scripts
+          file: ./scripts/Dockerfile.serverless-init.build
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:${{ inputs.tag }}
+
+      - name: Build and push (alpine)
+        id: docker_build_alpine
+        uses: docker/build-push-action@v2
+        with:
+          context: ./scripts
+          file: ./scripts/Dockerfile.serverless-init.alpine.build
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:${{ inputs.tag }}-alpine
+
+      - name: Build and push latest
+        id: docker_build_latest
+        uses: docker/build-push-action@v2
+        if: ${{ inputs.latestTag == 'yes' }}
+        with:
+          context: ./scripts
+          file: ./scripts/Dockerfile.serverless-init.build
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:latest
+
+      - name: Build and push latest alpine
+        id: docker_build_alpine_latest
+        uses: docker/build-push-action@v2
+        if: ${{ inputs.latestTag == 'yes' }}
+        with:
+          context: ./scripts
+          file: ./scripts/Dockerfile.serverless-init.alpine.build
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:latest-alpine

--- a/scripts/Dockerfile.serverless-init.alpine.build
+++ b/scripts/Dockerfile.serverless-init.alpine.build
@@ -1,0 +1,3 @@
+FROM scratch
+
+COPY ./bin/datadog-agent-alpine /datadog-init

--- a/scripts/Dockerfile.serverless-init.build
+++ b/scripts/Dockerfile.serverless-init.build
@@ -1,0 +1,3 @@
+FROM scratch
+
+COPY ./bin/datadog-agent /datadog-init

--- a/scripts/build_binary_and_layer_dockerized.sh
+++ b/scripts/build_binary_and_layer_dockerized.sh
@@ -19,7 +19,7 @@ if [ -z "$VERSION" ]; then
     exit 1
 fi
 
-if [ -z "$CLOUD_RUN" ]; then
+if [ -z "$SERVERLESS_INIT" ]; then
     CMD_PATH="cmd/serverless"
 else
     CMD_PATH="cmd/serverless-init"
@@ -29,7 +29,9 @@ if [ -z "$BUILD_TAGS" ]; then
     BUILD_TAGS="serverless otlp"
 fi
 
-AGENT_PATH="../datadog-agent"
+if [ -z "$AGENT_PATH" ]; then
+    AGENT_PATH="../datadog-agent"
+fi
 
 # Move into the root directory, so this script can be called from any directory
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
@@ -79,8 +81,8 @@ function docker_build_zip {
     unzip $TARGET_DIR/datadog_extension-${arch}${suffix}.zip -d $TARGET_DIR/datadog_extension-${arch}${suffix}
 }
 
-if [ "$CLOUD_RUN" == "true" ]; then
-    echo "Building for cloud run (both arch + alpine)"
+if [ "$SERVERLESS_INIT" == "true" ]; then
+    echo "Building serverless init (both arch + alpine)"
     docker_build_zip amd64
     BUILD_FILE=Dockerfile.alpine.build
     docker_build_zip amd64 -alpine

--- a/scripts/build_serverless_init.sh
+++ b/scripts/build_serverless_init.sh
@@ -5,7 +5,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
-# Usage: AGENT_VERSION=7.43.0 VERSION=5 ARCHITECTURE=[amd64|arm64] ./scripts/build_cloud_run.sh
+# Usage: AGENT_VERSION=7.43.0 VERSION=5 ARCHITECTURE=[amd64|arm64] ./scripts/build_serverless_init.sh
 
 # Optional environment variables:
 # VERSION - Use a specific version number
@@ -16,4 +16,4 @@ set -e
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $SCRIPTS_DIR/..
 
-AGENT_VERSION=$AGENT_VERSION VERSION=$VERSION ARCHITECTURE=$ARCHITECTURE CLOUD_RUN=true ./scripts/build_binary_and_layer_dockerized.sh
+AGENT_VERSION=$AGENT_VERSION VERSION=$VERSION ARCHITECTURE=$ARCHITECTURE SERVERLESS_INIT=true ./scripts/build_binary_and_layer_dockerized.sh


### PR DESCRIPTION
This PR adds a new Github action to deploy datadog/serverless-init:${tag} and serverless-init:${tag}-alpine to Dockerhub. This PR also introduces two new secrets: DOCKER_USERNAME and DOCKER_TOKEN. 