### PR TITLE
feat(bottlecap): set `request_id` on every log

### DIFF
--- a/bottlecap/src/logs/aggregator.rs
+++ b/bottlecap/src/logs/aggregator.rs
@@ -29,7 +29,7 @@ mod tests {
                 message: "test".to_string(),
                 lambda: Lambda {
                     arn: "arn".to_string(),
-                    request_id: "request_id".to_string(),
+                    request_id: Some("request_id".to_string()),
                 },
                 timestamp: 0,
                 status: "status".to_string(),
@@ -52,7 +52,7 @@ mod tests {
                 message: "test".to_string(),
                 lambda: Lambda {
                     arn: "arn".to_string(),
-                    request_id: "request_id".to_string(),
+                    request_id: Some("request_id".to_string()),
                 },
                 timestamp: 0,
                 status: "status".to_string(),

--- a/bottlecap/src/main.rs
+++ b/bottlecap/src/main.rs
@@ -212,7 +212,7 @@ fn main() -> Result<()> {
         }
         // Block until we get something from the telemetry API
         // Check if flush logic says we should block and flush or not
-        if flush_control.should_flush() {
+        if flush_control.should_flush() || shutdown {
             loop {
                 let received = event_bus.rx.recv();
                 if let Ok(event) = received {
@@ -253,6 +253,9 @@ fn main() -> Result<()> {
                                         "Platform report for request_id: {:?} with status: {:?}",
                                         request_id, status
                                     );
+                                    if shutdown {
+                                        break;
+                                    }
                                 }
                                 _ => {
                                     debug!("Unforwarded Telemetry event: {:?}", event);


### PR DESCRIPTION
# What?

Sets the correct `request_id` to every log.

# How?

1. The processor now has a `request_id` field which will be set on every `PlatformStart` event.
2. We set on every log the `request_id` field if available, if not, we flag it as orphan for later processing.
3. Whenever the processor get a successful `IntakeLog` from an event transformation, we flush flush orphan logs with the now available `request_id`.

# Motivation

Feature parity with the Go Agent.
[SVLS-4813](https://datadoghq.atlassian.net/browse/SVLS-4813)

[SVLS-4813]: https://datadoghq.atlassian.net/browse/SVLS-4813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