### PR TITLE
Aj/metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ local_tests/java/.gradle/
 local_tests/serverless-init/datadog-agent
 local_tests/serverless-init/logs.txt
 bottlecap/target
+bottlecap/proptest-regressions

--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -3,19 +3,17 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.21.0"
+name = "ahash"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
- "gimli",
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
 ]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
@@ -25,6 +23,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "atomic"
@@ -40,21 +44,6 @@ name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
-
-[[package]]
-name = "backtrace"
-version = "0.3.71"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "base64"
@@ -79,12 +68,16 @@ name = "bottlecap"
 version = "0.1.0"
 dependencies = [
  "figment",
+ "fnv",
+ "hashbrown",
  "log",
  "serde",
- "tokio",
+ "serde_json",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
  "ureq",
+ "ustr",
 ]
 
 [[package]]
@@ -94,10 +87,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
 
 [[package]]
-name = "cc"
-version = "1.0.90"
+name = "byteorder"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cc"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 
 [[package]]
 name = "cfg-if"
@@ -144,6 +143,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,16 +158,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.28.1"
+name = "getrandom"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "idna"
@@ -244,24 +258,6 @@ name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "object"
-version = "0.32.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "once_cell"
@@ -412,10 +408,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.23"
+name = "ring"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys",
+]
 
 [[package]]
 name = "rustix"
@@ -428,6 +433,37 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3bce581c0dd41bce533ce695a1437fa16a7ab5ac3ccfa99fe1a620a7885eabf"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -464,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",
@@ -502,6 +538,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
 name = "syn"
 version = "2.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +570,26 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -548,16 +616,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "tokio"
-version = "1.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
-dependencies = [
- "backtrace",
- "pin-project-lite",
-]
 
 [[package]]
 name = "tracing"
@@ -644,6 +702,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "ureq"
 version = "2.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,9 +716,13 @@ dependencies = [
  "base64",
  "log",
  "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "url",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -669,6 +737,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ustr"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e904a2279a4a36d2356425bb20be271029cc650c335bc82af8bfae30085a3d0"
