### PR TITLE
Switch serverless-init deployments to use GHCR instead of Dockerhub

### DIFF
--- a/.github/workflows/release-serverless-init.yml
+++ b/.github/workflows/release-serverless-init.yml
@@ -51,22 +51,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      # - name: Build binaries
-      #   working-directory: ./scripts
-      #   run: ./build_serverless_init.sh
-      #   env:
-      #     AGENT_PATH: datadog-agent
-      #     VERSION: ${{ github.event.inputs.tag }}
-      #     SERVERLESS_INIT: true
-      #     AGENT_VERSION: ${{ github.event.inputs.agentVersion }}
+      - name: Build binaries
+        working-directory: ./scripts
+        run: ./build_serverless_init.sh
+        env:
+          AGENT_PATH: datadog-agent
+          VERSION: ${{ github.event.inputs.tag }}
+          SERVERLESS_INIT: true
+          AGENT_VERSION: ${{ github.event.inputs.agentVersion }}
 
       - name: Set up build directory and copy binaries
         run: |
           mkdir ./scripts/bin
-          mkdir -p .layers/datadog_extension-amd64/extensions/
-          mkdir -p .layers/datadog_extension-amd64-alpine/extensions/
-          echo "test file" > .layers/datadog_extension-amd64/extensions/datadog-agent
-          echo "test file" > .layers/datadog_extension-amd64-alpine/extensions/datadog-agent
           cp .layers/datadog_extension-amd64/extensions/datadog-agent ./scripts/bin/datadog-agent
           cp .layers/datadog_extension-amd64-alpine/extensions/datadog-agent ./scripts/bin/datadog-agent-alpine
 

--- a/.github/workflows/release-serverless-init.yml
+++ b/.github/workflows/release-serverless-init.yml
@@ -98,19 +98,19 @@ jobs:
       - name: Build and push latest
         id: docker_build_latest
         uses: docker/build-push-action@v4
-        if: ${{ env.REGISTRY }}/${{ github.event.inputs.latestTag == 'yes' }}
+        if: ${{ github.event.inputs.latestTag == 'yes' }}
         with:
           context: ./scripts
           file: ./scripts/Dockerfile.serverless-init.build
           push: true
-          tags: ${{ env.IMAGE_NAME }}:latest
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
 
       - name: Build and push latest alpine
         id: docker_build_alpine_latest
         uses: docker/build-push-action@v4
-        if: ${{ env.REGISTRY }}/${{ github.event.inputs.latestTag == 'yes' }}
+        if: ${{ github.event.inputs.latestTag == 'yes' }}
         with:
           context: ./scripts
           file: ./scripts/Dockerfile.serverless-init.alpine.build
           push: true
-          tags: ${{ env.IMAGE_NAME }}:latest-alpine
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-alpine

--- a/.github/workflows/release-serverless-init.yml
+++ b/.github/workflows/release-serverless-init.yml
@@ -79,26 +79,26 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: ./scripts
           file: ./scripts/Dockerfile.serverless-init.build
           push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ github.event.inputs.tag }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.tag }}
 
       - name: Build and push (alpine)
         id: docker_build_alpine
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: ./scripts
           file: ./scripts/Dockerfile.serverless-init.alpine.build
           push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ github.event.inputs.tag }}-alpine
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.tag }}-alpine
 
       - name: Build and push latest
         id: docker_build_latest
-        uses: docker/build-push-action@v2
-        if: ${{ github.event.inputs.latestTag == 'yes' }}
+        uses: docker/build-push-action@v4
+        if: ${{ env.REGISTRY }}/${{ github.event.inputs.latestTag == 'yes' }}
         with:
           context: ./scripts
           file: ./scripts/Dockerfile.serverless-init.build
@@ -107,8 +107,8 @@ jobs:
 
       - name: Build and push latest alpine
         id: docker_build_alpine_latest
-        uses: docker/build-push-action@v2
-        if: ${{ github.event.inputs.latestTag == 'yes' }}
+        uses: docker/build-push-action@v4
+        if: ${{ env.REGISTRY }}/${{ github.event.inputs.latestTag == 'yes' }}
         with:
           context: ./scripts
           file: ./scripts/Dockerfile.serverless-init.alpine.build

--- a/.github/workflows/release-serverless-init.yml
+++ b/.github/workflows/release-serverless-init.yml
@@ -29,7 +29,8 @@ on:
         default: "main"
 
 env:
-  IMAGE_NAME: datadog/serverless-init
+  IMAGE_NAME: datadog/datadog-lambda-extension/serverless-init
+  REGISTRY: ghcr.io
 
 jobs:
   release-serverless-init:
