### PR TITLE
Go 1.21.9

### DIFF
--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -15,8 +15,8 @@ RUN arch="$(uname -m)"; \
     if [ "${arch}" = 'x86_64' ]; then \
     arch='amd64'; \
     fi; \
-    wget -O go1.21.7.linux-${arch}.tar.gz https://go.dev/dl/go1.21.7.linux-${arch}.tar.gz; \
-    tar -C /usr/local -xzf go1.21.7.linux-${arch}.tar.gz
+    wget -O go1.21.8.linux-${arch}.tar.gz https://go.dev/dl/go1.21.8.linux-${arch}.tar.gz; \
+    tar -C /usr/local -xzf go1.21.8.linux-${arch}.tar.gz
 
 # cache dependencies
 COPY ./scripts/.cache/go.mod /tmp/dd/datadog-agent

--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -15,8 +15,8 @@ RUN arch="$(uname -m)"; \
     if [ "${arch}" = 'x86_64' ]; then \
     arch='amd64'; \
     fi; \
-    wget -O go1.21.8.linux-${arch}.tar.gz https://go.dev/dl/go1.21.8.linux-${arch}.tar.gz; \
-    tar -C /usr/local -xzf go1.21.8.linux-${arch}.tar.gz
+    wget -O go1.21.9.linux-${arch}.tar.gz https://go.dev/dl/go1.21.9.linux-${arch}.tar.gz; \
+    tar -C /usr/local -xzf go1.21.9.linux-${arch}.tar.gz
 
 # cache dependencies
 COPY ./scripts/.cache/go.mod /tmp/dd/datadog-agent


### PR DESCRIPTION
the main agent now requires go 1.21.8, up from 1.21.7. Looks like we now use 1.21.9, but it hasn't made it into the lambda extension branch yet.

[source](https://github.com/DataDog/datadog-agent/blob/392692d2dffe9bde38a88dc2eae214a0435c3bba/releasenotes/notes/bump-go-to-1.21.8-4cd694f089ec6895.yaml#L4)
<img width="1121" alt="image" src="https://github.com/DataDog/datadog-lambda-extension/assets/1598537/44fd2681-f94d-46fe-8653-e3e2d65e529d">
