### PR TITLE
scripts/datadog_wrapper: appsec enables instrumentation telemetry

### DIFF
--- a/scripts/datadog_wrapper
+++ b/scripts/datadog_wrapper
@@ -22,8 +22,8 @@ then
   fi
 
   # Enable library's instrumentation telemetry needed for ASM OSS VM
-  export DD_INSTRUMENTATION_TELEMETRY_ENABLED="true" # the standard env var to enable telemetry
-  export DD_TRACE_TELEMETRY_ENABLED="true" # but dd-trace-js uses another one
+  export DD_INSTRUMENTATION_TELEMETRY_ENABLED="${DD_INSTRUMENTATION_TELEMETRY_ENABLED:-true}" # the standard env var to enable telemetry
+  export DD_TRACE_TELEMETRY_ENABLED="${DD_TRACE_TELEMETRY_ENABLED:-true}" # but dd-trace-js uses another one
 fi
 
 if [ "$DD_LOG_LEVEL" == "debug" ]

--- a/scripts/datadog_wrapper
+++ b/scripts/datadog_wrapper
@@ -22,7 +22,8 @@ then
   fi
 
   # Enable library's instrumentation telemetry needed for ASM OSS VM
-  export DD_INSTRUMENTATION_TELEMETRY_ENABLED="true"
+  export DD_INSTRUMENTATION_TELEMETRY_ENABLED="true" # the standard env var to enable telemetry
+  export DD_TRACE_TELEMETRY_ENABLED="true" # but dd-trace-js uses another one
 fi
 
 if [ "$DD_LOG_LEVEL" == "debug" ]

--- a/scripts/datadog_wrapper
+++ b/scripts/datadog_wrapper
@@ -20,6 +20,9 @@ then
   then
     echo "[bootstrap] rerouting AWS_LAMBDA_RUNTIME_API to the Datadog extension at $AWS_LAMBDA_RUNTIME_API"
   fi
+
+  # Enable library's instrumentation telemetry needed for ASM OSS VM
+  export DD_INSTRUMENTATION_TELEMETRY_ENABLED="true"
 fi
 
 if [ "$DD_LOG_LEVEL" == "debug" ]


### PR DESCRIPTION
Automatically enable `DD_INSTRUMENTATION_TELEMETRY_ENABLED` with AppSec so that Open-Source Software Vuln Scanning can work, which is based on telemetry data sent by the tracing libraries.

JIRA: APPSEC-11651