+dependencies = [
+ "ahash",
+ "byteorder",
+ "lazy_static",
+ "parking_lot",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,6 +759,21 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "windows-sys"
@@ -808,3 +903,29 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -52,6 +52,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +86,7 @@ dependencies = [
  "fnv",
  "hashbrown",
  "log",
+ "proptest",
  "serde",
  "serde_json",
  "thiserror",
@@ -223,6 +239,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,6 +280,16 @@ name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
+name = "num-traits"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+dependencies = [
+ "autocfg",
+ "libm",
+]
 
 [[package]]
 name = "once_cell"
@@ -324,6 +356,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,12 +384,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.5.0",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax 0.8.3",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -464,6 +567,18 @@ dependencies = [
  "ring",
  "rustls-pki-types",
  "untrusted",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -666,6 +781,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,6 +880,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -8,12 +8,15 @@ edition = "2021"
 [dependencies]
 figment = { version = "0.10.15", features = ["yaml", "env"] }
 log = "0.4.21"
-tokio = "1.37.0"
 serde = { version = "1.0.197", features = ["derive"], default-features = false }
-ureq = { version = "2.9.6", features = ["json"], default-features = false }
-
+ureq = { version = "2.9.6", features = ["json", "tls"], default-features = false }
 tracing = {version = "0.1.40", default-features = false }
 tracing-subscriber = { version = "0.3.18", default-features = false, features = ["fmt", "env-filter", "json"] }
+ustr = "1.0.0"
+thiserror = "1.0.58"
+fnv = "1.0.7"
+hashbrown = "0.14.3"
+serde_json = "1.0.116"
 
 
 [dev-dependencies]

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = "1.0.116"
 
 [dev-dependencies]
 figment = { version = "0.10.15", features = ["yaml", "env", "test"] }
+proptest = "1.4.0"
 
 
 [profile.release]

--- a/bottlecap/src/main.rs
+++ b/bottlecap/src/main.rs
@@ -120,7 +120,7 @@ fn main() -> Result<()> {
         host: DOGSTATSD_HOST.to_string(),
         port: DOGSTATSD_PORT,
     };
-    let dogstats_client =
+    let mut dogstats_client =
         DogStatsD::run(&dogstatsd_config, event_bus.get_sender_copy());
 
     loop {

--- a/bottlecap/src/metrics/aggregator.rs
+++ b/bottlecap/src/metrics/aggregator.rs
@@ -293,6 +293,21 @@ mod tests {
     }
 
     #[test]
+    fn clear() {
+        let mut aggregator = Aggregator::<2>::new().unwrap();
+
+        let metric1 = Metric::parse("test:1|c|k:v").expect("metric parse failed");
+        let metric2 = Metric::parse("foo:1|c|k:v").expect("metric parse failed");
+
+        assert!(aggregator.insert(&metric1).is_ok());
+        assert!(aggregator.insert(&metric2).is_ok());
+
+        assert_eq!(aggregator.len(), 2);
+        aggregator.clear();
+        assert_eq!(aggregator.len(), 0);
+    }
+
+    #[test]
     fn to_series() {
         let mut aggregator = Aggregator::<2>::new().unwrap();
 

--- a/bottlecap/src/metrics/aggregator.rs
+++ b/bottlecap/src/metrics/aggregator.rs
@@ -1,0 +1,315 @@
+//! The aggregation of metrics.
+
+use crate::metrics::metric;
+use crate::metrics::{constants, errors, datadog, metric::{Metric, Type}};
+
+use std::time;
+
+use hashbrown::hash_table;
+use tracing::error;
+use ustr::Ustr;
+
+/// Error for the `aggregate` function
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Metric insertion failed, possibly with recovery
+    #[error(transparent)]
+    Insert(#[from] errors::Insert),
+    /// Creation failed, unable to recover
+    #[error(transparent)]
+    Creation(#[from] errors::Creation),
+    /// IO error
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Entry {
+    id: u64,
+    generation: u16,
+    name: Ustr,
+    tags: Option<Ustr>,
+    kind: metric::Type,
+    value: f64,
+}
+
+impl Entry {
+    /// Return an iterator over key, value pairs
+    fn tag(&self) -> impl Iterator<Item = (Ustr, Ustr)> {
+        self.tags.into_iter().filter_map(|tags| {
+            let mut split = tags.split(',');
+            match (split.next(), split.next()) {
+                (Some(k), Some(v)) => Some((Ustr::from(k), Ustr::from(v))),
+                _ => None, // Skip tags that lack the proper format
+            }
+        })
+    }
+}
+
+impl Entry {
+    fn of_generation(generation: u16, id: u64, metric: &Metric) -> Self {
+        Self {
+            id,
+            generation,
+            value: metric.values().next().unwrap().unwrap(),
+            name: metric.name,
+            tags: metric.tags,
+            kind: metric.kind,
+        }
+    }
+
+    #[inline]
+    fn aged_out(self, generation: u16) -> bool {
+        self.generation.abs_diff(generation) >= 2
+    }
+}
+
+#[derive(Clone)]
+// NOTE by construction we know that intervals and contexts do not explore the
+// full space of usize but the type system limits how we can express this today.
+pub struct Aggregator<const CONTEXTS: usize> {
+    generation: u16,
+    map: hash_table::HashTable<Entry>,
+}
+
+impl<const CONTEXTS: usize> Aggregator<CONTEXTS> {
+    /// Create a new instance of `Aggregator`
+    ///
+    /// # Errors
+    ///
+    /// Will fail at runtime if the type `INTERVALS` and `CONTEXTS` exceed their
+    /// counterparts in `constants`. This would be better as a compile-time
+    /// issue, although leaving this open allows for runtime configuration.
+    #[allow(clippy::cast_precision_loss)]
+    pub fn new() -> Result<Self, errors::Creation> {
+        if CONTEXTS > constants::MAX_CONTEXTS {
+            return Err(errors::Creation::Contexts);
+        }
+
+        Ok(Self {
+            generation: 0,
+            map: hash_table::HashTable::new(),
+        })
+    }
+
+    /// Remove an members of the Aggregator that are outside the generation
+    /// window. (Arbitrarily, 2 generations.) The length of the Aggregator after
+    /// calling this function will be reduced by the value returned.
+    ///
+    /// Returns the number of purged entries.
+    fn purge(&mut self) -> usize {
+        let total_removed = self
+            .map
+            .extract_if(|entry| entry.aged_out(self.generation))
+            .fold(0, |acc, _| acc + 1);
+        self.generation = self.generation.wrapping_add(1);
+        total_removed
+    }
+
+    /// Scan the
+
+    /// Insert a `Metric` into the `Aggregator` at the current interval
+    ///
+    /// # Errors
+    ///
+    /// Function will return overflow error if more than
+    /// `min(constants::MAX_CONTEXTS, CONTEXTS)` is exceeded.
+    pub fn insert(&mut self, metric: &Metric) -> Result<(), errors::Insert> {
+        let id = metric::id(metric.name, metric.tags);
+        let len = self.map.len();
+
+        match self
+            .map
+            .entry(id, |m| m.id == id, |m| crate::metrics::metric::id(m.name, m.tags))
+        {
+            hash_table::Entry::Vacant(entry) => {
+                if len >= CONTEXTS {
+                    return Err(errors::Insert::Overflow);
+                }
+                let ent = Entry::of_generation(self.generation, id, metric);
+                entry.insert(ent);
+            }
+            hash_table::Entry::Occupied(mut entry) => match metric.kind {
+                Type::Count => {
+                    for value in metric.values() {
+                        entry.get_mut().value += value?;
+                    }
+                }
+                Type::Gauge => {
+                    for value in metric.values() {
+                        entry.get_mut().value = value?;
+                    }
+                }
+                Type::Distribution => {
+                    // Todo - grab Toby's implementation of ddsketch
+                }
+            },
+        }
+
+        Ok(())
+    }
+
+    /// Return true if the instance is empty -- has no metrics -- else false.
+    fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    /// Return the number of elements currently maintained in the table.
+    fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    pub fn clear(&mut self) {
+        self.map.clear();
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    pub fn to_series(&self) -> datadog::Series {
+        // TODO it would be really slick to use a bump allocator here since
+        // there's so many tiny allocations
+        let mut series = datadog::Series {
+            series: Vec::with_capacity(1_024),
+        };
+        for entry in &self.map {
+            let mut resources = Vec::with_capacity(constants::MAX_TAGS);
+            for (name, kind) in entry.tag() {
+                let resource = datadog::Resource {
+                    name: name.as_str(),
+                    kind: kind.as_str(),
+                };
+                resources.push(resource);
+            }
+            let kind = match entry.kind {
+                metric::Type::Count => datadog::DdMetricKind::Count,
+                metric::Type::Gauge => datadog::DdMetricKind::Gauge,
+                metric::Type::Distribution => datadog::DdMetricKind::Distribution,
+            };
+            let point = datadog::Point {
+                value: entry.value,
+                timestamp: time::SystemTime::now()
+                    .duration_since(time::UNIX_EPOCH)
+                    .expect("unable to poll clock, unrecoverable")
+                    .as_secs(),
+            };
+
+            let mut final_tags = Vec::new();
+            // TODO
+            // These tags are interned so we don't need to clone them here but we're just doing it
+            // because it's easier than dealing with the lifetimes.
+            if let Some(tags) = entry.tags {
+                final_tags = tags
+                    .split(',')
+                    .map(|tag| tag.to_string())
+                    .collect();
+            }
+            let metric = datadog::Metric {
+                metric: entry.name.as_str(),
+                resources,
+                kind,
+                points: [point; 1],
+                tags: final_tags,
+            };
+            series.series.push(metric);
+        }
+        series
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::metrics::aggregator::{
+        Aggregator,
+        metric::{self, Metric},
+    };
+
+    #[test]
+    fn insertion() {
+        let mut aggregator = Aggregator::<2>::new().unwrap();
+
+        let metric1 = Metric::parse("test:1|c|k:v").expect("metric parse failed");
+        let metric2 = Metric::parse("foo:1|c|k:v").expect("metric parse failed");
+
+        assert!(aggregator.insert(&metric1).is_ok());
+        assert!(aggregator.insert(&metric2).is_ok());
+
+        // Both unique contexts get one slot.
+        assert_eq!(aggregator.len(), 2);
+    }
+
+    #[test]
+    fn overflow() {
+        let mut aggregator = Aggregator::<2>::new().unwrap();
+
+        let metric1 = Metric::parse("test:1|c|k:v").expect("metric parse failed");
+        let metric2 = Metric::parse("foo:1|c|k:v").expect("metric parse failed");
+        let metric3 = Metric::parse("bar:1|c|k:v").expect("metric parse failed");
+
+        let id1 = metric::id(metric1.name, metric1.tags);
+        let id2 = metric::id(metric2.name, metric2.tags);
+        let id3 = metric::id(metric3.name, metric3.tags);
+
+        assert!(id1 != id2);
+        assert!(id1 != id3);
+        assert!(id2 != id3);
+
+        assert!(aggregator.insert(&metric1).is_ok());
+        assert_eq!(aggregator.len(), 1);
+
+        assert!(aggregator.insert(&metric2).is_ok());
+        assert!(aggregator.insert(&metric2).is_ok());
+        assert!(aggregator.insert(&metric2).is_ok());
+        assert_eq!(aggregator.len(), 2);
+
+        assert!(aggregator.insert(&metric3).is_err());
+        assert_eq!(aggregator.len(), 2);
+    }
+
+    #[test]
+    fn purge() {
+        let mut aggregator = Aggregator::<2>::new().unwrap();
+
+        let metric1 = Metric::parse("test:1|c|k:v").expect("metric parse failed");
+        let metric2 = Metric::parse("foo:1|c|k:v").expect("metric parse failed");
+
+        assert!(aggregator.insert(&metric1).is_ok());
+        assert!(aggregator.insert(&metric2).is_ok());
+
+        // No metrics age out after the first purge
+        assert_eq!(aggregator.generation, 0);
+        assert_eq!(aggregator.purge(), 0);
+        assert_eq!(aggregator.len(), 2);
+        // No metrics age out after the second purge
+        assert_eq!(aggregator.generation, 1);
+        assert_eq!(aggregator.purge(), 0);
+        assert_eq!(aggregator.len(), 2);
+        // Two metrics age out after the last purge
+        assert_eq!(aggregator.generation, 2);
+        assert_eq!(aggregator.purge(), 2);
+        assert_eq!(aggregator.len(), 0);
+        // No metrics exist
+        assert_eq!(aggregator.generation, 3);
+        assert_eq!(aggregator.purge(), 0);
+        assert_eq!(aggregator.len(), 0);
+    }
+
+    #[test]
+    fn to_series() {
+        let mut aggregator = Aggregator::<2>::new().unwrap();
+
+        let metric1 = Metric::parse("test:1|c|k:v").expect("metric parse failed");
+        let metric2 = Metric::parse("foo:1|c|k:v").expect("metric parse failed");
+        let metric3 = Metric::parse("bar:1|c|k:v").expect("metric parse failed");
+
+        assert!(aggregator.insert(&metric1).is_ok());
+        assert!(aggregator.insert(&metric2).is_ok());
+
+        assert_eq!(aggregator.len(), 2);
+        assert_eq!(aggregator.to_series().len(), 2);
+        assert_eq!(aggregator.len(), 2);
+        assert_eq!(aggregator.to_series().len(), 2);
+        assert_eq!(aggregator.len(), 2);
+
+        assert!(aggregator.insert(&metric3).is_err());
+        assert_eq!(aggregator.to_series().len(), 2);
+    }
+}

--- a/bottlecap/src/metrics/aggregator.rs
+++ b/bottlecap/src/metrics/aggregator.rs
@@ -48,10 +48,17 @@ impl Entry {
 
 impl Entry {
     fn of_generation(generation: u16, id: u64, metric: &Metric) -> Self {
+        let metric_value = match metric.first_value() {
+            Ok(value) => value,
+            Err(e) => {
+                error!("failed to parse metric: {:?}", e);
+                0.0
+            }
+        };
         Self {
             id,
             generation,
-            value: metric.values().next().unwrap().unwrap(),
+            value: metric_value,
             name: metric.name,
             tags: metric.tags,
             kind: metric.kind,

--- a/bottlecap/src/metrics/constants.rs
+++ b/bottlecap/src/metrics/constants.rs
@@ -1,0 +1,22 @@
+/// The maximum number of bytes that a metric name will be.
+pub const MAX_METRIC_NAME_BYTES: usize = 128;
+
+/// The maximum values that a `Metric` may hold.
+pub const MAX_VALUES: usize = 8;
+
+/// The maximum number of bytes that a value string represenation will be.
+pub const MAX_VALUE_BYTES: usize = 32;
+
+/// The maximum tags that a `Metric` may hold.
+pub const MAX_TAGS: usize = 32;
+
+/// The maximum number of bytes that a tag key will be.
+pub const MAX_TAG_KEY_BYTES: usize = 64;
+
+/// The maximum number of bytes that a tag value will be.
+pub const MAX_TAG_VALUE_BYTES: usize = 64;
+
+/// The maximum number of bytes that a container ID will be.
+pub const MAX_CONTAINER_ID_BYTES: usize = 64;
+
+pub static MAX_CONTEXTS: usize = 65_536; // 2**16, arbitrary

--- a/bottlecap/src/metrics/datadog.rs
+++ b/bottlecap/src/metrics/datadog.rs
@@ -1,0 +1,148 @@
+//!Types to serialize data into the Datadog API
+
+use std::env;
+
+use ureq;
+use serde::{Serialize, Serializer};
+use serde_json;
+use tracing::error;
+
+/// Interface for the DogStatsD metrics intake API.
+#[derive(Debug)]
+pub struct DdApi {
+    // runtime: tokio::runtime::Runtime,
+    api_key: String,
+}
+/// Error relating to `ship`
+#[derive(thiserror::Error, Debug)]
+pub enum ShipError {
+    #[error("Failed to push to API with status {status}: {body}")]
+    /// Datadog API failure
+    Failure {
+        /// HTTP status code
+        status: u16,
+        /// HTTP body that failed
+        body: String,
+    },
+
+    /// Json
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+}
+
+impl Default for DdApi {
+    fn default() -> Self {
+        Self {
+            api_key: env::var("DD_API_KEY").expect("unable to read envvars, catastrophic failure"),
+        }
+    }
+}
+
+impl DdApi {
+    /// Create a new `DdApi` instance
+    ///
+    /// # Panics
+    ///
+    /// Function will panic if `DD_API_KEY` cannot be read from the environment.
+    #[must_use]
+    pub fn new() -> Self {
+        DdApi::default()
+    }
+
+    /// Ship a serialized series to the API, blocking
+    pub fn ship(&self, series: &Series) -> Result<(), ShipError> {
+        // call inner_ship onto the runtime
+        let api_key = self.api_key.clone();
+        let body = serde_json::to_vec(&series)?;
+        log::info!("sending body: {:?}", &series);
+
+        let resp: Result<ureq::Response, ureq::Error> = ureq::post("https://api.datadoghq.com/api/v2/series")
+            .set("DD-API-KEY", &api_key)
+            .set("Content-Type", "application/json")
+            .send_bytes(body.as_slice());
+        match resp {
+            Ok(_resp) => Ok(()),
+            Err(ureq::Error::Status(code, response)) => {
+                Err(ShipError::Failure { status: code, body: response.into_string().unwrap() })
+            }
+            Err(e) => { Err(ShipError::Failure { status: 500, body: e.to_string() }) }
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone, Copy)]
+/// A single point in time
+pub(crate) struct Point {
+    /// The time at which the point exists
+    pub(crate) timestamp: u64,
+    /// The point's value
+    pub(crate) value: f64,
+}
+
+#[derive(Debug, Serialize)]
+/// A named resource
+pub(crate) struct Resource {
+    /// The name of this resource
+    pub(crate) name: &'static str,
+    #[serde(rename = "type")]
+    /// The kind of this resource
+    pub(crate) kind: &'static str,
+}
+
+#[derive(Debug, Clone, Copy)]
+/// The kinds of metrics the Datadog API supports
+pub(crate) enum DdMetricKind {
+    /// An accumulating sum
+    Count,
+    /// An instantaneous value
+    Gauge,
+    /// A distribution of values
+    Distribution,
+}
+
+impl Serialize for DdMetricKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match *self {
+            DdMetricKind::Count => serializer.serialize_u32(0),
+            DdMetricKind::Gauge => serializer.serialize_u32(1),
+            DdMetricKind::Distribution => serializer.serialize_u32(2),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[allow(clippy::struct_field_names)]
+/// A named collection of `Point` instances.
+pub(crate) struct Metric {
+    /// The name of the point collection
+    pub(crate) metric: &'static str,
+    /// The collection of points
+    pub(crate) points: [Point; 1],
+    /// The resources associated with the points
+    pub(crate) resources: Vec<Resource>,
+    #[serde(rename = "type")]
+    /// The kind of metric
+    pub(crate) kind: DdMetricKind,
+    pub(crate) tags: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+/// A collection of metrics as defined by the Datadog Metrics API.
+// NOTE we have a number of `Vec` instances in this implementation that could
+// otherwise be arrays, given that we have constants. Serializing to JSON would
+// require us to avoid serializing None or Uninit values, so there's some custom
+// work that's needed. For protobuf this more or less goes away.
+pub struct Series {
+    /// The collection itself
+    pub(crate) series: Vec<Metric>,
+}
+
+impl Series {
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.series.len()
+    }
+}

--- a/bottlecap/src/metrics/dogstatsd.rs
+++ b/bottlecap/src/metrics/dogstatsd.rs
@@ -1,15 +1,36 @@
 use std::sync::mpsc::Sender;
 
 use crate::events::{self, Event, MetricEvent};
+use crate::metrics::aggregator::Aggregator;
+use crate::metrics::metric::Metric;
+use crate::metrics::datadog;
+use std::sync::{Arc, Mutex};
+use tracing;
 
 pub struct DogStatsD {
-    join_handle: std::thread::JoinHandle<()>,
+    serve_handle: std::thread::JoinHandle<()>,
+    aggregator: Arc<Mutex<Aggregator<1024>>>,
+    dd_api: datadog::DdApi,
 }
 
+pub struct DogStatsDConfig {
+    pub host: String,
+    pub port: u16,
+}
+const CONTEXTS: usize = 1024;
+
 impl DogStatsD {
-    pub fn run(host: &str, port: u16, event_bus: Sender<events::Event>) -> DogStatsD {
+    pub fn run(config: &DogStatsDConfig, event_bus: Sender<events::Event>) -> DogStatsD {
+        let aggr: Arc<Mutex<Aggregator<CONTEXTS>>> = Arc::new(Mutex::new(Aggregator::<CONTEXTS>::new().expect("failed to create aggregator")));
+        let serializer_aggr = Arc::clone(&aggr);
+        let serve_handle = DogStatsD::run_server(&config.host, config.port, event_bus, serializer_aggr);
+        let dd_api = datadog::DdApi::new();
+        DogStatsD { serve_handle, aggregator: aggr, dd_api }
+    }
+
+    fn run_server(host: &str, port: u16, event_bus: Sender<events::Event>, aggregator: Arc<Mutex<Aggregator<CONTEXTS>>>) -> std::thread::JoinHandle<()> {
         let addr = format!("{}:{}", host, port);
-        let join_handle = std::thread::spawn(move || {
+        std::thread::spawn(move || {
             let socket = std::net::UdpSocket::bind(addr).expect("couldn't bind to address");
             loop {
                 let mut buf = [0; 1024]; // todo, do we want to make this dynamic? (not sure)
@@ -21,16 +42,38 @@ impl DogStatsD {
                     msg,
                     src
                 );
-                let dummy_tags = vec!["tagA:valueA".to_string(), "tagB:valueB".to_string()];
-                let metric_event = MetricEvent::new("metric_name".to_string(), 1.0, dummy_tags);
+                let parsed_metric = match Metric::parse(msg) {
+                    Ok(parsed_metric) => {
+                        log::info!("parsed metric: {:?}", parsed_metric);
+                        parsed_metric
+                    }
+                    Err(e) => {
+                        log::error!("failed to parse metric: {:?}\n message: {:?}", msg, e);
+                        continue;
+                    }
+                };
+                //TODO(astuyve): move expect to match, perhaps aggregate multi-value metrics in
+                //aggregator or modify metric event to pass multi-value metrics
+                let metric_event = MetricEvent::new(parsed_metric.name.to_string(), parsed_metric.first_value().expect("no first metric"), parsed_metric.tags());
+                let _ = aggregator.lock().expect("lock poisoned").insert(&parsed_metric);
+                log::info!("inserted metric into aggregator");
+                // Don't publish until after validation and adding metric_event to buff
                 let _ = event_bus.send(Event::Metric(metric_event)); // todo check the result
             }
-        });
-        DogStatsD { join_handle }
+        })
+    }
+
+    pub fn flush(&self) {
+        let current_points = &self.aggregator.lock().expect("lock poisoned").to_series();
+        if current_points.series.is_empty() {
+            return;
+        }
+        let _ = &self.dd_api.ship(&current_points).expect("failed to ship metrics to datadog");
     }
 
     pub fn shutdown(self) {
-        match self.join_handle.join() {
+        self.flush();
+        match self.serve_handle.join() {
             Ok(_) => {
                 log::info!("DogStatsD thread has been shutdown");
             }

--- a/bottlecap/src/metrics/errors.rs
+++ b/bottlecap/src/metrics/errors.rs
@@ -1,0 +1,30 @@
+//! Error types for `metrics` module
+
+/// Errors for the function [`crate::metric::Metric::parse`]
+#[derive(Debug, thiserror::Error, Clone, Copy, Eq, PartialEq)]
+pub enum ParseError {
+    /// Parse failure given in text
+    #[error("parse failure: {0}")]
+    Raw(&'static str),
+}
+
+/// Failure to create a new `Aggregator`
+#[derive(Debug, thiserror::Error, Clone, Copy)]
+pub enum Creation {
+    /// The specified context max is too large given our constants. Indicates a
+    /// serious programming error.
+    #[error("context max is too large")]
+    Contexts,
+}
+
+/// Failures from `Aggregator::insert`
+#[derive(Debug, thiserror::Error)]
+pub enum Insert {
+    /// The current interval is full and no further metrics can be inserted. The
+    /// inserted metric is returned.
+    #[error("interval is full")]
+    Overflow,
+    /// Unable to parse passed values
+    #[error(transparent)]
+    ValuesIteration(#[from] std::num::ParseFloatError),
+}

--- a/bottlecap/src/metrics/metric.rs
+++ b/bottlecap/src/metrics/metric.rs
@@ -1,0 +1,197 @@
+use ustr::Ustr;
+use std::hash::{Hash, Hasher};
+use crate::metrics::errors::ParseError;
+use crate::metrics::constants;
+use fnv::FnvHasher;
+#[derive(Debug)]
+#[derive(Clone, Copy, Eq, PartialEq)]
+/// Determine what kind/type of a metric has come in
+pub enum Type {
+    /// Dogstatsd 'count' metric type, monotonically increasing counter
+    Count,
+    /// Dogstatsd 'gauge' metric type, point-in-time value
+    Gauge,
+    /// Dogstatsd 'distribution' metric type, histogram
+    Distribution,
+}
+/// Representation of a dogstatsd Metric
+///
+/// For now this implementation covers only counters and gauges. We hope this is
+/// enough to demonstrate the impact of this program's design goals.
+#[derive(Clone, Copy, Debug)]
+pub struct Metric {
+    /// Name of the metric.
+    ///
+    /// Never more bytes than constants::MAX_METRIC_NAME_BYTES,
+    /// enforced by construction. Note utf8 issues.
+    pub(crate) name: Ustr,
+    /// What kind/type of metric this is.
+    pub(crate) kind: Type,
+    /// Values of the metric. A singular value may be either a floating point or
+    /// a integer. Although undocumented we assume 64 bit. A single metric may
+    /// encode multiple values a time in a message. There must be at least one
+    /// value here, meaning that there is guaranteed to be a Some value in the
+    /// 0th index.
+    ///
+    /// Parsing of the values to an integer type is deferred until the last
+    /// moment.
+    ///
+    /// Never longer than constants::MAX_VALUE_BYTES. Note utf8 issues.
+    values: Ustr,
+    /// Tags of the metric.
+    ///
+    /// The key is never longer than constants::MAX_TAG_KEY_BYTES, the value
+    /// never more than constants::MAX_TAG_VALUE_BYTES. These are enforced by
+    /// the parser. We assume here that tags are not sent in random order by the
+    /// clien or that, if they are, the API will tidy that up. That is `a:1,b:2`
+    /// is a different tagset from `b:2,a:1`.
+    pub(crate) tags: Option<Ustr>,
+}
+
+impl Metric {
+    /// Parse a metric from given input.
+    ///
+    /// This function parses a passed `&str` into a `Metric`. We assume that
+    /// DogStatsD metrics must be utf8 and are not ascii or some other encoding.
+    ///
+    /// # Errors
+    ///
+    /// This function will return with an error if the input violates any of the
+    /// limits in [`constants`]. Any non-viable input will be discarded.
+    /// example aj-test.increment:1|c|#user:aj-test from 127.0.0.1:50983
+    pub fn parse(input: &str) -> Result<Metric, crate::metrics::errors::ParseError> {
+
+        // TODO must enforce / exploit constraints given in `constants`.
+        let mut sections = input.split('|');
+
+        let nv_section = sections
+            .next()
+            .ok_or(ParseError::Raw("Missing metric name and value"))?;
+
+        let (name, values) = nv_section
+            .split_once(':')
+            .ok_or(ParseError::Raw("Missing name, value section"))?;
+
+        let kind_section = sections
+            .next()
+            .ok_or(ParseError::Raw("Missing metric type"))?;
+        let kind = match kind_section {
+            "c" => Type::Count,
+            "g" => Type::Gauge,
+            "d" => Type::Distribution,
+            _ => {
+                return Err(ParseError::Raw("Unsupported metric type"));
+            }
+        };
+
+        let mut tags = None;
+        for section in sections {
+            if section.starts_with('@') {
+                // Sample rate section, skip for now.
+                continue;
+            }
+            if let Some(tags_section) = section.strip_prefix('#') {
+                let tag_parts = tags_section.split(',');
+                // Validate that the tags have the right form.
+                for (i, part) in tag_parts.filter(|s| !s.is_empty()).enumerate() {
+                    if i >= constants::MAX_TAGS {
+                        return Err(ParseError::Raw("Too many tags"));
+                    }
+                    if !part.contains(':') {
+                        return Err(ParseError::Raw("Invalid tag format"));
+                    }
+                }
+                tags = Some(tags_section);
+                break;
+            }
+        }
+
+        Ok(Metric {
+            name: Ustr::from(name),
+            kind,
+            values: Ustr::from(values),
+            tags: tags.map(Ustr::from),
+        })
+    }
+    /// Return an iterator over values
+    pub(crate) fn values(
+        &self,
+    ) -> impl Iterator<Item = Result<f64, std::num::ParseFloatError>> + '_ {
+        self.values.split(':').map(|b: &str| {
+            let num = b.parse::<f64>()?;
+            Ok(num)
+        })
+    }
+
+    pub(crate) fn first_value(&self) -> Result<f64, crate::metrics::errors::ParseError> {
+        match self.values().next() {
+            Some(v) => match v {
+                Ok(v) => Ok(v),
+                Err(_e) => Err(ParseError::Raw("Failed to parse value as float")),
+            }
+            None => Err(ParseError::Raw("No value")),
+        }
+    }
+
+    pub(crate) fn tags(&self) -> Vec<String> {
+        self.tags.unwrap_or_default().to_string()
+                    .split(',')
+                    .map(|tag| tag.to_string())
+                    .collect()
+    }
+
+    #[cfg(test)]
+    fn raw_values(&self) -> &str {
+        self.values.as_str()
+    }
+
+    #[cfg(test)]
+    fn raw_name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    #[cfg(test)]
+    fn raw_tagset(&self) -> Option<&str> {
+        self.tags.map(|t| t.as_str())
+    }
+}
+
+/// Create an ID given a name and tagset.
+///
+/// This function constructs a hash of the name, the tagset and that hash is
+/// identical no matter the internal order of the tagset. That is, we consider a
+/// tagset like "a:1,b:2,c:3" to be idential to "b:2,c:3,a:1" to "c:3,a:1,b:2"
+/// etc. This implies that we must sort the tagset after parsing it, which we
+/// do. Note however that we _do not_ handle duplicate tags, so "a:1,a:1" will
+/// hash to a distinct ID than "a:1".
+///
+/// Note also that because we take `Ustr` arguments its possible that we've
+/// interned many possible combinations of a tagset, even if they are identical
+/// from the point of view of this function.
+#[inline]
+#[must_use]
+pub fn id(name: Ustr, tagset: Option<Ustr>) -> u64 {
+    let mut hasher = FnvHasher::default();
+
+    name.hash(&mut hasher);
+    // We sort tags. This is in feature parity with DogStatsD and also means
+    // that we avoid storing the same context multiple times because users have
+    // passed tags in differeing order through time.
+    if let Some(tagset) = tagset {
+        let mut tag_count = 0;
+        let mut scratch = [None; constants::MAX_TAGS];
+        for kv in tagset.split(',') {
+            if let Some((k, v)) = kv.split_once(':') {
+                scratch[tag_count] = Some((Ustr::from(k), Ustr::from(v)));
+                tag_count += 1;
+            }
+        }
+        scratch[..tag_count].sort_unstable();
+        // With the tags sorted -- note they're Copy -- we hash the whole kit.
+        for kv in scratch[..tag_count].iter().flatten() {
+            kv.0.as_bytes().hash(&mut hasher);
+            kv.1.as_bytes().hash(&mut hasher);
+        }
+    }
+    hasher.finish()
+}

--- a/bottlecap/src/metrics/mod.rs
+++ b/bottlecap/src/metrics/mod.rs
@@ -1,1 +1,6 @@
 pub mod dogstatsd;
+pub mod metric;
+pub mod errors;
+pub mod constants;
+pub mod aggregator;
+pub mod datadog;


### PR DESCRIPTION
Note: experimental.

Rough outline for gauge and counter metrics. Many TODOs here, pushing to instead start work on lifecycle.

Todos:
[ ] Use or remove `generation` feature
[ ] Distribution metrics
[ ] Handle multi-value metrics. Likely this means flattening them in the server thread, or refactoring MetricEvents to handle multi-value metrics.
[ ] Asynchrony to handle scheduled flushes as well as synchronous flushes.