### PR TITLE
Route all logs into the tracing subsystem

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -95,6 +95,8 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tracing",
+ "tracing-core",
+ "tracing-log",
  "tracing-subscriber",
  "ureq",
  "ustr",
@@ -812,12 +814,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.3"
+name = "tracing-log"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "serde",
+ "log",
+ "once_cell",
  "tracing-core",
 ]
 
@@ -830,13 +833,10 @@ dependencies = [
  "matchers",
  "once_cell",
  "regex",
- "serde",
- "serde_json",
  "sharded-slab",
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-serde",
 ]
 
 [[package]]

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -7,10 +7,12 @@ edition = "2021"
 
 [dependencies]
 figment = { version = "0.10.15", features = ["yaml", "env"] }
-log = "0.4.21"
 serde = { version = "1.0.197", features = ["derive"], default-features = false }
 tracing = {version = "0.1.40", default-features = false }
-tracing-subscriber = { version = "0.3.18", default-features = false, features = ["fmt", "env-filter", "json"] }
+tracing-core = { version = "0.1.32", default-features = false }
+tracing-subscriber = { version = "0.3.18", default-features = false, features = ["fmt", "env-filter"] }
+tracing-log = { version = "0.2.0", default-features = false, features = ["std", "log-tracer"] }
+log = { version = "0.4.21", default-features = false, features = [] }
 ustr = { version = "1.0.0", default-features = false }
 thiserror = { version = "1.0.58", default-features = false }
 fnv = { version = "1.0.7", default-features = false }
@@ -30,4 +32,3 @@ opt-level = "z"  # Optimize for size.
 lto = true
 codegen-units = 1
 strip = true
-

