### PR TITLE
fix cache while building the image

### DIFF
--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -31,7 +31,7 @@ ADD ./scripts/.src/datadog-agent.tgz /tmp/dd
 WORKDIR /tmp/dd/datadog-agent/"${CMD_PATH}"
 # add the current version number to the tags package before compilation
 
-RUN --mount=type=cache,target=/go/pkg/mod \
+RUN --mount=type=cache,target=/root/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     if [ -z "$AGENT_VERSION" ]; then \
         /usr/local/go/bin/go build -ldflags="-w \

--- a/scripts_v2/Dockerfile.build
+++ b/scripts_v2/Dockerfile.build
@@ -26,7 +26,7 @@ COPY ./datadog-agent /tmp/dd/datadog-agent
 WORKDIR /tmp/dd/datadog-agent/"${CMD_PATH}"
 # add the current version number to the tags package before compilation
 
-RUN --mount=type=cache,target=/go/pkg/mod \
+RUN --mount=type=cache,target=/root/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \ 
     if [ -z "$AGENT_VERSION" ]; then \
         /usr/local/go/bin/go build -ldflags="-w \


### PR DESCRIPTION
Due to the fact that the base image changed lately, the cache location has also moved.
This PR fixes this location to speed up drastically the build time