### PR TITLE
[ASCII-1171] Add some scripts to automatically deploy and benchmark the extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,14 @@
 .DS_Store
 .layers
 .idea
+.serverless
+response.x
 extensions
 existing_layers
 scripts/.cache
 scripts/.src
+reports.log
+__pycache__
 local_tests/logs.txt
 local_tests/META_INF
 local_tests/python

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# requires FUNCTION_NAME, REGION, and AWS_PROFILE to be set
+set -eu pipefail
+
+INVOKES="${INVOKES:-10}"
+SLEEP_TIME="${SLEEP_TIME:-1}"
+
+RESPONSE_FILE="response.x"
+
+function update_timeout {
+    aws-vault exec "$AWS_PROFILE" -- aws lambda update-function-configuration --region "$REGION" --function-name "$FUNCTION_NAME" --timeout "$1" > /dev/null 2>&1
+}
+
+function invoke_and_store_report {
+    aws-vault exec "$AWS_PROFILE" -- aws lambda invoke --region "$REGION" --function-name "$FUNCTION_NAME" "$RESPONSE_FILE" --log-type Tail | jq -r '.LogResult' | base64 -d | grep -e '^REPORT ' | tee -a reports.log
+}
+
+true > reports.log
+
+for i in $(seq "$INVOKES"); do
+    update_timeout $((60 + i % 2))
+    echo -n "$i: "
+    invoke_and_store_report
+
+    sleep "$SLEEP_TIME"
+done
+
+echo
+python report_stats.py reports.log

--- a/scripts/build_publish_deploy_bench.sh
+++ b/scripts/build_publish_deploy_bench.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -eu pipefail
+
+export ARCHITECTURE="${ARCHITECTURE:-amd64}"
+export REGION="${REGION:-sa-east-1}"
+export AWS_PROFILE="${AWS_PROFILE:-sso-serverless-sandbox-account-admin}"
+
+# use username to avoid conflicts
+if [ -z "${USER_NAME}" ]; then
+    echo "USER_NAME not set"
+    exit 1
+fi
+
+export DEPLOYMENT_BUCKET="$USER_NAME-s3-sa-east-1" # need to create a bucket
+export SERVICE_NAME="$USER_NAME-test"
+export FUNCTION_NAME="$USER_NAME-test"
+export SUFFIX=$USER_NAME-testing
+export LAYER_NAME="Datadog-Extension-$SUFFIX"
+
+if [ -z "${DD_API_KEY+set}" ]; then
+    echo "DD_API_KEY not set"
+    exit 1
+fi
+
+LATEST_VERSION=$(aws-vault exec $AWS_PROFILE -- aws lambda list-layer-versions --region "$REGION" --layer-name "${LAYER_NAME}" --query 'LayerVersions[0].Version || `0`')
+export VERSION=$(($LATEST_VERSION+1))
+
+export EXTENSION_ARN="arn:aws:lambda:$REGION:425362996713:layer:$LAYER_NAME:$VERSION"
+
+# publish_sandbox.sh also builds the layer
+echo "y" | ./scripts/publish_sandbox.sh
+
+(cd scripts/deploy && aws-vault exec $AWS_PROFILE -- sls deploy)
+
+(cd scripts && ./bench.sh)

--- a/scripts/deploy/index.js
+++ b/scripts/deploy/index.js
@@ -1,0 +1,7 @@
+exports.handler = async () => {
+    const response = {
+        statusCode: 200,
+        body: JSON.stringify('Hello from lambda !'),
+    };
+    return response;
+};

--- a/scripts/deploy/serverless.yml
+++ b/scripts/deploy/serverless.yml
@@ -1,0 +1,28 @@
+service: ${env:SERVICE_NAME}
+provider:
+  name: aws
+  region: sa-east-1
+  deploymentBucket: ${env:DEPLOYMENT_BUCKET}
+  memorySize: 128
+  timeout: 30
+  environment:
+    DD_SERVICE: ${env:SERVICE_NAME}
+    DD_CAPTURE_LAMBDA_PAYLOAD: "true"
+    DD_LAMBDA_HANDLER: index.handler
+    DD_MERGE_XRAY_TRACES: "false"
+    DD_SERVERLESS_APPSEC_ENABLED: "false"
+    DD_TRACE_ENABLED: "true"
+    DD_LOG_LEVEL: "debug"
+    DD_API_KEY: ${env:DD_API_KEY}
+    # GODEBUG: inittrace=1
+
+functions:
+  pierre-bench:
+    runtime: nodejs20.x
+    name: ${env:FUNCTION_NAME}
+    # in order to disable the tracer, set handler to index.handler, and comment the tracer layer line
+    handler: /opt/nodejs/node_modules/datadog-lambda-js/handler.handler
+    # handler: index.handler
+    layers:
+      - arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node20-x:104
+      - ${env:EXTENSION_ARN}

--- a/scripts/report_stats.py
+++ b/scripts/report_stats.py
@@ -1,0 +1,69 @@
+import re
+import statistics
+import sys
+from typing import Iterable, Optional, Tuple
+
+"""
+This file computes statistics from the logs of the Lambda function.
+It parses the REPORT lines to extract all available information.
+"""
+
+Report = Tuple[str, float, int, int, int, Optional[float]]
+REPORT_RE = re.compile(
+    r"^REPORT"
+    r"\s+RequestId: (?P<request_id>.+)"
+    r"\s+Duration: (?P<duration>.+) ms"
+    r"\s+Billed Duration: (?P<billed_duration>.+) ms"
+    r"\s+Memory Size: (?P<memory_size>.+) MB"
+    r"\s+Max Memory Used: (?P<max_memory_used>.+) MB"
+    r"(\s+Init Duration: (?P<init_duration>.+) ms)?"
+    r"\s*$"
+)
+
+
+def parse_reports(log_lines: Iterable[str]) -> Iterable[Report]:
+    for log_line in log_lines:
+        res = REPORT_RE.match(log_line)
+        if res is None:
+            continue
+
+        init_duration = res.group("init_duration")
+        if init_duration is not None:
+            init_duration = float(init_duration)
+
+        yield (
+            res.group("request_id"),
+            float(res.group("duration")),
+            int(res.group("billed_duration")),
+            int(res.group("memory_size")),
+            int(res.group("max_memory_used")),
+            init_duration,
+        )
+
+
+def print_stats(values, name, unit):
+    mean = sum(values) / len(values)
+    median = statistics.median(values)
+    print(f"{name}: min={min(values)}{unit}, max={max(values)}{unit}, avg={mean}{unit}, median={median}{unit}")
+
+
+if __name__ == "__main__":
+    with open(sys.argv[1], "r") as f:
+        log_reports = f.readlines()
+
+    durations = []
+    memories = []
+    init_durations = []
+
+    for _, duration, _, _, mem, init in parse_reports(log_reports):
+        durations.append(duration)
+        memories.append(mem)
+
+        if init is not None:
+            init_durations.append(init)
+        else:
+            print("REPORT did not contain init duration", file=sys.stderr)
+
+    print_stats(memories, "Memory", " MB")
+    print_stats(durations, "Duration", " ms")
+    print_stats(init_durations, "Init Duration", " ms")


### PR DESCRIPTION
Add a single script which:
- builds
- uploads the layer
- deploy a function with that layer
- invokes it N times
- computes and displays statistics over the init duration (triggering cold starts at each invoke)

It reuses existing scripts, but I had to add the steps to deploy the function, and parse logs to compute statistics, which weren't implemented in existing scripts.