### PR TITLE
feat(bottlecap): send logs to Datadog

### DIFF
--- a/bottlecap/src/logs/agent.rs
+++ b/bottlecap/src/logs/agent.rs
@@ -1,0 +1,78 @@
+use std::sync::mpsc::{self, Sender};
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use tracing::{debug, error};
+
+use crate::logs::aggregator::Aggregator;
+use crate::logs::datadog::DdApi;
+use crate::logs::processor::Processor;
+use crate::telemetry::events::TelemetryEvent;
+
+pub struct LogsAgent {
+    function_arn: Option<String>,
+    dd_api: DdApi,
+    aggregator: Arc<Mutex<Aggregator>>,
+    tx: Sender<TelemetryEvent>,
+    join_handle: std::thread::JoinHandle<()>,
+}
+
+impl LogsAgent {
+    pub fn run(function_arn: &str) -> LogsAgent {
+        let function_arn = function_arn.to_string();
+        let aggregator: Arc<Mutex<Aggregator>> = Arc::new(Mutex::new(Aggregator::new()));
+        let processor: Processor = Processor::new(function_arn.clone());
+
+        let cloned_aggregator = Arc::clone(&aggregator);
+
+        let (tx, rx) = mpsc::channel::<TelemetryEvent>();
+        let join_handle = thread::spawn(move || loop {
+            let received = rx.recv();
+            if let Ok(event) = received {
+                match processor.process(event) {
+                    Ok(log) => {
+                        cloned_aggregator.lock().expect("lock poisoned").add(log);
+                    }
+                    Err(e) => {
+                        error!("Error processing event: {}", e);
+                    }
+                }
+            }
+        });
+        LogsAgent {
+            tx,
+            join_handle,
+            dd_api: DdApi::new(),
+            aggregator,
+            function_arn: None,
+        }
+    }
+
+    pub fn get_sender_copy(&self) -> Sender<TelemetryEvent> {
+        self.tx.clone()
+    }
+
+    pub fn set_function_arn(&mut self, function_arn: String) {
+        self.function_arn = Some(function_arn);
+    }
+
+    pub fn flush(&self) {
+        let logs = self.aggregator.lock().expect("lock poisoned").get_batch();
+        self.dd_api
+            .send(&logs)
+            .expect("failed to send logs to Datadog");
+    }
+
+    pub fn shutdown(self) {
+        debug!("Shutting down LogsAgent");
+        self.flush();
+        match self.join_handle.join() {
+            Ok(_) => {
+                debug!("LogsAgent thread has been shutdown");
+            }
+            Err(e) => {
+                debug!("Error shutting down the LogsAgent thread: {:?}", e);
+            }
+        }
+    }
+}

