### PR TITLE
scripts/datadog_wrapper: set up the runtime api proxy with appsec

### DIFF
--- a/scripts/datadog_wrapper
+++ b/scripts/datadog_wrapper
@@ -3,20 +3,22 @@ args=("$@")
 
 # lowercase DD_LOG_LEVEL
 DD_LOG_LEVEL=$(echo "$DD_LOG_LEVEL" | tr '[:upper:]' '[:lower:]')
+DD_SERVERLESS_APPSEC_ENABLED=$(echo "$DD_SERVERLESS_APPSEC_ENABLED" | tr '[:upper:]' '[:lower:]')
 
-if [ "$DD_EXPERIMENTAL_ENABLE_PROXY" == "true" ]
+if [ "$DD_EXPERIMENTAL_ENABLE_PROXY" == "true" ] || [[ "$DD_SERVERLESS_APPSEC_ENABLED" =~ ^(1|t|true)$ ]]
 then
   if [ "$DD_LOG_LEVEL" == "debug" ]
   then
-    echo "[bootstrap] DD_EXPERIMENTAL_ENABLE_PROXY is true"
+    echo "[bootstrap] runtime api proxy mode"
     echo "[bootstrap] original AWS_LAMBDA_RUNTIME_API value is $AWS_LAMBDA_RUNTIME_API"
   fi
 
+  # Replace the Runtime API address with the proxy address of the extension
   export AWS_LAMBDA_RUNTIME_API="127.0.0.1:9000"
 
   if [ "$DD_LOG_LEVEL" == "debug" ]
   then
-    echo "[bootstrap] rerouting AWS_LAMBDA_RUNTIME_API to $AWS_LAMBDA_RUNTIME_API"
+    echo "[bootstrap] rerouting AWS_LAMBDA_RUNTIME_API to the Datadog extension at $AWS_LAMBDA_RUNTIME_API"
   fi
 fi
 


### PR DESCRIPTION
Setup the runtime api proxy when AppSec is enabled to comply with https://github.com/DataDog/datadog-agent/pull/18324 where AppSec always runs as a runtime api proxy.