### PR TITLE
[SLES-1145] Check if the Java trace agent jar is present

### DIFF
--- a/scripts/datadog_wrapper
+++ b/scripts/datadog_wrapper
@@ -68,7 +68,8 @@ then
 fi
 
 # if it is java
-if [[ "$AWS_EXECUTION_ENV" == *"java"* ]]
+DD_Agent_Jar=/opt/java/lib/dd-java-agent.jar
+if [[ "$AWS_EXECUTION_ENV" == *"java"* ]] || [ -f "$DD_Agent_Jar" ]
 then
   if [ "$DD_LOG_LEVEL" == "debug" ]
   then
@@ -78,7 +79,6 @@ then
   export DD_RUNTIME_METRICS_ENABLED="false"
   export DD_REMOTE_CONFIG_ENABLED="false"
 
-  DD_Agent_Jar=/opt/java/lib/dd-java-agent.jar
   if [ -f "$DD_Agent_Jar" ]
   then
     # Removes the -XX:-TieredCompilation flag from the java command passed 

--- a/scripts/datadog_wrapper
+++ b/scripts/datadog_wrapper
@@ -69,7 +69,7 @@ fi
 
 # if it is java
 DD_Agent_Jar=/opt/java/lib/dd-java-agent.jar
-if [[ "$AWS_EXECUTION_ENV" == *"java"* ]] || [ -f "$DD_Agent_Jar" ]
+if [[ "$AWS_EXECUTION_ENV" == *"java"* ]] && [ -f "$DD_Agent_Jar" ]
 then
   if [ "$DD_LOG_LEVEL" == "debug" ]
   then
@@ -79,24 +79,18 @@ then
   export DD_RUNTIME_METRICS_ENABLED="false"
   export DD_REMOTE_CONFIG_ENABLED="false"
 
-  if [ -f "$DD_Agent_Jar" ]
-  then
-    # Removes the -XX:-TieredCompilation flag from the java command passed 
-    # through from the Lambda runtime. Allows the JVM to use the C1 compiler
-    # and Interpreter, which is much faster on cold start and 
-    # uses less memory.
-    START_COMMAND=${args[0]}
-    REMAINDER_ARGS=("${args[@]:1}")
-    for index in "${!REMAINDER_ARGS[@]}" ; do
-      [[ ${REMAINDER_ARGS[$index]} == "-XX:-TieredCompilation" ]] && unset -v 'REMAINDER_ARGS[$index]' ;
-    done
-    REMAINDER_ARGS="${REMAINDER_ARGS[@]}"
-    # -XX:TieredStopAtLevel=1 tells the compiler to stop at the C1 compiler
-    args=($START_COMMAND -javaagent:$DD_Agent_Jar -XX:TieredStopAtLevel=1 ${REMAINDER_ARGS[@]})
-
-  else
-    echo "File $DD_Agent_Jar does not exist!"
-  fi
+  # Removes the -XX:-TieredCompilation flag from the java command passed 
+  # through from the Lambda runtime. Allows the JVM to use the C1 compiler
+  # and Interpreter, which is much faster on cold start and 
+  # uses less memory.
+  START_COMMAND=${args[0]}
+  REMAINDER_ARGS=("${args[@]:1}")
+  for index in "${!REMAINDER_ARGS[@]}" ; do
+    [[ ${REMAINDER_ARGS[$index]} == "-XX:-TieredCompilation" ]] && unset -v 'REMAINDER_ARGS[$index]' ;
+  done
+  REMAINDER_ARGS="${REMAINDER_ARGS[@]}"
+  # -XX:TieredStopAtLevel=1 tells the compiler to stop at the C1 compiler
+  args=($START_COMMAND -javaagent:$DD_Agent_Jar -XX:TieredStopAtLevel=1 ${REMAINDER_ARGS[@]})
 fi
 
 exec "${args[@]}"


### PR DESCRIPTION
Adds a check for the DD trace agent .jar prior to disabling runtime metrics. More specific to those instrumenting their container image Lambda functions, since the `AWS_EXECUTION_ENV` environment variable is not immediately identifiable as Java.

We had a support case where this specific issue came up, causing runtime metrics to be enabled and thus timing out the DD Extension's/agent's metric forwarder.