### PR TITLE
Update Go version to 1.21.7

### DIFF
--- a/scripts/Dockerfile.alpine.build
+++ b/scripts/Dockerfile.alpine.build
@@ -7,7 +7,7 @@ ARG CMD_PATH
 ARG BUILD_TAGS
 
 RUN apk add --no-cache git make musl-dev gcc
-COPY --from=golang:1.20-alpine /usr/local/go/ /usr/lib/go
+COPY --from=golang:1.21-alpine /usr/local/go/ /usr/lib/go
 
 ENV GOROOT /usr/lib/go
 ENV GOPATH /go

--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -15,8 +15,8 @@ RUN arch="$(uname -m)"; \
     if [ "${arch}" = 'x86_64' ]; then \
     arch='amd64'; \
     fi; \
-    wget -O go1.21.5.linux-${arch}.tar.gz https://go.dev/dl/go1.21.5.linux-${arch}.tar.gz; \
-    tar -C /usr/local -xzf go1.21.5.linux-${arch}.tar.gz
+    wget -O go1.21.7.linux-${arch}.tar.gz https://go.dev/dl/go1.21.7.linux-${arch}.tar.gz; \
+    tar -C /usr/local -xzf go1.21.7.linux-${arch}.tar.gz
 
 # cache dependencies
 COPY ./scripts/.cache/go.mod /tmp/dd/datadog-agent

--- a/scripts/Dockerfile.race.build
+++ b/scripts/Dockerfile.race.build
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:experimental
 
-FROM golang:1.20 as builder
+FROM golang:1.21 as builder
 ARG EXTENSION_VERSION
 ARG ENABLE_RACE_DETECTION
 ARG AGENT_VERSION

--- a/scripts_v2/Dockerfile.build
+++ b/scripts_v2/Dockerfile.build
@@ -14,8 +14,8 @@ RUN arch="$(uname -m)"; \
     if [ "${arch}" = 'x86_64' ]; then \
     arch='amd64'; \
     fi; \
-    wget -O go1.21.5.linux-${arch}.tar.gz https://go.dev/dl/go1.21.5.linux-${arch}.tar.gz; \
-    tar -C /usr/local -xzf go1.21.5.linux-${arch}.tar.gz
+    wget -O go1.21.7.linux-${arch}.tar.gz https://go.dev/dl/go1.21.7.linux-${arch}.tar.gz; \
+    tar -C /usr/local -xzf go1.21.7.linux-${arch}.tar.gz
 
 RUN mkdir -p /tmp/dd
 


### PR DESCRIPTION
Update the Go version to 1.21.7 (or just 1.21 when only the minor is needed) in some Dockerfiles.
It is blocking https://github.com/DataDog/datadog-agent/pull/22908.