### PR TITLE
feat: Set DD_APPSEC_ENABLED to false by default to avoid errors where appsec detects remoteconfig is not available

### DIFF
--- a/scripts/datadog_wrapper
+++ b/scripts/datadog_wrapper
@@ -86,6 +86,7 @@ then
   export DD_JMXFETCH_ENABLED="false"
   export DD_RUNTIME_METRICS_ENABLED="false"
   export DD_REMOTE_CONFIG_ENABLED="false"
+  export DD_APPSEC_ENABLED="false"
 
   # Removes the -XX:-TieredCompilation flag from the java command passed 
   # through from the Lambda runtime. Allows the JVM to use the C1 compiler


### PR DESCRIPTION
Fixes https://github.com/DataDog/serverless-plugin-datadog/issues/477

For Java, when RemoteConfig is disabled but AppSec is enabled, it logs an error on startup. This setting should save a few CPU cycles while also suppressing the log.