@@ -41,7 +42,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: DataDog/datadog-agent
-          ref: refs/heads/${{ inputs.agentBranch }}
+          ref: refs/heads/${{ github.event.inputs.agentBranch }}
           path: datadog-agent
 
       - name: Set up QEMU
@@ -50,26 +51,31 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build binaries
-        working-directory: ./scripts
-        run: ./build_serverless_init.sh
-        env:
-          AGENT_PATH: datadog-agent
-          VERSION: ${{ inputs.tag }}
-          SERVERLESS_INIT: true
-          AGENT_VERSION: ${{ inputs.agentVersion }}
+      # - name: Build binaries
+      #   working-directory: ./scripts
+      #   run: ./build_serverless_init.sh
+      #   env:
+      #     AGENT_PATH: datadog-agent
+      #     VERSION: ${{ github.event.inputs.tag }}
+      #     SERVERLESS_INIT: true
+      #     AGENT_VERSION: ${{ github.event.inputs.agentVersion }}
 
       - name: Set up build directory and copy binaries
         run: |
           mkdir ./scripts/bin
+          mkdir -p .layers/datadog_extension-amd64/extensions/
+          mkdir -p .layers/datadog_extension-amd64-alpine/extensions/
+          echo "test file" > .layers/datadog_extension-amd64/extensions/datadog-agent
+          echo "test file" > .layers/datadog_extension-amd64-alpine/extensions/datadog-agent
           cp .layers/datadog_extension-amd64/extensions/datadog-agent ./scripts/bin/datadog-agent
           cp .layers/datadog_extension-amd64-alpine/extensions/datadog-agent ./scripts/bin/datadog-agent-alpine
 
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         id: docker_build
@@ -78,7 +84,7 @@ jobs:
           context: ./scripts
           file: ./scripts/Dockerfile.serverless-init.build
           push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ inputs.tag }}
+          tags: ${{ env.IMAGE_NAME }}:${{ github.event.inputs.tag }}
 
       - name: Build and push (alpine)
         id: docker_build_alpine
@@ -87,12 +93,12 @@ jobs:
           context: ./scripts
           file: ./scripts/Dockerfile.serverless-init.alpine.build
           push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ inputs.tag }}-alpine
+          tags: ${{ env.IMAGE_NAME }}:${{ github.event.inputs.tag }}-alpine
 
       - name: Build and push latest
         id: docker_build_latest
         uses: docker/build-push-action@v2
-        if: ${{ inputs.latestTag == 'yes' }}
+        if: ${{ github.event.inputs.latestTag == 'yes' }}
         with:
           context: ./scripts
           file: ./scripts/Dockerfile.serverless-init.build
@@ -102,7 +108,7 @@ jobs:
       - name: Build and push latest alpine
         id: docker_build_alpine_latest
         uses: docker/build-push-action@v2
-        if: ${{ inputs.latestTag == 'yes' }}
+        if: ${{ github.event.inputs.latestTag == 'yes' }}
         with:
           context: ./scripts
           file: ./scripts/Dockerfile.serverless-init.alpine.build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -132,3 +132,17 @@ multi_region:
     include:
       - artifact: trigger_region.yaml
         job: prepare_multi_region
+
+deploy_serverless_init_to_docker_registries:
+  stage: deploy
+  when: manual
+  trigger:
+    project: DataDog/public-images
+    branch: main
+    strategy: depend
+  variables:
+    IMG_SOURCES: ghcr.io/datadog/datadog-lambda-extension/serverless-init:$IMAGE_TAG
+    IMG_DESTINATIONS: serverless-init:$IMAGE_TAG
+    IMG_SIGNING: "false"
+    RETRY_COUNT: 5
+    RETRY_DELAY: 300

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -132,17 +132,3 @@ multi_region:
     include:
       - artifact: trigger_region.yaml
         job: prepare_multi_region
-
-deploy_serverless_init_to_docker_registries:
-  stage: deploy
-  when: manual
-  trigger:
-    project: DataDog/public-images
-    branch: main
-    strategy: depend
-  variables:
-    IMG_SOURCES: ghcr.io/datadog/datadog-lambda-extension/serverless-init:$IMAGE_TAG
-    IMG_DESTINATIONS: serverless-init:$IMAGE_TAG
-    IMG_SIGNING: "false"
-    RETRY_COUNT: 5
-    RETRY_DELAY: 300


### PR DESCRIPTION
It's easier to use GHCR as we don't need to manage credentials, and we're replicating to Dockerhub, ECR, and GCR anyways. This makes GHCR the source of truth, and provides clear separation as to which registry is responsible for what.