### PR TITLE
[Bottlecap] Support Apple Silicon development

### DIFF
--- a/bottlecap/README.md
+++ b/bottlecap/README.md
@@ -1,5 +1,14 @@
 # Bottlecap
 
+## Developing on Apple Silicon
+One time setup:
+1. `rustup target add aarch64-unknown-linux-gnu`
+2. `brew install zig`
+3. `cargo install cargo-zigbuild`
+
+Then: `./runBottlecap.sh`
+
+## Developing using Codespaces
 Step 1: Create a codespace (code > codespaces > create codespace on main) 
 
 ![img](./codespace.png)

--- a/runBottlecap.sh
+++ b/runBottlecap.sh
@@ -6,8 +6,10 @@ cd bottlecap
 # build bottlecap in debug mode
 if (echo $arch | grep -q "Darwin"); then
     PATH=/usr/bin:$PATH cargo zigbuild --target=aarch64-unknown-linux-gnu
+    build_path=bottlecap/target/aarch64-unknown-linux-gnu/debug/bottlecap
 else
     cargo build
+    build_path=bottlecap/target/debug/bottlecap
 fi
 cd ..
 
@@ -18,7 +20,7 @@ echo -e 'export const handler = async () => {\n\tconsole.log("Hello world!");\n}
 docker cp "/tmp/index.mjs" "${docker_name}:/var/task/index.mjs"
 docker start "${docker_name}"           
 docker exec "${docker_name}" mkdir -p /opt/extensions
-docker cp bottlecap/target/aarch64-unknown-linux-gnu/debug/bottlecap "${docker_name}:/opt/extensions/bottlecap"
+docker cp "${build_path}" "${docker_name}:/opt/extensions/bottlecap"
 curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -d '{}'
 docker logs "${docker_name}"                                             
 docker stop "${docker_name}" 

--- a/runBottlecap.sh
+++ b/runBottlecap.sh
@@ -1,6 +1,14 @@
-# build bottlecap in debug mode
+#!/bin/bash
+
+set -e
+arch=$(uname -a)
 cd bottlecap 
-cargo build
+# build bottlecap in debug mode
+if (echo $arch | grep -q "Darwin"); then
+    PATH=/usr/bin:$PATH cargo zigbuild --target=aarch64-unknown-linux-gnu
+else
+    cargo build
+fi
 cd ..
 
 # run a hello world function in Lambda RIE (https://github.com/aws/aws-lambda-runtime-interface-emulator)
@@ -10,7 +18,7 @@ echo -e 'export const handler = async () => {\n\tconsole.log("Hello world!");\n}
 docker cp "/tmp/index.mjs" "${docker_name}:/var/task/index.mjs"
 docker start "${docker_name}"           
 docker exec "${docker_name}" mkdir -p /opt/extensions
-docker cp bottlecap/target/debug/bottlecap "${docker_name}:/opt/extensions/bottlecap"
+docker cp bottlecap/target/aarch64-unknown-linux-gnu/debug/bottlecap "${docker_name}:/opt/extensions/bottlecap"
 curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -d '{}'
 docker logs "${docker_name}"                                             
 docker stop "${docker_name}" 


### PR DESCRIPTION
Supports apple m* silicon development by cross compiling to aarch64 linux and running in docker.

Still supports github codespaces:
<img width="2153" alt="image" src="https://github.com/DataDog/datadog-lambda-extension/assets/1598537/27db8f38-3571-4edb-822c-2a47185f9ef4">
