### PR TITLE
Build binaries with go 1.20.11.

### DIFF
--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -15,8 +15,8 @@ RUN arch="$(uname -m)"; \
     if [ "${arch}" = 'x86_64' ]; then \
     arch='amd64'; \
     fi; \
-    wget -O go1.20.6.linux-${arch}.tar.gz https://go.dev/dl/go1.20.6.linux-${arch}.tar.gz; \
-    tar -C /usr/local -xzf go1.20.6.linux-${arch}.tar.gz
+    wget -O go1.20.11.linux-${arch}.tar.gz https://go.dev/dl/go1.20.11.linux-${arch}.tar.gz; \
+    tar -C /usr/local -xzf go1.20.11.linux-${arch}.tar.gz
 
 # cache dependencies
 COPY ./scripts/.cache/go.mod /tmp/dd/datadog-agent

--- a/scripts_v2/Dockerfile.build
+++ b/scripts_v2/Dockerfile.build
@@ -14,8 +14,8 @@ RUN arch="$(uname -m)"; \
     if [ "${arch}" = 'x86_64' ]; then \
     arch='amd64'; \
     fi; \
-    wget -O go1.20.6.linux-${arch}.tar.gz https://go.dev/dl/go1.20.6.linux-${arch}.tar.gz; \
-    tar -C /usr/local -xzf go1.20.6.linux-${arch}.tar.gz
+    wget -O go1.20.11.linux-${arch}.tar.gz https://go.dev/dl/go1.20.11.linux-${arch}.tar.gz; \
+    tar -C /usr/local -xzf go1.20.11.linux-${arch}.tar.gz
 
 RUN mkdir -p /tmp/dd
 


### PR DESCRIPTION
## What does this PR do?

Updates the version of go used to build the extension.

## Motivation

Fixes a security vulnerability in go1.20.6, which is what we were previously using to build the extension. See https://nvd.nist.gov/vuln/detail/CVE-2023-39323.

## Testing

To confirm the vuln is fixed, build the extension locally, then run:

```bash
$ grype .layers/datadog_extension-amd64.zip
```