--- a/bottlecap/src/logs/agent.rs
+++ b/bottlecap/src/logs/agent.rs
@@ -11,7 +11,7 @@ use crate::logs::processor::Processor;
 use crate::telemetry::events::TelemetryEvent;
 
 pub struct LogsAgent {
-    dd_api: datadog::DdApi,
+    dd_api: datadog::Api,
     aggregator: Arc<Mutex<Aggregator>>,
     tx: Sender<TelemetryEvent>,
     join_handle: std::thread::JoinHandle<()>,
@@ -23,7 +23,7 @@ impl LogsAgent {
         let aggregator: Arc<Mutex<Aggregator>> = Arc::new(Mutex::new(Aggregator::default()));
         let processor: Processor = Processor::new(function_arn, Arc::clone(&datadog_config));
 
-        let cloned_aggregator = Arc::clone(&aggregator);
+        let cloned_aggregator = aggregator.clone();
 
         let (tx, rx) = mpsc::channel::<TelemetryEvent>();
         let join_handle = thread::spawn(move || loop {
@@ -40,8 +40,7 @@ impl LogsAgent {
             }
         });
 
-        let dd_api =
-            datadog::DdApi::new(datadog_config.api_key.clone(), datadog_config.site.clone());
+        let dd_api = datadog::Api::new(datadog_config.api_key.clone(), datadog_config.site.clone());
         LogsAgent {
             tx,
             join_handle,

--- a/bottlecap/src/logs/agent.rs
+++ b/bottlecap/src/logs/agent.rs
@@ -54,8 +54,10 @@ impl LogsAgent {
         }
     }
 
-    pub fn send_event(&self, event: TelemetryEvent) -> Result<(), mpsc::SendError<TelemetryEvent>> {
-        self.tx.send(event)
+    pub fn send_event(&self, event: TelemetryEvent) {
+        if let Err(e) = self.tx.send(event) {
+            error!("Error sending Telemetry event to the Logs Agent: {}", e);
+        }
     }
 
     pub fn flush(&self) {

--- a/bottlecap/src/logs/aggregator.rs
+++ b/bottlecap/src/logs/aggregator.rs
@@ -21,3 +21,59 @@ impl Aggregator {
         messages
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::logs::processor::{Lambda, LambdaMessage};
+
+    use super::*;
+
+    #[test]
+    fn add() {
+        let mut aggregator = Aggregator::new();
+        let log = IntakeLog {
+            message: LambdaMessage {
+                message: "test".to_string(),
+                lambda: Lambda {
+                    arn: "arn".to_string(),
+                    request_id: "request_id".to_string(),
+                },
+                timestamp: 0,
+                status: "status".to_string(),
+            },
+            hostname: "hostname".to_string(),
+            service: "service".to_string(),
+            tags: "tags".to_string(),
+            source: "source".to_string(),
+        };
+        aggregator.add(log.clone());
+        assert_eq!(aggregator.messages.len(), 1);
+        assert_eq!(aggregator.messages[0], log);
+    }
+
+    #[test]
+    fn get_batch() {
+        let mut aggregator = Aggregator::new();
+        let log = IntakeLog {
+            message: LambdaMessage {
+                message: "test".to_string(),
+                lambda: Lambda {
+                    arn: "arn".to_string(),
+                    request_id: "request_id".to_string(),
+                },
+                timestamp: 0,
+                status: "status".to_string(),
+            },
+            hostname: "hostname".to_string(),
+            service: "service".to_string(),
+            tags: "tags".to_string(),
+            source: "source".to_string(),
+        };
+        aggregator.add(log.clone());
+        assert_eq!(aggregator.messages.len(), 1);
+        let batch = aggregator.get_batch();
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0], log);
+        assert_eq!(aggregator.messages.len(), 0);
+    }
+}

--- a/bottlecap/src/logs/aggregator.rs
+++ b/bottlecap/src/logs/aggregator.rs
@@ -1,0 +1,23 @@
+use crate::logs::processor::IntakeLog;
+
+pub struct Aggregator {
+    messages: Vec<IntakeLog>,
+}
+
+impl Aggregator {
+    pub fn new() -> Self {
+        Aggregator {
+            messages: Vec::new(),
+        }
+    }
+
+    pub fn add(&mut self, log: IntakeLog) {
+        self.messages.push(log);
+    }
+
+    pub fn get_batch(&mut self) -> Vec<IntakeLog> {
+        let messages = self.messages.clone();
+        self.messages.clear();
+        messages
+    }
+}

--- a/bottlecap/src/logs/aggregator.rs
+++ b/bottlecap/src/logs/aggregator.rs
@@ -1,23 +1,17 @@
 use crate::logs::processor::IntakeLog;
 
+#[derive(Default)]
 pub struct Aggregator {
     messages: Vec<IntakeLog>,
 }
 
 impl Aggregator {
-    pub fn new() -> Self {
-        Aggregator {
-            messages: Vec::new(),
-        }
-    }
-
     pub fn add(&mut self, log: IntakeLog) {
         self.messages.push(log);
     }
 
     pub fn get_batch(&mut self) -> Vec<IntakeLog> {
-        let messages = self.messages.clone();
-        self.messages.clear();
+        let messages = std::mem::take(&mut self.messages);
         messages
     }
 }
@@ -30,7 +24,7 @@ mod tests {
 
     #[test]
     fn add() {
-        let mut aggregator = Aggregator::new();
+        let mut aggregator = Aggregator::default();
         let log = IntakeLog {
             message: LambdaMessage {
                 message: "test".to_string(),
@@ -53,7 +47,7 @@ mod tests {
 
     #[test]
     fn get_batch() {
-        let mut aggregator = Aggregator::new();
+        let mut aggregator = Aggregator::default();
         let log = IntakeLog {
             message: LambdaMessage {
                 message: "test".to_string(),

--- a/bottlecap/src/logs/aggregator.rs
+++ b/bottlecap/src/logs/aggregator.rs
@@ -11,8 +11,7 @@ impl Aggregator {
     }
 
     pub fn get_batch(&mut self) -> Vec<IntakeLog> {
-        let messages = std::mem::take(&mut self.messages);
-        messages
+        std::mem::take(&mut self.messages)
     }
 }
 

--- a/bottlecap/src/logs/datadog.rs
+++ b/bottlecap/src/logs/datadog.rs
@@ -4,15 +4,15 @@ use tracing::{debug, error};
 
 use crate::logs::processor::IntakeLog;
 
-pub struct DdApi {
+pub struct Api {
     api_key: String,
     site: String,
     ureq_agent: ureq::Agent,
 }
 
-impl DdApi {
+impl Api {
     pub fn new(api_key: String, site: String) -> Self {
-        DdApi {
+        Api {
             api_key,
             site,
             ureq_agent: ureq::AgentBuilder::new().build(),

--- a/bottlecap/src/logs/datadog.rs
+++ b/bottlecap/src/logs/datadog.rs
@@ -1,39 +1,39 @@
-use std::{env, error::Error};
+use std::error::Error;
 
 use tracing::{debug, error};
 
 use crate::logs::processor::IntakeLog;
 
-const LOGS_API_INTAKE: &str = "https://http-intake.logs.datadoghq.com/api/v2/logs";
-
 pub struct DdApi {
     api_key: String,
+    site: String,
     ureq_agent: ureq::Agent,
 }
 
 impl DdApi {
-    pub fn new() -> Self {
+    pub fn new(api_key: String, site: String) -> Self {
         DdApi {
-            api_key: env::var("DD_API_KEY").expect("unable to read envvars, catastrophic failure"),
+            api_key,
+            site,
             ureq_agent: ureq::AgentBuilder::new().build(),
         }
     }
 
     pub fn send(&self, logs: &Vec<IntakeLog>) -> Result<(), Box<dyn Error>> {
-        let api_key = self.api_key.clone();
+        let url = format!("https://http-intake.logs.{}/api/v2/logs", &self.site);
 
         if !logs.is_empty() {
             let resp: Result<ureq::Response, ureq::Error> = self
                 .ureq_agent
-                .post(LOGS_API_INTAKE)
-                .set("DD-API-KEY", &api_key)
+                .post(&url)
+                .set("DD-API-KEY", &self.api_key)
                 .set("DD-PROTOCOL", "agent-json")
                 .set("Content-Type", "application/json")
                 .send_json(logs);
 
             match resp {
                 Ok(resp) => {
-                    if resp.status() != 200 {
+                    if resp.status() != 202 {
                         debug!("Failed to send logs to datadog: {}", resp.status());
                     }
                 }

--- a/bottlecap/src/logs/datadog.rs
+++ b/bottlecap/src/logs/datadog.rs
@@ -1,0 +1,48 @@
+use std::{env, error::Error};
+
+use tracing::{debug, error};
+
+use crate::logs::processor::IntakeLog;
+
+const LOGS_API_INTAKE: &str = "https://http-intake.logs.datadoghq.com/api/v2/logs";
+
+pub struct DdApi {
+    api_key: String,
+    ureq_agent: ureq::Agent,
+}
+
+impl DdApi {
+    pub fn new() -> Self {
+        DdApi {
+            api_key: env::var("DD_API_KEY").expect("unable to read envvars, catastrophic failure"),
+            ureq_agent: ureq::AgentBuilder::new().build(),
+        }
+    }
+
+    pub fn send(&self, logs: &Vec<IntakeLog>) -> Result<(), Box<dyn Error>> {
+        let api_key = self.api_key.clone();
+
+        if !logs.is_empty() {
+            let resp: Result<ureq::Response, ureq::Error> = self
+                .ureq_agent
+                .post(LOGS_API_INTAKE)
+                .set("DD-API-KEY", &api_key)
+                .set("DD-PROTOCOL", "agent-json")
+                .set("Content-Type", "application/json")
+                .send_json(logs);
+
+            match resp {
+                Ok(resp) => {
+                    if resp.status() != 200 {
+                        debug!("Failed to send logs to datadog: {}", resp.status());
+                    }
+                }
+                Err(e) => {
+                    error!("Failed to send logs to datadog: {}", e);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/bottlecap/src/logs/mod.rs
+++ b/bottlecap/src/logs/mod.rs
@@ -1,0 +1,4 @@
+pub mod agent;
+pub mod aggregator;
+pub mod datadog;
+pub mod processor;

--- a/bottlecap/src/logs/processor.rs
+++ b/bottlecap/src/logs/processor.rs
@@ -66,7 +66,8 @@ impl Processor {
                     request_id: "placeholder-request-id".to_string(), // TODO: replace with incoming request id
                 },
                 timestamp: event.time.timestamp_millis(),
-                status: "placeholder-status".to_string(),
+                // Default status
+                status: "info".to_string(),
             },
         };
         match event.record {
@@ -84,7 +85,6 @@ impl Processor {
                 let rv = runtime_version.unwrap_or("?".to_string()); // TODO: check what does containers display
                 let rv_arn = runtime_version_arn.unwrap_or("?".to_string()); // TODO: check what do containers display
                 log.message.message = format!("INIT_START Runtime Version: {} Runtime Version ARN: {}", rv, rv_arn);
-                log.message.status = "info".to_string();
 
                 Ok(log)
             },
@@ -96,14 +96,12 @@ impl Processor {
                 log.message.message =
                     format!("START RequestId: {} Version: {}", request_id, version);
                 log.message.lambda.request_id = request_id;
-                log.message.status = "info".to_string();
 
                 Ok(log)
             },
             TelemetryRecord::PlatformRuntimeDone { request_id , .. } => {  // TODO: check what to do with rest of the fields
                 log.message.message = format!("END RequestId: {}", request_id);
                 log.message.lambda.request_id = request_id;
-                log.message.status = "info".to_string();
                 Ok(log)
             },
             TelemetryRecord::PlatformReport { request_id, metrics, .. } => { // TODO: check what to do with rest of the fields
@@ -123,7 +121,6 @@ impl Processor {
 
                 log.message.message = message;
                 log.message.lambda.request_id = request_id;
-                log.message.status = "info".to_string();
 
                 Ok(log)
             },

--- a/bottlecap/src/logs/processor.rs
+++ b/bottlecap/src/logs/processor.rs
@@ -1,0 +1,70 @@
+use std::error::Error;
+
+use serde::Serialize;
+
+use crate::telemetry::events::{TelemetryEvent, TelemetryRecord};
+
+const LOGS_SOURCE: &str = "lambda";
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct Lambda {
+    pub arn: String,
+    pub request_id: String,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct LambdaMessage {
+    pub message: String,
+    pub lambda: Lambda,
+    pub timestamp: i64,
+    pub status: String,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct IntakeLog {
+    pub message: LambdaMessage,
+    pub hostname: String,
+    pub service: String,
+    #[serde(rename(serialize = "ddtags"))]
+    pub tags: String,
+    #[serde(rename(serialize = "ddsource"))]
+    pub source: String,
+}
+
+#[derive(Clone)]
+pub struct Processor {
+    function_arn: String,
+}
+
+impl Processor {
+    pub fn new(function_arn: String) -> Processor {
+        Processor { function_arn }
+    }
+
+    pub fn process(&self, event: TelemetryEvent) -> Result<IntakeLog, Box<dyn Error>> {
+        match event.record {
+            TelemetryRecord::PlatformStart {
+                request_id,
+                version,
+            } => {
+                let version = version.unwrap_or("$LATEST".to_string());
+                Ok(IntakeLog {
+                    message: LambdaMessage {
+                        message: format!("START RequestId: {} Version: {}", request_id, version),
+                        lambda: Lambda {
+                            arn: self.function_arn.clone(),
+                            request_id,
+                        },
+                        timestamp: event.time.timestamp_millis(),
+                        status: "info".to_string(),
+                    },
+                    hostname: self.function_arn.clone(),
+                    service: "TODO-add-service".to_string(),
+                    tags: "todo:add-tags".to_string(),
+                    source: LOGS_SOURCE.to_string(),
+                })
+            }
+            _ => Err("Unsupported event type".into()),
+        }
+    }
+}

--- a/bottlecap/src/logs/processor.rs
+++ b/bottlecap/src/logs/processor.rs
@@ -48,12 +48,8 @@ impl Processor {
     }
 
     pub fn process(&self, event: TelemetryEvent) -> Result<IntakeLog, Box<dyn Error>> {
-        let service = self
-            .datadog_config
-            .service
-            .clone()
-            .unwrap_or("".to_string());
-        let tags = self.datadog_config.tags.clone().unwrap_or("".to_string());
+        let service = self.datadog_config.service.clone().unwrap_or_default();
+        let tags = self.datadog_config.tags.clone().unwrap_or_default();
         let mut log = IntakeLog {
             hostname: self.function_arn.clone(),
             source: LOGS_SOURCE.to_string(),

--- a/bottlecap/src/logs/processor.rs
+++ b/bottlecap/src/logs/processor.rs
@@ -42,28 +42,78 @@ impl Processor {
     }
 
     pub fn process(&self, event: TelemetryEvent) -> Result<IntakeLog, Box<dyn Error>> {
+        let mut log = IntakeLog {
+            hostname: self.function_arn.clone(),
+            source: LOGS_SOURCE.to_string(),
+            service: "placeholder-service".to_string(), // TODO: replace with config service
+            tags: "placeholder:tags".to_string(),       // TODO: replace with config tags
+            message: LambdaMessage {
+                message: "placeholder-message".to_string(),
+                lambda: Lambda {
+                    arn: self.function_arn.clone(),
+                    request_id: "placeholder-request-id".to_string(), // TODO: replace with incoming request id
+                },
+                timestamp: event.time.timestamp_millis(),
+                status: "placeholder-status".to_string(),
+            },
+        };
         match event.record {
+            TelemetryRecord::Function(v) | TelemetryRecord::Extension(v) => {
+                log.message.status = "info".to_string();
+                log.message.message = v;
+
+                Ok(log)
+            }
+            TelemetryRecord::PlatformInitStart {
+                runtime_version,
+                runtime_version_arn,
+                .. // TODO: check if we could do something with this metrics: `initialization_type` and `phase`
+            } => {
+                let rv = runtime_version.unwrap_or("?".to_string()); // TODO: check what does containers display
+                let rv_arn = runtime_version_arn.unwrap_or("?".to_string()); // TODO: check what do containers display
+                log.message.message = format!("INIT_START Runtime Version: {} Runtime Version ARN: {}", rv, rv_arn);
+
+                Ok(log)
+            },
             TelemetryRecord::PlatformStart {
                 request_id,
                 version,
             } => {
                 let version = version.unwrap_or("$LATEST".to_string());
-                Ok(IntakeLog {
-                    message: LambdaMessage {
-                        message: format!("START RequestId: {} Version: {}", request_id, version),
-                        lambda: Lambda {
-                            arn: self.function_arn.clone(),
-                            request_id,
-                        },
-                        timestamp: event.time.timestamp_millis(),
-                        status: "info".to_string(),
-                    },
-                    hostname: self.function_arn.clone(),
-                    service: "TODO-add-service".to_string(),
-                    tags: "todo:add-tags".to_string(),
-                    source: LOGS_SOURCE.to_string(),
-                })
-            }
+                log.message.message =
+                    format!("START RequestId: {} Version: {}", request_id, version);
+                log.message.lambda.request_id = request_id;
+                log.message.status = "info".to_string();
+
+                Ok(log)
+            },
+            TelemetryRecord::PlatformRuntimeDone { request_id , .. } => {  // TODO: check what to do with rest of the fields
+                log.message.message = format!("END RequestId: {}", request_id);
+                log.message.lambda.request_id = request_id;
+                log.message.status = "info".to_string();
+                Ok(log)
+            },
+            TelemetryRecord::PlatformReport { request_id, metrics, .. } => { // TODO: check what to do with rest of the fields
+                let mut message = format!(
+                    "REPORT RequestId: {} Duration: {} ms Billed Duration: {} ms Memory Size: {} MB Max Memory Used: {} MB",
+                    request_id,
+                    metrics.duration_ms,
+                    metrics.billed_duration_ms,
+                    metrics.memory_size_mb,
+                    metrics.max_memory_used_mb,
+                );
+
+                let init_duration_ms = metrics.init_duration_ms;
+                if let Some(init_duration_ms) = init_duration_ms {
+                    message = format!("{} Init Duration: {} ms", message, init_duration_ms)
+                }
+
+                log.message.message = message;
+                log.message.lambda.request_id = request_id;
+                log.message.status = "info".to_string();
+
+                Ok(log)
+            },
             _ => Err("Unsupported event type".into()),
         }
     }

--- a/bottlecap/src/main.rs
+++ b/bottlecap/src/main.rs
@@ -141,7 +141,7 @@ fn main() -> Result<()> {
         .init();
 
     // First load the configuration
-    let lambda_directory = std::env::var("LAMBDA_TASK_ROOT").unwrap_or("".to_string());
+    let lambda_directory = std::env::var("LAMBDA_TASK_ROOT").unwrap_or_default();
     let config = match config::get_config(Path::new(&lambda_directory)) {
         Ok(config) => Arc::new(config),
         Err(e) => {

--- a/bottlecap/src/main.rs
+++ b/bottlecap/src/main.rs
@@ -221,9 +221,7 @@ fn main() -> Result<()> {
                             debug!("Metric event: {:?}", event);
                         }
                         Event::Telemetry(event) => {
-                            if let Err(e) = logs_agent.send_event(event.clone()) {
-                                error!("Error sending Telemetry event to the Logs Agent: {}", e);
-                            }
+                            logs_agent.send_event(event.clone());
                             match event.record {
                                 TelemetryRecord::PlatformInitReport {
                                     initialization_type,

--- a/bottlecap/src/main.rs
+++ b/bottlecap/src/main.rs
@@ -159,7 +159,6 @@ fn main() -> Result<()> {
     let function_arn = build_function_arn(&r.account_id, &region, &function_name);
 
     let logs_agent = LogsAgent::run(&function_arn, Arc::clone(&config));
-    let logs_agent_tx = logs_agent.get_sender_copy();
     let event_bus = EventBus::run();
     let dogstatsd_config = DogStatsDConfig {
         host: EXTENSION_HOST.to_string(),
@@ -222,7 +221,7 @@ fn main() -> Result<()> {
                             debug!("Metric event: {:?}", event);
                         }
                         Event::Telemetry(event) => {
-                            if let Err(e) = logs_agent_tx.send(event.clone()) {
+                            if let Err(e) = logs_agent.send_event(event.clone()) {
                                 error!("Error sending Telemetry event to the Logs Agent: {}", e);
                             }
                             match event.record {


### PR DESCRIPTION
# What?

Send Telemetry API logs to Datadog.

# How?

Created the Logs Agent which handles the coordination for:
1. Logs Aggregator (needs batching mechanism).
2. Logs Processor: convert `TelemetryEvents` into `IntakeLog`s.
3. Logs API `datadog.rs`: sending data to backend.

# Testing

- [x] manual testing
- [x] unit testing for processing, logs agent e2e testing will be needed later 

# Motivation

[SVLS-4809](https://datadoghq.atlassian.net/browse/SVLS-4809)


[SVLS-4809]: https://datadoghq.atlassian.net/browse/SVLS-4809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