### PR TITLE
aj/bottlecap/lifecycle

### DIFF
--- a/bottlecap/src/config.rs
+++ b/bottlecap/src/config.rs
@@ -313,7 +313,10 @@ pub mod tests {
     fn test_parse_flush_strategy_invalid_periodic() {
         figment::Jail::expect_with(|jail| {
             jail.clear_env();
-            jail.set_env("DD_SERVERLESS_FLUSH_STRATEGY", "periodically,invalid_interval");
+            jail.set_env(
+                "DD_SERVERLESS_FLUSH_STRATEGY",
+                "periodically,invalid_interval",
+            );
             let config = get_config(Path::new("")).expect("should parse config");
             assert_eq!(
                 config,

--- a/bottlecap/src/config.rs
+++ b/bottlecap/src/config.rs
@@ -17,6 +17,31 @@ pub enum LogLevel {
     Error,
 }
 
+pub struct PeriodicStrategy {
+    pub interval: u64,
+}
+
+pub enum FlushStrategy {
+    End,
+    Periodically(PeriodicStrategy),
+}
+
+impl Serde::Deserilize for FlushStrategy {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        match value.as_str() {
+            "end" => Ok(FlushStrategy::End),
+            _ => {
+                let strategy = PeriodicStrategy::deserialize(value)?;
+                Ok(FlushStrategy::Periodically(strategy))
+            }
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(default)]
@@ -31,6 +56,7 @@ pub struct Config {
     pub serverless_logs_enabled: bool,
     pub apm_enabled: bool,
     pub lambda_handler: String,
+    pub serverless_flush_strategy: Option<String>,
 }
 
 impl Default for Config {

--- a/bottlecap/src/config.rs
+++ b/bottlecap/src/config.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use serde::{Deserialize, Deserializer, self};
+use serde::{self, Deserialize, Deserializer};
 use tracing::debug;
 
 use figment::{
@@ -49,15 +49,16 @@ impl<'de> Deserialize<'de> for FlushStrategy {
                         // "60000"
                         match interval {
                             Some(interval) => {
-                                let interval = interval.parse().map_err(serde::de::Error::custom)?;
+                                let interval =
+                                    interval.parse().map_err(serde::de::Error::custom)?;
                                 Ok(FlushStrategy::Periodically(PeriodicStrategy { interval }))
-                            },
+                            }
                             None => {
                                 debug!("invalid flush strategy: {}, using default", value);
                                 Ok(FlushStrategy::Default)
                             }
                         }
-                    },
+                    }
                     _ => {
                         debug!("invalid flush strategy: {}, using default", value);
                         Ok(FlushStrategy::Default)

--- a/bottlecap/src/config.rs
+++ b/bottlecap/src/config.rs
@@ -25,6 +25,7 @@ pub struct PeriodicStrategy {
 
 #[derive(Debug, PartialEq)]
 pub enum FlushStrategy {
+    Default,
     End,
     Periodically(PeriodicStrategy),
 }
@@ -52,14 +53,14 @@ impl<'de> Deserialize<'de> for FlushStrategy {
                                 Ok(FlushStrategy::Periodically(PeriodicStrategy { interval }))
                             },
                             None => {
-                                debug!("invalid flush strategy: {}, using end", value);
-                                Ok(FlushStrategy::End)
+                                debug!("invalid flush strategy: {}, using default", value);
+                                Ok(FlushStrategy::Default)
                             }
                         }
                     },
                     _ => {
-                        debug!("invalid flush strategy: {}, using end", value);
-                        Ok(FlushStrategy::End)
+                        debug!("invalid flush strategy: {}, using default", value);
+                        Ok(FlushStrategy::Default)
                     }
                 }
             }
@@ -90,7 +91,7 @@ impl Default for Config {
             // General
             site: "datadoqhq.com".to_string(),
             api_key: String::default(),
-            serverless_flush_strategy: FlushStrategy::End,
+            serverless_flush_strategy: FlushStrategy::Default,
             // Unified Tagging
             env: None,
             service: None,

--- a/bottlecap/src/event_bus/bus.rs
+++ b/bottlecap/src/event_bus/bus.rs
@@ -1,53 +1,21 @@
 use std::sync::mpsc;
 use std::sync::mpsc::Sender;
-use std::thread;
-use tracing::debug;
-use tracing::error;
 
 use crate::events;
-use events::Event;
 
 pub struct EventBus {
     tx: Sender<events::Event>,
-    join_handle: thread::JoinHandle<()>,
+    pub rx: mpsc::Receiver<events::Event>,
 }
 
 impl EventBus {
     pub fn run() -> EventBus {
         let (tx, rx) = mpsc::channel();
-        let join_handle = thread::spawn(move || loop {
-            let received = rx.recv();
-            if let Ok(event) = received {
-                match event {
-                    Event::Metric(event) => {
-                        debug!("Metric event: {:?}", event);
-                    }
-                    Event::Telemetry(event) => {
-                        debug!("Telemetry event: {:?}", event);
-                    }
-                    _ => {
-                        debug!("Other event");
-                    }
-                }
-            } else {
-                error!("could not get the event");
-            }
-        });
-        EventBus { tx, join_handle }
+        EventBus { tx, rx}
     }
 
     pub fn get_sender_copy(&self) -> Sender<events::Event> {
         self.tx.clone()
     }
 
-    pub fn shutdown(self) {
-        match self.join_handle.join() {
-            Ok(_) => {
-                debug!("EventBus thread has been shutdown");
-            }
-            Err(e) => {
-                error!("Error shutting down the EventBus thread: {:?}", e);
-            }
-        }
-    }
 }

--- a/bottlecap/src/event_bus/bus.rs
+++ b/bottlecap/src/event_bus/bus.rs
@@ -11,11 +11,10 @@ pub struct EventBus {
 impl EventBus {
     pub fn run() -> EventBus {
         let (tx, rx) = mpsc::channel();
-        EventBus { tx, rx}
+        EventBus { tx, rx }
     }
 
     pub fn get_sender_copy(&self) -> Sender<events::Event> {
         self.tx.clone()
     }
-
 }

--- a/bottlecap/src/lifecycle/flush_control.rs
+++ b/bottlecap/src/lifecycle/flush_control.rs
@@ -55,7 +55,9 @@ impl FlushControl {
                 self.last_flush = now;
                 true
             }
-            FlushStrategy::Periodically(periodic) => self.should_periodic_flush(now, periodic.interval),
+            FlushStrategy::Periodically(periodic) => {
+                self.should_periodic_flush(now, periodic.interval)
+            }
             FlushStrategy::End => true,
         }
     }

--- a/bottlecap/src/lifecycle/flush_control.rs
+++ b/bottlecap/src/lifecycle/flush_control.rs
@@ -1,6 +1,6 @@
-use::std::time;
 use crate::config::FlushStrategy;
 use crate::lifecycle::invocation_times::InvocationTimes;
+use ::std::time;
 use tracing::debug;
 
 const TWENTY_SECONDS: u64 = 20 * 1000;
@@ -25,30 +25,43 @@ pub struct FlushControl {
 //      - Always flush at the end of the invocation
 impl FlushControl {
     pub fn new(flush_strategy: FlushStrategy) -> FlushControl {
-        FlushControl { flush_strategy, last_flush: 0, invocation_times: InvocationTimes::new() }
+        FlushControl {
+            flush_strategy,
+            last_flush: 0,
+            invocation_times: InvocationTimes::new(),
+        }
     }
 
     pub fn should_flush(&mut self) -> bool {
-        let now = time::SystemTime::now().duration_since(time::UNIX_EPOCH).unwrap().as_secs();
+        let now = time::SystemTime::now()
+            .duration_since(time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
         self.invocation_times.add(now);
         match &self.flush_strategy {
             FlushStrategy::Default => {
                 if self.invocation_times.should_adapt_to_periodic(now) {
                     let should_periodic_flush = self.should_periodic_flush(TWENTY_SECONDS);
-                    debug!("Adapting over to periodic flush strategy. should_periodic_flush: {}", should_periodic_flush);
+                    debug!(
+                        "Adapting over to periodic flush strategy. should_periodic_flush: {}",
+                        should_periodic_flush
+                    );
                     return should_periodic_flush;
                 }
                 debug!("Not enough invocations to adapt to periodic flush, flushing at the end of the invocation");
                 self.last_flush = now;
                 true
-            },
+            }
             FlushStrategy::Periodically(periodic) => self.should_periodic_flush(periodic.interval),
             FlushStrategy::End => true,
         }
     }
 
     fn should_periodic_flush(&mut self, interval: u64) -> bool {
-        let now = time::SystemTime::now().duration_since(time::UNIX_EPOCH).unwrap().as_secs();
+        let now = time::SystemTime::now()
+            .duration_since(time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
         if now - self.last_flush > (interval / 1000) {
             self.last_flush = now;
             true
@@ -70,10 +83,10 @@ mod tests {
     fn should_flush_default_periodic() {
         const LOOKBACK_COUNT: usize = 20;
         let mut flush_control = super::FlushControl::new(FlushStrategy::Default);
-        for _ in 0..LOOKBACK_COUNT-1 {
+        for _ in 0..LOOKBACK_COUNT - 1 {
             assert_eq!(flush_control.should_flush(), true);
         }
-            assert_eq!(flush_control.should_flush(), false);
+        assert_eq!(flush_control.should_flush(), false);
     }
     #[test]
     fn should_flush_end() {
@@ -82,7 +95,10 @@ mod tests {
     }
     #[test]
     fn should_flush_periodically() {
-        let mut flush_control = super::FlushControl::new(FlushStrategy::Periodically(config::PeriodicStrategy{ interval: 1 }));
+        let mut flush_control =
+            super::FlushControl::new(FlushStrategy::Periodically(config::PeriodicStrategy {
+                interval: 1,
+            }));
         assert_eq!(flush_control.should_flush(), true);
         assert_eq!(flush_control.should_flush(), false);
     }

--- a/bottlecap/src/lifecycle/flush_control.rs
+++ b/bottlecap/src/lifecycle/flush_control.rs
@@ -1,0 +1,77 @@
+use::std::time;
+use crate::config::FlushStrategy;
+use crate::lifecycle::invocation_times::InvocationTimes;
+use tracing::debug;
+
+const TWENTY_SECONDS: u64 = 20 * 1000;
+
+pub struct FlushControl {
+    pub last_flush: u64,
+    flush_strategy: FlushStrategy,
+    invocation_times: InvocationTimes,
+}
+
+impl FlushControl {
+    pub fn new(flush_strategy: FlushStrategy) -> FlushControl {
+        FlushControl { flush_strategy, last_flush: 0, invocation_times: InvocationTimes::new() }
+    }
+
+    pub fn should_flush(&mut self) -> bool {
+        let now = time::SystemTime::now().duration_since(time::UNIX_EPOCH).unwrap().as_secs();
+        self.invocation_times.add(now);
+        match &self.flush_strategy {
+            FlushStrategy::Default => {
+                if self.invocation_times.should_adapt_to_periodic(now) {
+                    let should_periodic_flush = self.should_periodic_flush(TWENTY_SECONDS);
+                    debug!("Adapting over to periodic flush strategy. should_periodic_flush: {}", should_periodic_flush);
+                    return should_periodic_flush;
+                }
+                debug!("Not enough invocations to adapt to periodic flush, flushing at the end of the invocation");
+                self.last_flush = now;
+                true
+            },
+            FlushStrategy::Periodically(periodic) => self.should_periodic_flush(periodic.interval),
+            FlushStrategy::End => true,
+        }
+    }
+
+    fn should_periodic_flush(&mut self, interval: u64) -> bool {
+        let now = time::SystemTime::now().duration_since(time::UNIX_EPOCH).unwrap().as_secs();
+        if now - self.last_flush > (interval / 1000) {
+            self.last_flush = now;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::{self, FlushStrategy};
+    #[test]
+    fn should_flush_default_end() {
+        let mut flush_control = super::FlushControl::new(FlushStrategy::Default);
+        assert_eq!(flush_control.should_flush(), true);
+    }
+    #[test]
+    fn should_flush_default_periodic() {
+        const LOOKBACK_COUNT: usize = 20;
+        let mut flush_control = super::FlushControl::new(FlushStrategy::Default);
+        for _ in 0..LOOKBACK_COUNT-1 {
+            assert_eq!(flush_control.should_flush(), true);
+        }
+            assert_eq!(flush_control.should_flush(), false);
+    }
+    #[test]
+    fn should_flush_end() {
+        let mut flush_control = super::FlushControl::new(FlushStrategy::End);
+        assert_eq!(flush_control.should_flush(), true);
+    }
+    #[test]
+    fn should_flush_periodically() {
+        let mut flush_control = super::FlushControl::new(FlushStrategy::Periodically(config::PeriodicStrategy{ interval: 1 }));
+        assert_eq!(flush_control.should_flush(), true);
+        assert_eq!(flush_control.should_flush(), false);
+    }
+}

--- a/bottlecap/src/lifecycle/flush_control.rs
+++ b/bottlecap/src/lifecycle/flush_control.rs
@@ -11,6 +11,18 @@ pub struct FlushControl {
     invocation_times: InvocationTimes,
 }
 
+// FlushControl is called at the end of every invocation and decides whether or not we should flush
+// The flushing logic is complex and depends on the flush strategy
+// 1. Default Strategy
+//   - Flush at the end of the first 20 invocations
+//   - We keep track of the last 20 invocations and calculate the frequency.
+//     - If the duration from the last invocation to the 20th is less than 2 minutes, switch to
+//     periodic flush every 20s
+//     - else, flush at the end of the invocation
+//  2. Periodic Strategy
+//      - User specifies the interval in milliseconds
+//  3. End strategy
+//      - Always flush at the end of the invocation
 impl FlushControl {
     pub fn new(flush_strategy: FlushStrategy) -> FlushControl {
         FlushControl { flush_strategy, last_flush: 0, invocation_times: InvocationTimes::new() }

--- a/bottlecap/src/lifecycle/invocation_times.rs
+++ b/bottlecap/src/lifecycle/invocation_times.rs
@@ -1,0 +1,82 @@
+const LOOKBACK_COUNT: usize = 20;
+const ONE_TWENTY_SECONDS: f64 = 120.0;
+
+pub struct InvocationTimes {
+    times: [u64; LOOKBACK_COUNT],
+    head: usize,
+}
+
+impl InvocationTimes {
+    pub fn new() -> InvocationTimes {
+        InvocationTimes { times: [0; LOOKBACK_COUNT], head: 0 }
+    }
+
+    pub fn add(&mut self, timestamp: u64) {
+        self.times[self.head] = timestamp;
+        self.head = (self.head + 1) % LOOKBACK_COUNT;
+    }
+    
+    pub fn should_adapt_to_periodic(&self, now: u64) -> bool {
+        let mut count = 0;
+        let mut last = 0;
+        for time in self.times.iter() {
+            if *time != 0 {
+                count += 1;
+                last = *time;
+            }
+        }
+        // If we haven't seen enough invocations, we should flush
+        if count < LOOKBACK_COUNT {
+            return false;
+        }
+        let elapsed = now - last;
+        (elapsed as f64 / (count - 1) as f64) < ONE_TWENTY_SECONDS
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::lifecycle::invocation_times;
+
+    #[test]
+    fn new() {
+        let invocation_times = invocation_times::InvocationTimes::new();
+        assert_eq!(invocation_times.times, [0; invocation_times::LOOKBACK_COUNT]);
+        assert_eq!(invocation_times.head, 0);
+    }
+
+    #[test]
+    fn insertion() {
+        let mut invocation_times = invocation_times::InvocationTimes::new();
+        let timestamp = 1;
+        invocation_times.add(timestamp);
+        assert_eq!(invocation_times.times[0], timestamp);
+        assert_eq!(invocation_times.head, 1);
+        assert_eq!(invocation_times.should_adapt_to_periodic(1), false);
+    }
+    
+    #[test]
+    fn insertion_with_full_buffer_fast_invokes() {
+        let mut invocation_times = invocation_times::InvocationTimes::new();
+        for i in 0..invocation_times::LOOKBACK_COUNT+1 {
+            invocation_times.add(i as u64);
+        }
+        // should wrap around
+        assert_eq!(invocation_times.times[0], 20);
+        assert_eq!(invocation_times.head, 1);
+        assert_eq!(invocation_times.should_adapt_to_periodic(21), true);
+    }
+
+    #[test]
+    fn insertion_with_full_buffer_slow_invokes() {
+        let mut invocation_times = invocation_times::InvocationTimes::new();
+        invocation_times.add(1 as u64);
+        for i in 0..invocation_times::LOOKBACK_COUNT {
+            invocation_times.add((i + 5000) as u64);
+        }
+        // should wrap around
+        assert_eq!(invocation_times.times[0], 5019);
+        assert_eq!(invocation_times.head, 1);
+        assert_eq!(invocation_times.should_adapt_to_periodic(10000), false);
+    }
+}

--- a/bottlecap/src/lifecycle/invocation_times.rs
+++ b/bottlecap/src/lifecycle/invocation_times.rs
@@ -8,14 +8,17 @@ pub struct InvocationTimes {
 
 impl InvocationTimes {
     pub fn new() -> InvocationTimes {
-        InvocationTimes { times: [0; LOOKBACK_COUNT], head: 0 }
+        InvocationTimes {
+            times: [0; LOOKBACK_COUNT],
+            head: 0,
+        }
     }
 
     pub fn add(&mut self, timestamp: u64) {
         self.times[self.head] = timestamp;
         self.head = (self.head + 1) % LOOKBACK_COUNT;
     }
-    
+
     pub fn should_adapt_to_periodic(&self, now: u64) -> bool {
         let mut count = 0;
         let mut last = 0;
@@ -41,7 +44,10 @@ mod tests {
     #[test]
     fn new() {
         let invocation_times = invocation_times::InvocationTimes::new();
-        assert_eq!(invocation_times.times, [0; invocation_times::LOOKBACK_COUNT]);
+        assert_eq!(
+            invocation_times.times,
+            [0; invocation_times::LOOKBACK_COUNT]
+        );
         assert_eq!(invocation_times.head, 0);
     }
 
@@ -54,11 +60,11 @@ mod tests {
         assert_eq!(invocation_times.head, 1);
         assert_eq!(invocation_times.should_adapt_to_periodic(1), false);
     }
-    
+
     #[test]
     fn insertion_with_full_buffer_fast_invokes() {
         let mut invocation_times = invocation_times::InvocationTimes::new();
-        for i in 0..invocation_times::LOOKBACK_COUNT+1 {
+        for i in 0..invocation_times::LOOKBACK_COUNT + 1 {
             invocation_times.add(i as u64);
         }
         // should wrap around

--- a/bottlecap/src/lifecycle/mod.rs
+++ b/bottlecap/src/lifecycle/mod.rs
@@ -1,0 +1,2 @@
+pub mod flush_control;
+mod invocation_times;

--- a/bottlecap/src/main.rs
+++ b/bottlecap/src/main.rs
@@ -149,10 +149,10 @@ fn main() -> Result<()> {
         .map_err(|e| Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
 
     let mut flush_control = FlushControl::new(config.serverless_flush_strategy);
+    let mut shutdown = false;
 
     loop {
         let evt = next_event(&r.extension_id);
-        let mut shutdown = false;
         match evt {
             Ok(NextEventResponse::Invoke {
                 request_id,
@@ -221,7 +221,9 @@ fn main() -> Result<()> {
                                         request_id, status
                                     );
                                 }
-                                _ => {}
+                                _ => {
+                                    debug!("Unforwarded Telemetry event: {:?}", event);
+                                }
                             }
                         }
                         _ => {}

--- a/bottlecap/src/metrics/dogstatsd.rs
+++ b/bottlecap/src/metrics/dogstatsd.rs
@@ -95,6 +95,7 @@ impl DogStatsD {
         let _ = &self
             .dd_api
             .ship(&current_points)
+            // TODO(astuyve) retry and do not panic
             .expect("failed to ship metrics to datadog");
         locked_aggr.clear();
     }

--- a/bottlecap/src/telemetry/client.rs
+++ b/bottlecap/src/telemetry/client.rs
@@ -1,4 +1,5 @@
 use std::error::Error;
+use tracing::debug;
 
 use crate::{base_url, EXTENSION_ID_HEADER, TELEMETRY_SUBSCRIPTION_ROUTE};
 
@@ -24,7 +25,7 @@ impl TelemetryApiClient {
             "buffering": { // TODO: re evaluate using default values
                 "maxItems": 1000,
                 "maxBytes": 256 * 1024,
-                "timeoutMs": 1000
+                "timeoutMs": 25
             }
         });
 
@@ -33,6 +34,7 @@ impl TelemetryApiClient {
             .set(EXTENSION_ID_HEADER, &self.extension_id)
             .send_json(data);
 
+        debug!("subscribed to telemetry: {:?}", resp);
         Ok(resp?)
     }
 }


### PR DESCRIPTION
- **WIP- lifecycle**
- **feat: Parse dd serverless flush strategy**
- **feat: Add lifecycle scheduler, honor DD_SERVERLESS_FLUSH_STRATEGY, adds flush controller and invocation counter**

First, we move the event bus reader into the main loop so we can decide if we should block and wait for `PlatformRuntimeDone` (so that we can flush) or not.

In the future this logic will get more complex as we may not necessarily need to flush after the function exits, but perform some form of compaction or aggregation, freeing memory, etc.

This adds a lifecycle module composed of a flush controller and invocation counter. This should implement the same flushing strategy we have in the main extension.

This also adds a parser for the DD_SERVERLESS_FLUSH_STRATEGY env var

The logic is described in the FlushControl module.
