### PR TITLE
Add continuous integration for bottlecap

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/rs_ci.yml
+++ b/.github/workflows/rs_ci.yml
@@ -1,0 +1,164 @@
+name: Continuous integration (Rust)
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+env:
+  PB_VERSION: 25.3
+  PB_URL: https://github.com/protocolbuffers/protobuf/releases/download
+  PB_TARGET: linux-x86_64
+
+jobs:
+  cancel-previous:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 3
+    steps:
+      - uses: styfle/cancel-workflow-action@0.12.1
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+          all_but_latest: true # can cancel workflows scheduled later
+
+  check:
+    name: Check
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+    steps:
+      - uses: actions/checkout@v4
+
+      # Install protobuf compiler for linux. The versions bundled with Ubuntu
+      # 20.04 and 22.04 are too old -- our messages require protobuf >= 3.15 --
+      # so we need to download a protoc binary instead.
+      - run: sudo apt-get update
+      - run: sudo apt-get install -y curl unzip cmake
+      - name: Install protobuf ${{ env.PB_VERSION }} compiler from binary for ${{ env.PB_TARGET }}
+        run: |
+          curl -LO "${{ env.PB_URL }}/v${{ env.PB_VERSION }}/protoc-${{ env.PB_VERSION }}-${{ env.PB_TARGET }}.zip"
+          unzip "protoc-${{ env.PB_VERSION }}-${{ env.PB_TARGET }}.zip" -d "$HOME/.local"
+          export PATH="$PATH:$HOME/.local/bin"
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.8.0
+        with:
+          cache: false
+      - uses: mozilla-actions/sccache-action@v0.0.4
+      - working-directory: ./bottlecap
+        run: cargo check --workspace
+
+  clippy_check:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+    steps:
+      - uses: actions/checkout@v4
+
+      # Install protobuf compiler for linux. The versions bundled with Ubuntu
+      # 20.04 and 22.04 are too old -- our messages require protobuf >= 3.15 --
+      # so we need to download a protoc binary instead.
+      - run: sudo apt-get update
+      - run: sudo apt-get install -y curl unzip cmake
+      - name: Install protobuf ${{ env.PB_VERSION }} compiler from binary for ${{ env.PB_TARGET }}
+        run: |
+          curl -LO "${{ env.PB_URL }}/v${{ env.PB_VERSION }}/protoc-${{ env.PB_VERSION }}-${{ env.PB_TARGET }}.zip"
+          unzip "protoc-${{ env.PB_VERSION }}-${{ env.PB_TARGET }}.zip" -d "$HOME/.local"
+          export PATH="$PATH:$HOME/.local/bin"
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.8.0
+        with:
+          components: clippy
+          cache: false
+      - uses: mozilla-actions/sccache-action@v0.0.4
+      - working-directory: ./bottlecap
+        run: cargo clippy --workspace --all-features
+
+  build_all:
+    name: Build All
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+    steps:
+      - uses: actions/checkout@v4
+
+      # Install protobuf compiler for linux. The versions bundled with Ubuntu
+      # 20.04 and 22.04 are too old -- our messages require protobuf >= 3.15 --
+      # so we need to download a protoc binary instead.
+      - run: sudo apt-get update
+      - run: sudo apt-get install -y curl unzip cmake
+      - name: Install protobuf ${{ env.PB_VERSION }} compiler from binary for ${{ env.PB_TARGET }}
+        run: |
+          curl -LO "${{ env.PB_URL }}/v${{ env.PB_VERSION }}/protoc-${{ env.PB_VERSION }}-${{ env.PB_TARGET }}.zip"
+          unzip "protoc-${{ env.PB_VERSION }}-${{ env.PB_TARGET }}.zip" -d "$HOME/.local"
+          export PATH="$PATH:$HOME/.local/bin"
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.8.0
+        with:
+          cache: false
+      - uses: mozilla-actions/sccache-action@v0.0.4
+      - working-directory: ./bottlecap
+        run: cargo build --all
+
+  test:
+    name: Test Suite
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+    steps:
+      - uses: actions/checkout@v4
+
+      # Install protobuf compiler for linux. The versions bundled with Ubuntu
+      # 20.04 and 22.04 are too old -- our messages require protobuf >= 3.15 --
+      # so we need to download a protoc binary instead.
+      - run: sudo apt-get update
+      - run: sudo apt-get install -y curl unzip cmake
+      - name: Install protobuf ${{ env.PB_VERSION }} compiler from binary for ${{ env.PB_TARGET }}
+        run: |
+          curl -LO "${{ env.PB_URL }}/v${{ env.PB_VERSION }}/protoc-${{ env.PB_VERSION }}-${{ env.PB_TARGET }}.zip"
+          unzip "protoc-${{ env.PB_VERSION }}-${{ env.PB_TARGET }}.zip" -d "$HOME/.local"
+          export PATH="$PATH:$HOME/.local/bin"
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.8.0
+        with:
+          cache: false
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9
+      - uses: mozilla-actions/sccache-action@v0.0.4
+      - working-directory: ./bottlecap
+        run: cargo nextest run --workspace
+
+  fmt:
+    name: Rustfmt
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.8.0
+        with:
+          components: rustfmt
+          cache: false
+      - working-directory: ./bottlecap
+        run: cargo fmt --all -- --check

