### PR TITLE
update paths to .NET tracer libs

### DIFF
--- a/scripts/datadog_wrapper
+++ b/scripts/datadog_wrapper
@@ -33,15 +33,20 @@ then
     echo "Configuring for the .NET runtime!"
   fi
   # Handle the CORECLR_PROFILER_PATH:
-  # Load the tracer library directly (Datadog.Tracer.Native.so),
-  # which avoids loading the shared loader (Datadog.Trace.ClrProfiler.Native.so)
-  # since we don't support Continuous Profiling yet.
-  # Keep trying Datadog.Trace.ClrProfiler.Native.so for backwards compatibility.
-  PROFILER_PATHS=("/opt/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
-                  "/opt/datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
-                  "/opt/datadog/linux-x64/Datadog.Tracer.Native.so"
-                  "/opt/datadog/linux-arm64/Datadog.Tracer.Native.so"
-                  "/opt/datadog/Datadog.Trace.ClrProfiler.Native.so")
+  # Try to loads the library from these paths in order:
+  PROFILER_PATHS=(
+    # use the shared loader if it's present (it was removed from
+    # the dotnet layer for now, but this keeps
+    # forwards compatibility with Continuous Profiling)
+    "/opt/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
+    "/opt/datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
+    # use the tracer library directly (without the shared loader),
+    # this should be the common case going forward
+    "/opt/datadog/linux-x64/Datadog.Tracer.Native.so"
+    "/opt/datadog/linux-arm64/Datadog.Tracer.Native.so"
+    # keep this as a fallback for backwards compatibility
+    "/opt/datadog/Datadog.Trace.ClrProfiler.Native.so"
+  )
   PROFILER_FOUND=false
   ## Search from all possible places
   for PROFILER_PATH in "${PROFILER_PATHS[@]}"

--- a/scripts/datadog_wrapper
+++ b/scripts/datadog_wrapper
@@ -32,13 +32,15 @@ then
   then
     echo "Configuring for the .NET runtime!"
   fi
-  # Handle the CORECLR_PROFILER_PATH
-  # Try the native loader first (Datadog.Trace.ClrProfiler.Native.so), then
-  # fall back to the tracer library (Datadog.Tracer.Native.so)
-  PROFILER_PATHS=("/opt/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
-                  "/opt/datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
-                  "/opt/datadog/linux-x64/Datadog.Tracer.Native.so"
-                  "/opt/datadog/linux-arm64/Datadog.Tracer.Native.so")
+  # Handle the CORECLR_PROFILER_PATH:
+  # Load the tracer library directly (Datadog.Tracer.Native.so),
+  # which avoids loading the shared loader (Datadog.Trace.ClrProfiler.Native.so)
+  # since we don't support Continuous Profiling yet.
+  # Keep trying Datadog.Trace.ClrProfiler.Native.so as a fall back for backwards compatibility.
+  PROFILER_PATHS=("/opt/datadog/linux-x64/Datadog.Tracer.Native.so"
+                  "/opt/datadog/linux-arm64/Datadog.Tracer.Native.so"
+                  "/opt/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
+                  "/opt/datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so")
   PROFILER_FOUND=false
   ## Search from all possible places
   for PROFILER_PATH in "${PROFILER_PATHS[@]}"
@@ -52,7 +54,7 @@ then
   done
   if [ $PROFILER_FOUND == false ]
   then
-    echo "CLR Profiler file not found. Function profiling may not work correctly"
+    echo ".NET CLR Profiler file not found. APM instrumentation may not work correctly."
   fi
   # Other env variables for .NET
   export CORECLR_ENABLE_PROFILING="1"

--- a/scripts/datadog_wrapper
+++ b/scripts/datadog_wrapper
@@ -33,10 +33,12 @@ then
     echo "Configuring for the .NET runtime!"
   fi
   # Handle the CORECLR_PROFILER_PATH
-  DEFAULT_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
-  ARM64_PATH=/opt/datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so
-  X64_PATH=/opt/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so
-  PROFILER_PATHS=("${DEFAULT_PATH}" "${ARM64_PATH}" "${X64_PATH}")
+  # Try the native loader first (Datadog.Trace.ClrProfiler.Native.so), then
+  # fall back to the tracer library (Datadog.Tracer.Native.so)
+  PROFILER_PATHS=("/opt/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
+                  "/opt/datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
+                  "/opt/datadog/linux-x64/Datadog.Tracer.Native.so"
+                  "/opt/datadog/linux-arm64/Datadog.Tracer.Native.so")
   PROFILER_FOUND=false
   ## Search from all possible places
   for PROFILER_PATH in "${PROFILER_PATHS[@]}"

