### PR TITLE
feat(bottlecap): batch logs properly

### DIFF
--- a/bottlecap/src/logs/aggregator.rs
+++ b/bottlecap/src/logs/aggregator.rs
@@ -3,12 +3,40 @@ use tracing::{debug, warn};
 
 use crate::logs::constants;
 use crate::logs::processor::IntakeLog;
-#[derive(Default)]
 pub struct Aggregator {
     messages: VecDeque<String>,
+    max_batch_entries_size: usize,
+    max_content_size_bytes: usize,
+    max_log_size_bytes: usize,
+}
+
+impl Default for Aggregator {
+    fn default() -> Self {
+        Aggregator {
+            messages: VecDeque::new(),
+            max_batch_entries_size: constants::MAX_BATCH_ENTRIES_SIZE,
+            max_content_size_bytes: constants::MAX_CONTENT_SIZE_BYTES,
+            max_log_size_bytes: constants::MAX_LOG_SIZE_BYTES,
+        }
+    }
 }
 
 impl Aggregator {
+    // Used in testing
+    #[allow(dead_code)]
+    pub fn new(
+        max_batch_entries_size: usize,
+        max_content_size_bytes: usize,
+        max_log_size_bytes: usize,
+    ) -> Self {
+        Aggregator {
+            messages: VecDeque::new(),
+            max_batch_entries_size,
+            max_content_size_bytes,
+            max_log_size_bytes,
+        }
+    }
+
     pub fn add(&mut self, log: IntakeLog) {
         match serde_json::to_string(&log) {
             Ok(log) => self.messages.push_back(log),
@@ -17,24 +45,20 @@ impl Aggregator {
     }
 
     pub fn get_batch(&mut self) -> Vec<u8> {
-        let mut buffer: Vec<u8> = Vec::with_capacity(constants::MAX_CONTENT_SIZE_BYTES);
+        let mut buffer: Vec<u8> = Vec::with_capacity(self.max_content_size_bytes);
         buffer.extend(b"[");
 
         // Fill the batch with logs from the messages
-        for index in 0..constants::MAX_BATCH_ENTRIES_SIZE {
-            if index > 0 {
-                buffer.extend(b",");
-            }
-
+        for _ in 0..self.max_batch_entries_size {
             if let Some(log) = self.messages.pop_front() {
                 // Check if the buffer will be full after adding the log
-                if buffer.len() + log.len() > constants::MAX_CONTENT_SIZE_BYTES {
+                if buffer.len() + log.len() > self.max_content_size_bytes {
                     // Put the log back in the queue
                     self.messages.push_front(log);
                     break;
                 }
 
-                if log.len() > constants::MAX_LOG_SIZE_BYTES {
+                if log.len() > self.max_log_size_bytes {
                     warn!(
                         "Log size exceeds the 1MB limit: {}, will be truncated by the backend.",
                         log.len()
@@ -42,6 +66,7 @@ impl Aggregator {
                 }
 
                 buffer.extend(log.as_bytes());
+                buffer.extend(b",")
             } else {
                 break;
             }
@@ -65,7 +90,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn add() {
+    fn test_add() {
         let mut aggregator = Aggregator::default();
         let log = IntakeLog {
             message: LambdaMessage {
@@ -88,7 +113,7 @@ mod tests {
     }
 
     #[test]
-    fn get_batch() {
+    fn test_get_batch() {
         let mut aggregator = Aggregator::default();
         let log = IntakeLog {
             message: LambdaMessage {
@@ -110,5 +135,78 @@ mod tests {
         let batch = aggregator.get_batch();
         let serialized_batch = format!("[{}]", serde_json::to_string(&log).unwrap());
         assert_eq!(batch, serialized_batch.as_bytes());
+    }
+
+    #[test]
+    fn test_get_batch_full_entries() {
+        let mut aggregator = Aggregator::new(2, 1_024, 1_024);
+        let log = IntakeLog {
+            message: LambdaMessage {
+                message: "test".to_string(),
+                lambda: Lambda {
+                    arn: "arn".to_string(),
+                    request_id: "request_id".to_string(),
+                },
+                timestamp: 0,
+                status: "status".to_string(),
+            },
+            hostname: "hostname".to_string(),
+            service: "service".to_string(),
+            tags: "tags".to_string(),
+            source: "source".to_string(),
+        };
+        // Add 3 logs
+        aggregator.add(log.clone());
+        aggregator.add(log.clone());
+        aggregator.add(log.clone());
+
+        // The batch should only contain the first 2 logs
+        let first_batch = aggregator.get_batch();
+        let serialized_log = serde_json::to_string(&log).unwrap();
+        let serialized_batch = format!("[{},{}]", serialized_log, serialized_log);
+        assert_eq!(first_batch, serialized_batch.as_bytes());
+        assert_eq!(aggregator.messages.len(), 1);
+
+        // The second batch should only contain the last log
+        let second_batch = aggregator.get_batch();
+        let serialized_batch = format!("[{}]", serialized_log);
+        assert_eq!(second_batch, serialized_batch.as_bytes());
+        assert_eq!(aggregator.messages.len(), 0);
+    }
+
+    #[test]
+    fn test_get_batch_full_payload() {
+        let mut aggregator = Aggregator::new(2, 256, 1_024);
+        let log = IntakeLog {
+            message: LambdaMessage {
+                message: "test".to_string(),
+                lambda: Lambda {
+                    arn: "arn".to_string(),
+                    request_id: "request_id".to_string(),
+                },
+                timestamp: 0,
+                status: "status".to_string(),
+            },
+            hostname: "hostname".to_string(),
+            service: "service".to_string(),
+            tags: "tags".to_string(),
+            source: "source".to_string(),
+        };
+        // Add 2 logs
+        aggregator.add(log.clone());
+
+        // This log will exceed the max content size
+        let mut big_log = log.clone();
+        big_log.message.message = "a".repeat(256);
+        aggregator.add(big_log.clone());
+
+        let first_batch = aggregator.get_batch();
+        let serialized_log = serde_json::to_string(&log).unwrap();
+        let serialized_batch = format!("[{}]", serialized_log);
+        assert_eq!(first_batch, serialized_batch.as_bytes());
+
+        // I really doubt someone would make a log that is 5MB long,
+        // so we never send it, but we still keep it in the queue.
+        assert_eq!(aggregator.messages.len(), 1);
     }
 }

--- a/bottlecap/src/logs/aggregator.rs
+++ b/bottlecap/src/logs/aggregator.rs
@@ -145,7 +145,7 @@ mod tests {
                 message: "test".to_string(),
                 lambda: Lambda {
                     arn: "arn".to_string(),
-                    request_id: "request_id".to_string(),
+                    request_id: Some("request_id".to_string()),
                 },
                 timestamp: 0,
                 status: "status".to_string(),
@@ -182,7 +182,7 @@ mod tests {
                 message: "test".to_string(),
                 lambda: Lambda {
                     arn: "arn".to_string(),
-                    request_id: "request_id".to_string(),
+                    request_id: Some("request_id".to_string()),
                 },
                 timestamp: 0,
                 status: "status".to_string(),

--- a/bottlecap/src/logs/constants.rs
+++ b/bottlecap/src/logs/constants.rs
@@ -1,0 +1,10 @@
+/// Maximum content size per payload uncompressed in bytes,
+/// that the Datadog Logs API accepts.
+pub const MAX_CONTENT_SIZE_BYTES: usize = 5 * 1_024 * 1_024;
+
+/// Maximum size in bytes of a single log entry, before it
+/// gets truncated.
+pub const MAX_LOG_SIZE_BYTES: usize = 1_024 * 1_024;
+
+/// Maximum logs array size accepted.
+pub const MAX_BATCH_ENTRIES_SIZE: usize = 1000;

--- a/bottlecap/src/logs/datadog.rs
+++ b/bottlecap/src/logs/datadog.rs
@@ -1,8 +1,5 @@
 use std::error::Error;
-
 use tracing::{debug, error};
-
-use crate::logs::processor::IntakeLog;
 
 pub struct Api {
     api_key: String,
@@ -19,17 +16,18 @@ impl Api {
         }
     }
 
-    pub fn send(&self, logs: &Vec<IntakeLog>) -> Result<(), Box<dyn Error>> {
+    pub fn send(&self, data: &[u8]) -> Result<(), Box<dyn Error>> {
         let url = format!("https://http-intake.logs.{}/api/v2/logs", &self.site);
 
-        if !logs.is_empty() {
+        // It could be an empty JSON array: []
+        if data.len() > 2 {
             let resp: Result<ureq::Response, ureq::Error> = self
                 .ureq_agent
                 .post(&url)
                 .set("DD-API-KEY", &self.api_key)
                 .set("DD-PROTOCOL", "agent-json")
                 .set("Content-Type", "application/json")
-                .send_json(logs);
+                .send_bytes(data);
 
             match resp {
                 Ok(resp) => {

--- a/bottlecap/src/logs/mod.rs
+++ b/bottlecap/src/logs/mod.rs
@@ -1,4 +1,5 @@
 pub mod agent;
 pub mod aggregator;
+pub mod constants;
 pub mod datadog;
 pub mod processor;

--- a/bottlecap/src/logs/processor.rs
+++ b/bottlecap/src/logs/processor.rs
@@ -525,7 +525,7 @@ mod tests {
             tags: "test:tags".to_string(),
         };
         let serialized_log = format!("[{}]", serde_json::to_string(&log).unwrap());
-        assert_eq!(batch, serialized_log.as_bytes(),);
+        assert_eq!(batch, serialized_log.as_bytes());
     }
 
     #[test]

--- a/bottlecap/src/logs/processor.rs
+++ b/bottlecap/src/logs/processor.rs
@@ -509,25 +509,23 @@ mod tests {
 
         let mut aggregator_lock = aggregator.lock().unwrap();
         let batch = aggregator_lock.get_batch();
-        assert_eq!(batch.len(), 1);
-        assert_eq!(
-            batch[0],
-            IntakeLog {
-                message: LambdaMessage {
-                    message: "START RequestId: test-request-id Version: test".to_string(),
-                    lambda: Lambda {
-                        arn: "test-arn".to_string(),
-                        request_id: Some("test-request-id".to_string()),
-                    },
-                    timestamp: 1673061827000,
-                    status: "info".to_string(),
+        let log = IntakeLog {
+            message: LambdaMessage {
+                message: "START RequestId: test-request-id Version: test".to_string(),
+                lambda: Lambda {
+                    arn: "test-arn".to_string(),
+                    request_id: Some("test-request-id".to_string()),
                 },
-                hostname: "test-arn".to_string(),
-                source: "lambda".to_string(),
-                service: "test-service".to_string(),
-                tags: "test:tags".to_string(),
-            }
-        );
+                timestamp: 1673061827000,
+                status: "info".to_string(),
+            },
+            hostname: "test-arn".to_string(),
+            source: "lambda".to_string(),
+            service: "test-service".to_string(),
+            tags: "test:tags".to_string(),
+        };
+        let serialized_log = format!("[{}]", serde_json::to_string(&log).unwrap());
+        assert_eq!(batch, serialized_log.as_bytes(),);
     }
 
     #[test]
@@ -552,7 +550,7 @@ mod tests {
 
         let mut aggregator_lock = aggregator.lock().unwrap();
         let batch = aggregator_lock.get_batch();
-        assert_eq!(batch.len(), 0);
+        assert_eq!(batch, "[]".as_bytes());
     }
 
     #[test]
@@ -589,43 +587,41 @@ mod tests {
         // Verify aggregator logs
         let mut aggregator_lock = aggregator.lock().unwrap();
         let batch = aggregator_lock.get_batch();
-        assert_eq!(batch.len(), 2);
-        assert_eq!(
-            batch[0],
-            IntakeLog {
-                message: LambdaMessage {
-                    message: "START RequestId: test-request-id Version: test".to_string(),
-                    lambda: Lambda {
-                        arn: "test-arn".to_string(),
-                        request_id: Some("test-request-id".to_string()),
-                    },
-                    timestamp: 1673061827000,
-                    status: "info".to_string(),
+        let start_log = IntakeLog {
+            message: LambdaMessage {
+                message: "START RequestId: test-request-id Version: test".to_string(),
+                lambda: Lambda {
+                    arn: "test-arn".to_string(),
+                    request_id: Some("test-request-id".to_string()),
                 },
-                hostname: "test-arn".to_string(),
-                source: "lambda".to_string(),
-                service: "test-service".to_string(),
-                tags: "test:tags".to_string(),
-            }
-        );
-
-        assert_eq!(
-            batch[1],
-            IntakeLog {
-                message: LambdaMessage {
-                    message: "test-function".to_string(),
-                    lambda: Lambda {
-                        arn: "test-arn".to_string(),
-                        request_id: Some("test-request-id".to_string()),
-                    },
-                    timestamp: 1673061827000,
-                    status: "info".to_string(),
+                timestamp: 1673061827000,
+                status: "info".to_string(),
+            },
+            hostname: "test-arn".to_string(),
+            source: "lambda".to_string(),
+            service: "test-service".to_string(),
+            tags: "test:tags".to_string(),
+        };
+        let function_log = IntakeLog {
+            message: LambdaMessage {
+                message: "test-function".to_string(),
+                lambda: Lambda {
+                    arn: "test-arn".to_string(),
+                    request_id: Some("test-request-id".to_string()),
                 },
-                hostname: "test-arn".to_string(),
-                source: "lambda".to_string(),
-                service: "test-service".to_string(),
-                tags: "test:tags".to_string(),
-            }
+                timestamp: 1673061827000,
+                status: "info".to_string(),
+            },
+            hostname: "test-arn".to_string(),
+            source: "lambda".to_string(),
+            service: "test-service".to_string(),
+            tags: "test:tags".to_string(),
+        };
+        let serialized_log = format!(
+            "[{},{}]",
+            serde_json::to_string(&start_log).unwrap(),
+            serde_json::to_string(&function_log).unwrap()
         );
+        assert_eq!(batch, serialized_log.as_bytes());
     }
 }


### PR DESCRIPTION
# What?

Add batching logic for the logs `aggregator.rs`.

# How?

Using Datadog's HTTP Logs API limits described in the [docs](https://docs.datadoghq.com/api/latest/logs/?code-lang=curl).

# Motivation

We need it, or else logs are dropped if not sent correctly.
Also [SVLS-4837](https://datadoghq.atlassian.net/browse/SVLS-4837)

# Notes
- Might need to update the flushing mechanism too -> if there are multiple batches on shutdown, we need to try to flush everything on the queue.

[SVLS-4837]: https://datadoghq.atlassian.net/browse/SVLS-4837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