### PR TITLE
feat(bottlecap): make configuration an atomic reference counter

### DIFF
--- a/bottlecap/src/config.rs
+++ b/bottlecap/src/config.rs
@@ -8,7 +8,7 @@ use figment::{
     Figment,
 };
 
-#[derive(Debug, PartialEq, Deserialize, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Default)]
 pub enum LogLevel {
     Trace,
     Debug,
@@ -18,12 +18,12 @@ pub enum LogLevel {
     Error,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PeriodicStrategy {
     pub interval: u64,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FlushStrategy {
     Default,
     End,

--- a/bottlecap/src/config.rs
+++ b/bottlecap/src/config.rs
@@ -18,12 +18,12 @@ pub enum LogLevel {
     Error,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct PeriodicStrategy {
     pub interval: u64,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum FlushStrategy {
     Default,
     End,

--- a/bottlecap/src/logger.rs
+++ b/bottlecap/src/logger.rs
@@ -4,7 +4,7 @@ use log::{LevelFilter, Log, Metadata, Record};
 pub struct SimpleLogger {}
 
 impl SimpleLogger {
-    pub fn init(level: &LogLevel) -> Result<(), log::SetLoggerError> {
+    pub fn init(level: LogLevel) -> Result<(), log::SetLoggerError> {
         let level = match level {
             LogLevel::Trace => LevelFilter::Trace,
             LogLevel::Debug => LevelFilter::Debug,

--- a/bottlecap/src/logger.rs
+++ b/bottlecap/src/logger.rs
@@ -4,7 +4,7 @@ use log::{LevelFilter, Log, Metadata, Record};
 pub struct SimpleLogger {}
 
 impl SimpleLogger {
-    pub fn init(level: LogLevel) -> Result<(), log::SetLoggerError> {
+    pub fn init(level: &LogLevel) -> Result<(), log::SetLoggerError> {
         let level = match level {
             LogLevel::Trace => LevelFilter::Trace,
             LogLevel::Debug => LevelFilter::Debug,

--- a/bottlecap/src/main.rs
+++ b/bottlecap/src/main.rs
@@ -150,8 +150,7 @@ fn main() -> Result<()> {
         .subscribe()
         .map_err(|e| Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
 
-    let serverless_flush_strategy = config.serverless_flush_strategy.clone();
-    let mut flush_control = FlushControl::new(serverless_flush_strategy);
+    let mut flush_control = FlushControl::new(config.serverless_flush_strategy);
     let mut shutdown = false;
 
     loop {

--- a/bottlecap/src/main.rs
+++ b/bottlecap/src/main.rs
@@ -126,8 +126,7 @@ fn main() -> Result<()> {
             panic!("Error starting the extension: {:?}", err);
         }
     };
-    let log_level = &config.log_level;
-    SimpleLogger::init(log_level).expect("Error initializing logger");
+    SimpleLogger::init(config.log_level).expect("Error initializing logger");
 
     let r = register().map_err(|e| Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
 

--- a/bottlecap/src/main.rs
+++ b/bottlecap/src/main.rs
@@ -151,7 +151,8 @@ fn main() -> Result<()> {
         .subscribe()
         .map_err(|e| Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
 
-    let mut flush_control = FlushControl::new(config.serverless_flush_strategy);
+    let serverless_flush_strategy = config.lock().unwrap().serverless_flush_strategy.clone();
+    let mut flush_control = FlushControl::new(serverless_flush_strategy);
     let mut shutdown = false;
 
     loop {

--- a/bottlecap/src/main.rs
+++ b/bottlecap/src/main.rs
@@ -23,7 +23,7 @@ use std::env;
 use std::io::Error;
 use std::io::Result;
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::{os::unix::process::CommandExt, path::Path, process::Command};
 
 use logger::SimpleLogger;

--- a/bottlecap/src/main.rs
+++ b/bottlecap/src/main.rs
@@ -119,14 +119,14 @@ fn main() -> Result<()> {
     // First load the configuration
     let lambda_directory = std::env::var("LAMBDA_TASK_ROOT").unwrap_or("".to_string());
     let config = match config::get_config(Path::new(&lambda_directory)) {
-        Ok(config) => Arc::new(Mutex::new(config)),
+        Ok(config) => Arc::new(config),
         Err(e) => {
             log::error!("Error loading configuration: {:?}", e);
             let err = Command::new("/opt/datadog-agent-go").exec();
             panic!("Error starting the extension: {:?}", err);
         }
     };
-    let log_level = &config.lock().unwrap().log_level;
+    let log_level = &config.log_level;
     SimpleLogger::init(log_level).expect("Error initializing logger");
 
     let r = register().map_err(|e| Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
@@ -151,7 +151,7 @@ fn main() -> Result<()> {
         .subscribe()
         .map_err(|e| Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
 
-    let serverless_flush_strategy = config.lock().unwrap().serverless_flush_strategy.clone();
+    let serverless_flush_strategy = config.serverless_flush_strategy.clone();
     let mut flush_control = FlushControl::new(serverless_flush_strategy);
     let mut shutdown = false;
 

--- a/bottlecap/src/metrics/datadog.rs
+++ b/bottlecap/src/metrics/datadog.rs
@@ -9,6 +9,7 @@ use ureq;
 #[derive(Debug)]
 pub struct DdApi {
     api_key: String,
+    site: String,
     ureq_agent: ureq::Agent,
 }
 /// Error relating to `ship`
@@ -29,9 +30,10 @@ pub enum ShipError {
 }
 
 impl DdApi {
-    pub fn new(api_key: String) -> Self {
+    pub fn new(api_key: String, site: String) -> Self {
         DdApi {
             api_key,
+            site,
             ureq_agent: ureq::AgentBuilder::new().build(),
         }
     }
@@ -42,9 +44,10 @@ impl DdApi {
         let body = serde_json::to_vec(&series)?;
         log::info!("sending body: {:?}", &series);
 
+        let url = format!("https://api.{}/api/v2/series", &self.site);
         let resp: Result<ureq::Response, ureq::Error> = self
             .ureq_agent
-            .post("https://api.datadoghq.com/api/v2/series")
+            .post(&url)
             .set("DD-API-KEY", &self.api_key)
             .set("Content-Type", "application/json")
             .send_bytes(body.as_slice());

--- a/bottlecap/src/metrics/dogstatsd.rs
+++ b/bottlecap/src/metrics/dogstatsd.rs
@@ -17,7 +17,7 @@ pub struct DogStatsD {
 pub struct DogStatsDConfig {
     pub host: String,
     pub port: u16,
-    pub datadog_config: Arc<Mutex<config::Config>>,
+    pub datadog_config: Arc<config::Config>,
 }
 
 impl DogStatsD {
@@ -28,12 +28,7 @@ impl DogStatsD {
         let serializer_aggr = Arc::clone(&aggr);
         let serve_handle =
             DogStatsD::run_server(&config.host, config.port, event_bus, serializer_aggr);
-        let api_key = config
-            .datadog_config
-            .lock()
-            .expect("lock poisoned")
-            .api_key
-            .clone();
+        let api_key = config.datadog_config.api_key.clone();
         let dd_api = datadog::DdApi::new(api_key);
         DogStatsD {
             serve_handle,

--- a/bottlecap/src/metrics/dogstatsd.rs
+++ b/bottlecap/src/metrics/dogstatsd.rs
@@ -28,8 +28,10 @@ impl DogStatsD {
         let serializer_aggr = Arc::clone(&aggr);
         let serve_handle =
             DogStatsD::run_server(&config.host, config.port, event_bus, serializer_aggr);
-        let api_key = config.datadog_config.api_key.clone();
-        let dd_api = datadog::DdApi::new(api_key);
+        let dd_api = datadog::DdApi::new(
+            config.datadog_config.api_key.clone(),
+            config.datadog_config.site.clone(),
+        );
         DogStatsD {
             serve_handle,
             aggregator: aggr,


### PR DESCRIPTION
# What?

Update configuration to be an `Arc<Config>` so we can use across services and threads.

# How?

Updated `main.rs` to reflect this changes.
Also updated the Metrics API to use the configuration instead of reading from environment variables.