--- a/bottlecap/src/events/mod.rs
+++ b/bottlecap/src/events/mod.rs
@@ -1,7 +1,7 @@
 use crate::telemetry::events::TelemetryEvent;
 
 #[derive(Debug)]
-
+#[allow(dead_code)] // TODO if this is ever used in practice remove this allow
 pub struct MetricEvent {
     name: String,
     value: f64,
@@ -18,5 +18,4 @@ impl MetricEvent {
 pub enum Event {
     Metric(MetricEvent),
     Telemetry(TelemetryEvent),
-    Unknown,
 }

--- a/bottlecap/src/main.rs
+++ b/bottlecap/src/main.rs
@@ -276,7 +276,6 @@ fn main() -> Result<()> {
                                 }
                             }
                         }
-                        _ => {}
                     }
                 } else {
                     error!("could not get the event");

--- a/bottlecap/src/metrics/constants.rs
+++ b/bottlecap/src/metrics/constants.rs
@@ -1,23 +1,5 @@
-/// The maximum number of bytes that a metric name will be.
-pub const MAX_METRIC_NAME_BYTES: usize = 128;
-
-/// The maximum values that a `Metric` may hold.
-pub const MAX_VALUES: usize = 8;
-
-/// The maximum number of bytes that a value string represenation will be.
-pub const MAX_VALUE_BYTES: usize = 32;
-
 /// The maximum tags that a `Metric` may hold.
 pub const MAX_TAGS: usize = 32;
-
-/// The maximum number of bytes that a tag key will be.
-pub const MAX_TAG_KEY_BYTES: usize = 64;
-
-/// The maximum number of bytes that a tag value will be.
-pub const MAX_TAG_VALUE_BYTES: usize = 64;
-
-/// The maximum number of bytes that a container ID will be.
-pub const MAX_CONTAINER_ID_BYTES: usize = 64;
 
 pub const CONTEXTS: usize = 1024;
 

--- a/bottlecap/src/metrics/dogstatsd.rs
+++ b/bottlecap/src/metrics/dogstatsd.rs
@@ -9,7 +9,6 @@ use crate::metrics::constants;
 use crate::metrics::datadog;
 use crate::metrics::metric::Metric;
 use std::sync::{Arc, Mutex};
-use tracing::debug;
 
 pub struct DogStatsD {
     serve_handle: std::thread::JoinHandle<()>,

--- a/bottlecap/src/metrics/metric.rs
+++ b/bottlecap/src/metrics/metric.rs
@@ -135,7 +135,6 @@ impl Metric {
     pub(crate) fn tags(&self) -> Vec<String> {
         self.tags
             .unwrap_or_default()
-            .to_string()
             .split(',')
             .map(|tag| tag.to_string())
             .collect()


### PR DESCRIPTION
This commit adds continous integration for the bottlecap sub-project, including a dependabot setup. This is patterned from the [single-machine-performance](https://github.com/DataDog/single-machine-performance) setup and includes the lessons learned over time in that repo, especially around caches.

Clippy dings are corrected, roughly, in this PR. I expect some conflicts with PR https://github.com/DataDog/datadog-lambda-extension/pull/227.