### PR TITLE
Add architecture to deploy script

### DIFF
--- a/.github/workflows/release-serverless-init.yml
+++ b/.github/workflows/release-serverless-init.yml
@@ -31,6 +31,7 @@ on:
 env:
   IMAGE_NAME: datadog/datadog-lambda-extension/serverless-init
   REGISTRY: ghcr.io
+  ARCHITECTURE: amd64
 
 jobs:
   release-serverless-init:


### PR DESCRIPTION
The build script takes this as an argument, which we weren't setting.