### PR TITLE
Add a rust-toolchain.toml to the project

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.78.0"
+components = [ "rustfmt", "clippy" ]
+profile = "minimal"


### PR DESCRIPTION
This commit is a follow-on from the work done in #228. This ensures that CI and dev environments have a consistent build toolchain.