### PR TITLE
Move `main.rs` into a binary path

### DIFF
--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -2,33 +2,33 @@
 name = "bottlecap"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
+chrono = { version = "0.4.38", features = ["serde"] }
+datadog-protos = { git = "https://github.com/DataDog/saluki/", version = "0.1.0", default-features = false }
+ddsketch-agent = { git = "https://github.com/DataDog/saluki/", version = "0.1.0", default-features = false }
 figment = { version = "0.10.15", features = ["yaml", "env"] }
-serde = { version = "1.0.197", features = ["derive"], default-features = false }
-tracing = {version = "0.1.40", default-features = false }
-tracing-core = { version = "0.1.32", default-features = false }
-tracing-subscriber = { version = "0.3.18", default-features = false, features = ["fmt", "env-filter"] }
-tracing-log = { version = "0.2.0", default-features = false, features = ["std", "log-tracer"] }
-log = { version = "0.4.21", default-features = false, features = [] }
-ustr = { version = "1.0.0", default-features = false }
-thiserror = { version = "1.0.58", default-features = false }
 fnv = { version = "1.0.7", default-features = false }
 hashbrown = { version = "0.14.3", default-features = false, features = ["inline-more"] }
-serde_json = { version = "1.0.116", features = ["alloc"], default-features = false }
-ureq = { version = "2.9.7", features = ["tls", "json"], default-features = false }
-chrono = { version = "0.4.38", features = ["serde"] }
-ddsketch-agent = { git = "https://github.com/DataDog/saluki/", version = "0.1.0", default-features = false }
-datadog-protos = { git = "https://github.com/DataDog/saluki/", version = "0.1.0", default-features = false }
+log = { version = "0.4.21", default-features = false, features = [] }
 protobuf = { version = "3.4.0", default-features = false }
-
+serde = { version = "1.0.197", features = ["derive"], default-features = false }
+serde_json = { version = "1.0.116", features = ["alloc"], default-features = false }
+thiserror = { version = "1.0.58", default-features = false }
+tracing = {version = "0.1.40", default-features = false }
+tracing-core = { version = "0.1.32", default-features = false }
+tracing-log = { version = "0.2.0", default-features = false, features = ["std", "log-tracer"] }
+tracing-subscriber = { version = "0.3.18", default-features = false, features = ["fmt", "env-filter"] }
+ureq = { version = "2.9.7", features = ["tls", "json"], default-features = false }
+ustr = { version = "1.0.0", default-features = false }
 
 [dev-dependencies]
 figment = { version = "0.10.15", features = ["yaml", "env", "test"] }
 proptest = "1.4.0"
 
+[[bin]]
+name = "bottlecap"
 
 [profile.release]
 opt-level = "z"  # Optimize for size.

--- a/bottlecap/src/lib.rs
+++ b/bottlecap/src/lib.rs
@@ -1,0 +1,34 @@
+///! Crate for the `bottlecap` project
+pub mod config;
+pub mod event_bus;
+pub mod events;
+pub mod lifecycle;
+pub mod logger;
+pub mod logs;
+pub mod metrics;
+pub mod telemetry;
+
+use std::{env, io};
+
+pub const EXTENSION_HOST: &str = "0.0.0.0";
+pub const EXTENSION_NAME: &str = "datadog-agent";
+pub const EXTENSION_FEATURES: &str = "accountId";
+pub const EXTENSION_NAME_HEADER: &str = "Lambda-Extension-Name";
+pub const EXTENSION_ID_HEADER: &str = "Lambda-Extension-Identifier";
+pub const EXTENSION_ACCEPT_FEATURE_HEADER: &str = "Lambda-Extension-Accept-Feature";
+pub const EXTENSION_ROUTE: &str = "2020-01-01/extension";
+
+// todo: make sure we can override those with environment variables
+pub const DOGSTATSD_PORT: u16 = 8185;
+
+pub const TELEMETRY_SUBSCRIPTION_ROUTE: &str = "2022-07-01/telemetry";
+pub const TELEMETRY_PORT: u16 = 8124;
+
+pub fn base_url(route: &str) -> io::Result<String> {
+    Ok(format!(
+        "http://{}/{}",
+        env::var("AWS_LAMBDA_RUNTIME_API")
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?,
+        route
+    ))
+}

--- a/bottlecap/src/lib.rs
+++ b/bottlecap/src/lib.rs
@@ -1,4 +1,4 @@
-///! Crate for the `bottlecap` project
+//! Crate for the `bottlecap` project
 pub mod config;
 pub mod event_bus;
 pub mod events;


### PR DESCRIPTION
This commit moves the `main.rs` down into `src/bin/bottlecap` allowing for code solely used by `bottlecap` binary to be migrated into that directory, for additional binaries to be created in the project on the same pattern and for the `bottlecap` crate to be built indepdently of its binary, useful for micro benchmarks and the like.

If it becomes desirable we can make a workspace with multiple sub-crates, in the manner of https://github.com/DataDog/single-machine-performance or https://github.com/DataDog/saluki/. I don't know that this is necessary right now.