### PR TITLE
Change README testing section to use correct verbage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ If you find an issue with this package and have a fix, please feel free to open 
 
 ## Testing
 
-To test a change to the Datadog Lambda Extension in Google Cloud Run:
+To test a change to the Datadog Serverless-Init in Google Cloud Run:
 
 1. Clone this repo and [the Datadog Agent repo](https://github.com/DataDog/datadog-agent) into the same parent directory.
-2. Run `VERSION=0 SERVERLESS_INIT=true ./scripts/build_binary_and_layer_dockerized.sh` in this repo to build the extension.
+2. Run `VERSION=0 SERVERLESS_INIT=true ./scripts/build_binary_and_layer_dockerized.sh` in this repo to build the serverless-init binary.
 3. Create a "Hello World" serverless application [as described here](https://cloud.google.com/run/docs/quickstarts/build-and-deploy/go).
-4. Follow [the public instructions](https://docs.datadoghq.com/serverless/google_cloud_run) to add the Lambda Extension to your serverless application.
+4. Follow [the public instructions](https://docs.datadoghq.com/serverless/google_cloud_run) to add the Serverless-Init to your serverless application.
 5. Copy the binary file that you built to the same location as your Dockerfile:
 ```
 cp datadog-lambda-extension/.layers/datadog_extension-amd64/extensions/datadog-agent ~/hello-world-app/datadog-init
@@ -60,7 +60,7 @@ with
 COPY datadog-init /app/datadog-init
 ```
 
-Deploy your serverless application, and it will run with a version of the Lambda Extension that includes your changes to the code.
+Deploy your serverless application, and it will run with a version of the Serverless-Init that includes your changes to the code.
 
 ## Community
 


### PR DESCRIPTION
This PR changes references to "Lambda Extension" in the Testing section of the README to "Serverless-Init". This is because the testing described is done on Google Cloud Run, which uses the Serverless-Init binary and not the Lambda Extension.