--- a/scripts/datadog_wrapper
+++ b/scripts/datadog_wrapper
@@ -33,7 +33,7 @@ then
     echo "Configuring for the .NET runtime!"
   fi
   # Handle the CORECLR_PROFILER_PATH:
-  # Try to loads the library from these paths in order:
+  # Try to load the library from these paths in order:
   PROFILER_PATHS=(
     # use the shared loader if it's present (it was removed from
     # the dotnet layer for now, but this keeps

--- a/scripts/datadog_wrapper
+++ b/scripts/datadog_wrapper
@@ -36,7 +36,7 @@ then
   # Load the tracer library directly (Datadog.Tracer.Native.so),
   # which avoids loading the shared loader (Datadog.Trace.ClrProfiler.Native.so)
   # since we don't support Continuous Profiling yet.
-  # Keep trying Datadog.Trace.ClrProfiler.Native.so as a fall back for backwards compatibility.
+  # Keep trying Datadog.Trace.ClrProfiler.Native.so for backwards compatibility.
   PROFILER_PATHS=("/opt/datadog/linux-x64/Datadog.Tracer.Native.so"
                   "/opt/datadog/linux-arm64/Datadog.Tracer.Native.so"
                   "/opt/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so"

--- a/scripts/datadog_wrapper
+++ b/scripts/datadog_wrapper
@@ -33,15 +33,14 @@ then
     echo "Configuring for the .NET runtime!"
   fi
   # Handle the CORECLR_PROFILER_PATH:
-  # Try to load the library from these paths in order:
+  # Try to load the library from these paths, in order:
   PROFILER_PATHS=(
-    # use the shared loader if it's present (it was removed from
-    # the dotnet layer for now, but this keeps
-    # forwards compatibility with Continuous Profiling)
+    # use the shared loader if it's present (it was removed from the dotnet
+    # layer, this keeps forwards compatibility if it's added back)
     "/opt/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
     "/opt/datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
-    # use the tracer library directly (without the shared loader),
-    # this should be the common case going forward
+    # if shared loader is not found,
+    # use the tracer library directly
     "/opt/datadog/linux-x64/Datadog.Tracer.Native.so"
     "/opt/datadog/linux-arm64/Datadog.Tracer.Native.so"
     # keep this as a fallback for backwards compatibility

--- a/scripts/datadog_wrapper
+++ b/scripts/datadog_wrapper
@@ -40,7 +40,8 @@ then
   PROFILER_PATHS=("/opt/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
                   "/opt/datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
                   "/opt/datadog/linux-x64/Datadog.Tracer.Native.so"
-                  "/opt/datadog/linux-arm64/Datadog.Tracer.Native.so")
+                  "/opt/datadog/linux-arm64/Datadog.Tracer.Native.so"
+                  "/opt/datadog/Datadog.Trace.ClrProfiler.Native.so")
   PROFILER_FOUND=false
   ## Search from all possible places
   for PROFILER_PATH in "${PROFILER_PATHS[@]}"

--- a/scripts/datadog_wrapper
+++ b/scripts/datadog_wrapper
@@ -37,10 +37,10 @@ then
   # which avoids loading the shared loader (Datadog.Trace.ClrProfiler.Native.so)
   # since we don't support Continuous Profiling yet.
   # Keep trying Datadog.Trace.ClrProfiler.Native.so for backwards compatibility.
-  PROFILER_PATHS=("/opt/datadog/linux-x64/Datadog.Tracer.Native.so"
-                  "/opt/datadog/linux-arm64/Datadog.Tracer.Native.so"
-                  "/opt/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
-                  "/opt/datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so")
+  PROFILER_PATHS=("/opt/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
+                  "/opt/datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
+                  "/opt/datadog/linux-x64/Datadog.Tracer.Native.so"
+                  "/opt/datadog/linux-arm64/Datadog.Tracer.Native.so")
   PROFILER_FOUND=false
   ## Search from all possible places
   for PROFILER_PATH in "${PROFILER_PATHS[@]}"

--- a/scripts/datadog_wrapper
+++ b/scripts/datadog_wrapper
@@ -36,7 +36,7 @@ then
   # Try to load the library from these paths, in order:
   PROFILER_PATHS=(
     # use the shared loader if it's present (it was removed from the dotnet
-    # layer, this keeps forwards compatibility if it's added back)
+    # layer, this lines keep forwards compatibility if it's added back)
     "/opt/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
     "/opt/datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
     # if shared loader is not found,


### PR DESCRIPTION
This PR updates the paths used in the `datadog_wrapper` script to discover the .NET tracer's libraries.

Try these paths, in order:
- the shared loader
- the tracer stand-alone library
- an older path for backwards compat with very old .NET tracer layers