--- a/bottlecap/src/config.rs
+++ b/bottlecap/src/config.rs
@@ -150,9 +150,10 @@ pub enum ConfigError {
 
 pub fn get_config(config_directory: &Path) -> Result<Config, ConfigError> {
     let path = config_directory.join("datadog.yaml");
-    let figment = Figment::new().merge(Yaml::file(path));
-    // .merge(Env::prefixed("DATADOG_"))
-    // .merge(Env::prefixed("DD_"));
+    let figment = Figment::new()
+        .merge(Yaml::file(path))
+        .merge(Env::prefixed("DATADOG_"))
+        .merge(Env::prefixed("DD_"));
 
     let config = figment.extract().map_err(|err| match err.kind {
         figment::error::Kind::UnknownField(field, _) => ConfigError::UnsupportedField(field),

--- a/bottlecap/src/logger.rs
+++ b/bottlecap/src/logger.rs
@@ -1,31 +1,54 @@
-use crate::config::LogLevel;
-use log::{LevelFilter, Log, Metadata, Record};
+use std::fmt;
+use tracing_core::{Event, Subscriber};
+use tracing_subscriber::fmt::{
+    format::{self, FormatEvent, FormatFields},
+    FmtContext, FormattedFields,
+};
+use tracing_subscriber::registry::LookupSpan;
 
-pub struct SimpleLogger {}
+pub struct Formatter;
 
-impl SimpleLogger {
-    pub fn init(level: LogLevel) -> Result<(), log::SetLoggerError> {
-        let level = match level {
-            LogLevel::Trace => LevelFilter::Trace,
-            LogLevel::Debug => LevelFilter::Debug,
-            LogLevel::Info => LevelFilter::Info,
-            LogLevel::Warn => LevelFilter::Warn,
-            LogLevel::Error => LevelFilter::Error,
-        };
+impl<S, N> FormatEvent<S, N> for Formatter
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: format::Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        // Format values from the event's's metadata:
+        let metadata = event.metadata();
+        write!(&mut writer, "[{}] ", metadata.level())?;
 
-        log::set_max_level(level);
-        log::set_logger(&SimpleLogger {})
+        // Format all the spans in the event's span context.
+        if let Some(scope) = ctx.event_scope() {
+            for span in scope.from_root() {
+                write!(writer, "{}", span.name())?;
+
+                // `FormattedFields` is a formatted representation of the span's
+                // fields, which is stored in its extensions by the `fmt` layer's
+                // `new_span` method. The fields will have been formatted
+                // by the same field formatter that's provided to the event
+                // formatter in the `FmtContext`.
+                let ext = span.extensions();
+                let fields = &ext
+                    .get::<FormattedFields<N>>()
+                    .expect("will never be `None`");
+
+                // Skip formatting the fields if the span had no fields.
+                if !fields.is_empty() {
+                    write!(writer, "{{{}}}", fields)?;
+                }
+                write!(writer, ": ")?;
+            }
+        }
+
+        // Write fields on the event
+        ctx.field_format().format_fields(writer.by_ref(), event)?;
+
+        writeln!(writer)
     }
-}
-
-impl Log for SimpleLogger {
-    fn enabled(&self, _metadata: &Metadata) -> bool {
-        true
-    }
-
-    fn log(&self, record: &Record) {
-        println!("[{}] {}", record.level(), record.args());
-    }
-
-    fn flush(&self) {}
 }

--- a/bottlecap/src/main.rs
+++ b/bottlecap/src/main.rs
@@ -2,16 +2,16 @@
 mod config;
 mod event_bus;
 mod lifecycle;
-mod logger;
 mod logs;
 mod metrics;
 mod telemetry;
 use lifecycle::flush_control::FlushControl;
 use telemetry::listener::TelemetryListenerConfig;
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 use tracing_subscriber::EnvFilter;
 
 mod events;
+mod logger;
 
 use crate::event_bus::bus::EventBus;
 use crate::events::Event;
@@ -28,7 +28,6 @@ use std::io::Result;
 use std::sync::Arc;
 use std::{os::unix::process::CommandExt, path::Path, process::Command};
 
-use logger::SimpleLogger;
 use serde::Deserialize;
 
 const EXTENSION_HOST: &str = "0.0.0.0";
@@ -134,23 +133,43 @@ fn build_function_arn(account_id: &str, region: &str, function_name: &str) -> St
 }
 
 fn main() -> Result<()> {
-    tracing_subscriber::fmt()
-        .json()
-        .with_env_filter(EnvFilter::from_default_env())
-        .without_time()
-        .init();
-
     // First load the configuration
-    let lambda_directory = std::env::var("LAMBDA_TASK_ROOT").unwrap_or_default();
+    let lambda_directory = env::var("LAMBDA_TASK_ROOT")
+        .expect("unable to read environment variable: LAMBDA_TASK_ROOT");
     let config = match config::get_config(Path::new(&lambda_directory)) {
         Ok(config) => Arc::new(config),
         Err(e) => {
-            log::error!("Error loading configuration: {:?}", e);
+            // NOTE we must print here as the logging subsystem is not enabled yet.
+            println!("Error loading configuration: {:?}", e);
             let err = Command::new("/opt/datadog-agent-go").exec();
             panic!("Error starting the extension: {:?}", err);
         }
     };
-    SimpleLogger::init(config.log_level).expect("Error initializing logger");
+
+    // Bridge any `log` logs into the tracing subsystem. Note this is a global
+    // registration.
+    tracing_log::LogTracer::builder()
+        .with_max_level(config.log_level.as_level_filter())
+        .init()
+        .expect("failed to set up log bridge");
+
+    let subscriber = tracing_subscriber::fmt::Subscriber::builder()
+        .with_env_filter(
+            EnvFilter::try_new(config.log_level)
+                .expect("could not parse log level in configuration"),
+        )
+        .with_level(true)
+        .with_thread_names(false)
+        .with_thread_ids(false)
+        .with_line_number(false)
+        .with_file(false)
+        .with_target(false)
+        .without_time()
+        .event_format(logger::Formatter)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+
+    info!("logging subsystem enabled");
 
     let r = register().map_err(|e| Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
 
@@ -190,11 +209,9 @@ fn main() -> Result<()> {
                 deadline_ms,
                 invoked_function_arn,
             }) => {
-                log::info!(
+                info!(
                     "[bottlecap] Invoke event {}; deadline: {}, invoked_function_arn: {}",
-                    request_id,
-                    deadline_ms,
-                    invoked_function_arn
+                    request_id, deadline_ms, invoked_function_arn
                 );
             }
             Ok(NextEventResponse::Shutdown {

--- a/bottlecap/src/metrics/datadog.rs
+++ b/bottlecap/src/metrics/datadog.rs
@@ -2,7 +2,7 @@
 
 use serde::{Serialize, Serializer};
 use serde_json;
-use tracing::error;
+use tracing::{debug, error};
 use ureq;
 
 /// Interface for the DogStatsD metrics intake API.
@@ -42,7 +42,7 @@ impl DdApi {
     pub fn ship(&self, series: &Series) -> Result<(), ShipError> {
         // call inner_ship onto the runtime
         let body = serde_json::to_vec(&series)?;
-        log::info!("sending body: {:?}", &series);
+        debug!("sending body: {:?}", &series);
 
         let url = format!("https://api.{}/api/v2/series", &self.site);
         let resp: Result<ureq::Response, ureq::Error> = self

--- a/bottlecap/src/metrics/dogstatsd.rs
+++ b/bottlecap/src/metrics/dogstatsd.rs
@@ -1,5 +1,7 @@
 use std::sync::mpsc::Sender;
 
+use tracing::{error, info};
+
 use crate::config;
 use crate::events::{self, Event, MetricEvent};
 use crate::metrics::aggregator::Aggregator;
@@ -53,25 +55,24 @@ impl DogStatsD {
                 let (amt, src) = socket.recv_from(&mut buf).expect("didn't receive data");
                 let buf = &mut buf[..amt];
                 let msg = std::str::from_utf8(buf).expect("couldn't parse as string");
-                log::info!(
+                info!(
                     "received message: {} from {}, sending it to the bus",
-                    msg,
-                    src
+                    msg, src
                 );
                 let parsed_metric = match Metric::parse(msg) {
                     Ok(parsed_metric) => {
-                        log::info!("parsed metric: {:?}", parsed_metric);
+                        info!("parsed metric: {:?}", parsed_metric);
                         parsed_metric
                     }
                     Err(e) => {
-                        log::error!("failed to parse metric: {:?}\n message: {:?}", msg, e);
+                        error!("failed to parse metric: {:?}\n message: {:?}", msg, e);
                         continue;
                     }
                 };
                 let first_value = match parsed_metric.first_value() {
                     Ok(val) => val,
                     Err(e) => {
-                        log::error!("failed to parse metric: {:?}\n message: {:?}", msg, e);
+                        error!("failed to parse metric: {:?}\n message: {:?}", msg, e);
                         continue;
                     }
                 };
@@ -84,7 +85,7 @@ impl DogStatsD {
                     .lock()
                     .expect("lock poisoned")
                     .insert(&parsed_metric);
-                log::info!("inserted metric into aggregator");
+                info!("inserted metric into aggregator");
                 // Don't publish until after validation and adding metric_event to buff
                 let _ = event_bus.send(Event::Metric(metric_event)); // todo check the result
             }
@@ -109,10 +110,10 @@ impl DogStatsD {
         self.flush();
         match self.serve_handle.join() {
             Ok(_) => {
-                log::info!("DogStatsD thread has been shutdown");
+                info!("DogStatsD thread has been shutdown");
             }
             Err(e) => {
-                log::error!("Error shutting down the DogStatsD thread: {:?}", e);
+                error!("Error shutting down the DogStatsD thread: {:?}", e);
             }
         }
     }


### PR DESCRIPTION
This commit removes the `SimpleLogger` entirely, using the `tracing-log` crate to route any `log` logs into the tracing subsystem. This preserves debug logs et al from `ureq` and avoids contention between two logging subsystems. I've maintained the simple formatter previously used. I've also converted every `log::` call made by our code to the use of `tracing`, further reducing confusion between the two subsystems.

`json` feature is removed from tracing, removing a dependency on `serde_json` and `tracing-serde`. Small win.