### PR TITLE
Build extension with go 1.21.5.

### DIFF
--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -15,8 +15,8 @@ RUN arch="$(uname -m)"; \
     if [ "${arch}" = 'x86_64' ]; then \
     arch='amd64'; \
     fi; \
-    wget -O go1.20.11.linux-${arch}.tar.gz https://go.dev/dl/go1.20.11.linux-${arch}.tar.gz; \
-    tar -C /usr/local -xzf go1.20.11.linux-${arch}.tar.gz
+    wget -O go1.21.5.linux-${arch}.tar.gz https://go.dev/dl/go1.21.5.linux-${arch}.tar.gz; \
+    tar -C /usr/local -xzf go1.21.5.linux-${arch}.tar.gz
 
 # cache dependencies
 COPY ./scripts/.cache/go.mod /tmp/dd/datadog-agent

--- a/scripts_v2/Dockerfile.build
+++ b/scripts_v2/Dockerfile.build
@@ -14,8 +14,8 @@ RUN arch="$(uname -m)"; \
     if [ "${arch}" = 'x86_64' ]; then \
     arch='amd64'; \
     fi; \
-    wget -O go1.20.11.linux-${arch}.tar.gz https://go.dev/dl/go1.20.11.linux-${arch}.tar.gz; \
-    tar -C /usr/local -xzf go1.20.11.linux-${arch}.tar.gz
+    wget -O go1.21.5.linux-${arch}.tar.gz https://go.dev/dl/go1.21.5.linux-${arch}.tar.gz; \
+    tar -C /usr/local -xzf go1.21.5.linux-${arch}.tar.gz
 
 RUN mkdir -p /tmp/dd
 


### PR DESCRIPTION
Build extension and serverless-init with go 1.21.5. This upgrade was requested of us in an email by January 31.