### PR TITLE
Add clippy lints to the project, address some dings 

### DIFF
--- a/bottlecap/src/event_bus/bus.rs
+++ b/bottlecap/src/event_bus/bus.rs
@@ -4,17 +4,20 @@ use crate::events;
 
 use crate::event_bus::constants::MAX_EVENTS;
 
+#[allow(clippy::module_name_repetitions)]
 pub struct EventBus {
     tx: SyncSender<events::Event>,
     pub rx: mpsc::Receiver<events::Event>,
 }
 
 impl EventBus {
+    #[must_use]
     pub fn run() -> EventBus {
         let (tx, rx) = mpsc::sync_channel(MAX_EVENTS);
         EventBus { tx, rx }
     }
 
+    #[must_use]
     pub fn get_sender_copy(&self) -> SyncSender<events::Event> {
         self.tx.clone()
     }

--- a/bottlecap/src/event_bus/constants.rs
+++ b/bottlecap/src/event_bus/constants.rs
@@ -1,1 +1,1 @@
-pub const MAX_EVENTS: usize = 100;
+pub(crate) const MAX_EVENTS: usize = 100;

--- a/bottlecap/src/events/mod.rs
+++ b/bottlecap/src/events/mod.rs
@@ -9,6 +9,7 @@ pub struct MetricEvent {
 }
 
 impl MetricEvent {
+    #[must_use]
     pub fn new(name: String, value: f64, tags: Vec<String>) -> MetricEvent {
         MetricEvent { name, value, tags }
     }

--- a/bottlecap/src/lib.rs
+++ b/bottlecap/src/lib.rs
@@ -1,4 +1,22 @@
 //! Crate for the `bottlecap` project
+#![deny(clippy::all)]
+#![deny(clippy::pedantic)]
+#![deny(clippy::unwrap_used)]
+#![deny(unused_extern_crates)]
+#![deny(unused_allocation)]
+#![deny(unused_assignments)]
+#![deny(unused_comparisons)]
+#![deny(unreachable_pub)]
+#![deny(missing_copy_implementations)]
+// #![deny(missing_debug_implementations)]
+
+// TODO rmove these over time
+#![allow(missing_docs)]
+#![allow(clippy::missing_panics_doc)]
+#![allow(clippy::missing_errors_doc)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::needless_pass_by_value)]
+
 pub mod config;
 pub mod event_bus;
 pub mod events;
@@ -24,6 +42,12 @@ pub const DOGSTATSD_PORT: u16 = 8185;
 pub const TELEMETRY_SUBSCRIPTION_ROUTE: &str = "2022-07-01/telemetry";
 pub const TELEMETRY_PORT: u16 = 8124;
 
+/// Return the base URL for the lambda runtime API
+///
+/// # Errors
+///
+/// Function will error if the envar `AWS_LAMBDA_RUNTIME_API` is not set in the
+/// environment.
 pub fn base_url(route: &str) -> io::Result<String> {
     Ok(format!(
         "http://{}/{}",

--- a/bottlecap/src/lifecycle/flush_control.rs
+++ b/bottlecap/src/lifecycle/flush_control.rs
@@ -24,6 +24,7 @@ pub struct FlushControl {
 //  3. End strategy
 //      - Always flush at the end of the invocation
 impl FlushControl {
+    #[must_use]
     pub fn new(flush_strategy: FlushStrategy) -> FlushControl {
         FlushControl {
             flush_strategy,
@@ -78,21 +79,21 @@ mod tests {
     #[test]
     fn should_flush_default_end() {
         let mut flush_control = super::FlushControl::new(FlushStrategy::Default);
-        assert_eq!(flush_control.should_flush(), true);
+        assert!(flush_control.should_flush());
     }
     #[test]
     fn should_flush_default_periodic() {
         const LOOKBACK_COUNT: usize = 20;
         let mut flush_control = super::FlushControl::new(FlushStrategy::Default);
         for _ in 0..LOOKBACK_COUNT - 1 {
-            assert_eq!(flush_control.should_flush(), true);
+            assert!(flush_control.should_flush());
         }
-        assert_eq!(flush_control.should_flush(), false);
+        assert!(!flush_control.should_flush());
     }
     #[test]
     fn should_flush_end() {
         let mut flush_control = super::FlushControl::new(FlushStrategy::End);
-        assert_eq!(flush_control.should_flush(), true);
+        assert!(flush_control.should_flush());
     }
     #[test]
     fn should_flush_periodically() {
@@ -100,7 +101,7 @@ mod tests {
             super::FlushControl::new(FlushStrategy::Periodically(config::PeriodicStrategy {
                 interval: 1,
             }));
-        assert_eq!(flush_control.should_flush(), true);
-        assert_eq!(flush_control.should_flush(), false);
+        assert!(flush_control.should_flush());
+        assert!(!flush_control.should_flush());
     }
 }

--- a/bottlecap/src/logger.rs
+++ b/bottlecap/src/logger.rs
@@ -6,6 +6,7 @@ use tracing_subscriber::fmt::{
 };
 use tracing_subscriber::registry::LookupSpan;
 
+#[derive(Debug, Clone, Copy)]
 pub struct Formatter;
 
 impl<S, N> FormatEvent<S, N> for Formatter
@@ -40,7 +41,7 @@ where
 
                 // Skip formatting the fields if the span had no fields.
                 if !fields.is_empty() {
-                    write!(writer, "{{{}}}", fields)?;
+                    write!(writer, "{{{fields}}}")?;
                 }
                 write!(writer, ": ")?;
             }

--- a/bottlecap/src/logs/agent.rs
+++ b/bottlecap/src/logs/agent.rs
@@ -10,6 +10,7 @@ use crate::logs::datadog;
 use crate::logs::processor::Processor;
 use crate::telemetry::events::TelemetryEvent;
 
+#[allow(clippy::module_name_repetitions)]
 pub struct LogsAgent {
     dd_api: datadog::Api,
     aggregator: Arc<Mutex<Aggregator>>,
@@ -18,6 +19,7 @@ pub struct LogsAgent {
 }
 
 impl LogsAgent {
+    #[must_use]
     pub fn run(function_arn: &str, datadog_config: Arc<config::Config>) -> LogsAgent {
         let function_arn = function_arn.to_string();
         let aggregator: Arc<Mutex<Aggregator>> = Arc::new(Mutex::new(Aggregator::default()));
@@ -40,10 +42,10 @@ impl LogsAgent {
 
         let dd_api = datadog::Api::new(datadog_config.api_key.clone(), datadog_config.site.clone());
         LogsAgent {
-            tx,
-            join_handle,
             dd_api,
             aggregator,
+            tx,
+            join_handle,
         }
     }
 
@@ -67,7 +69,7 @@ impl LogsAgent {
         // Dropping this sender to help close the thread
         drop(self.tx);
         match self.join_handle.join() {
-            Ok(_) => {
+            Ok(()) => {
                 debug!("LogsAgent Message Receiver thread has been shutdown");
             }
             Err(e) => {

--- a/bottlecap/src/logs/datadog.rs
+++ b/bottlecap/src/logs/datadog.rs
@@ -11,6 +11,7 @@ pub struct Api {
 }
 
 impl Api {
+    #[must_use]
     pub fn new(api_key: String, site: String) -> Self {
         Api {
             api_key,

--- a/bottlecap/src/logs/processor.rs
+++ b/bottlecap/src/logs/processor.rs
@@ -24,6 +24,7 @@ pub struct LambdaMessage {
 }
 
 impl LambdaMessage {
+    #[must_use]
     pub fn new(
         message: String,
         request_id: Option<String>,
@@ -64,6 +65,7 @@ pub struct Processor {
 }
 
 impl Processor {
+    #[must_use]
     pub fn new(function_arn: String, datadog_config: Arc<config::Config>) -> Processor {
         let service = datadog_config.service.clone().unwrap_or_default();
         let tags = datadog_config.tags.clone().unwrap_or_default();
@@ -97,7 +99,7 @@ impl Processor {
                 let rv = runtime_version.unwrap_or("?".to_string()); // TODO: check what does containers display
                 let rv_arn = runtime_version_arn.unwrap_or("?".to_string()); // TODO: check what do containers display
                 Ok(LambdaMessage::new(
-                    format!("INIT_START Runtime Version: {} Runtime Version ARN: {}", rv, rv_arn),
+                    format!("INIT_START Runtime Version: {rv} Runtime Version ARN: {rv_arn}"),
                     None,
                     self.function_arn.clone(),
                     event.time.timestamp_millis(),
@@ -114,7 +116,7 @@ impl Processor {
 
                 let version = version.unwrap_or("$LATEST".to_string());
                 Ok(LambdaMessage::new(
-                    format!("START RequestId: {} Version: {}", request_id, version),
+                    format!("START RequestId: {request_id} Version: {version}"),
                     Some(request_id),
                     self.function_arn.clone(),
                     event.time.timestamp_millis(),
@@ -122,7 +124,7 @@ impl Processor {
             },
             TelemetryRecord::PlatformRuntimeDone { request_id , .. } => {  // TODO: check what to do with rest of the fields
                 Ok(LambdaMessage::new(
-                    format!("END RequestId: {}", request_id),
+                    format!("END RequestId: {request_id}"),
                     Some(request_id),
                     self.function_arn.clone(),
                     event.time.timestamp_millis(),
@@ -140,7 +142,7 @@ impl Processor {
 
                 let init_duration_ms = metrics.init_duration_ms;
                 if let Some(init_duration_ms) = init_duration_ms {
-                    message = format!("{} Init Duration: {} ms", message, init_duration_ms)
+                    message = format!("{message} Init Duration: {init_duration_ms} ms");
                 }
 
                 Ok(LambdaMessage::new(
@@ -204,7 +206,11 @@ impl Processor {
 
             // Process orphan logs, since we have a `request_id` now
             for mut orphan_log in self.orphan_logs.drain(..) {
-                orphan_log.message.lambda.request_id = Some(self.request_id.clone().unwrap());
+                orphan_log.message.lambda.request_id = Some(
+                    self.request_id
+                        .clone()
+                        .expect("unable to retrieve request ID"),
+                );
                 aggregator.add(orphan_log);
             }
         }
@@ -259,7 +265,7 @@ mod tests {
                         arn: "arn".to_string(),
                         request_id: None,
                     },
-                    timestamp: 1673061827000,
+                    timestamp: 1_673_061_827_000,
                     status: "info".to_string(),
                 },
         ),
@@ -276,7 +282,7 @@ mod tests {
                         arn: "arn".to_string(),
                         request_id: None,
                     },
-                    timestamp: 1673061827000,
+                    timestamp: 1_673_061_827_000,
                     status: "info".to_string(),
                 },
         ),
@@ -298,7 +304,7 @@ mod tests {
                         arn: "arn".to_string(),
                         request_id: None,
                     },
-                    timestamp: 1673061827000,
+                    timestamp: 1_673_061_827_000,
                     status: "info".to_string(),
                 },
         ),
@@ -318,7 +324,7 @@ mod tests {
                         arn: "arn".to_string(),
                         request_id: Some("test-request-id".to_string()),
                     },
-                    timestamp: 1673061827000,
+                    timestamp: 1_673_061_827_000,
                     status: "info".to_string(),
                 },
         ),
@@ -343,7 +349,7 @@ mod tests {
                         arn: "arn".to_string(),
                         request_id: Some("test-request-id".to_string()),
                     },
-                    timestamp: 1673061827000,
+                    timestamp: 1_673_061_827_000,
                     status: "info".to_string(),
                 },
         ),
@@ -372,7 +378,7 @@ mod tests {
                         arn: "arn".to_string(),
                         request_id: Some("test-request-id".to_string()),
                     },
-                    timestamp: 1673061827000,
+                    timestamp: 1_673_061_827_000,
                     status: "info".to_string(),
                 },
         ),
@@ -410,7 +416,7 @@ mod tests {
                         arn: "test-arn".to_string(),
                         request_id: Some("test-request-id".to_string()),
                     },
-                    timestamp: 1673061827000,
+                    timestamp: 1_673_061_827_000,
                     status: "info".to_string(),
                 },
                 hostname: "test-arn".to_string(),
@@ -519,7 +525,7 @@ mod tests {
                         arn: "test-arn".to_string(),
                         request_id: Some("test-request-id".to_string()),
                     },
-                    timestamp: 1673061827000,
+                    timestamp: 1_673_061_827_000,
                     status: "info".to_string(),
                 },
                 hostname: "test-arn".to_string(),
@@ -599,7 +605,7 @@ mod tests {
                         arn: "test-arn".to_string(),
                         request_id: Some("test-request-id".to_string()),
                     },
-                    timestamp: 1673061827000,
+                    timestamp: 1_673_061_827_000,
                     status: "info".to_string(),
                 },
                 hostname: "test-arn".to_string(),
@@ -618,7 +624,7 @@ mod tests {
                         arn: "test-arn".to_string(),
                         request_id: Some("test-request-id".to_string()),
                     },
-                    timestamp: 1673061827000,
+                    timestamp: 1_673_061_827_000,
                     status: "info".to_string(),
                 },
                 hostname: "test-arn".to_string(),

--- a/bottlecap/src/metrics/datadog.rs
+++ b/bottlecap/src/metrics/datadog.rs
@@ -7,7 +7,7 @@ use serde_json;
 use tracing::{debug, error};
 use ureq;
 
-/// Interface for the DogStatsD metrics intake API.
+/// Interface for the `DogStatsD` metrics intake API.
 #[derive(Debug)]
 pub struct DdApi {
     api_key: String,
@@ -32,6 +32,7 @@ pub enum ShipError {
 }
 
 impl DdApi {
+    #[must_use]
     pub fn new(api_key: String, site: String) -> Self {
         DdApi {
             api_key,
@@ -56,7 +57,9 @@ impl DdApi {
             Ok(_resp) => Ok(()),
             Err(ureq::Error::Status(code, response)) => Err(ShipError::Failure {
                 status: code,
-                body: response.into_string().unwrap(),
+                body: response
+                    .into_string()
+                    .expect("body could not be converted to string"),
             }),
             Err(e) => Err(ShipError::Failure {
                 status: 500,
@@ -91,7 +94,9 @@ impl DdApi {
             Ok(_resp) => Ok(()),
             Err(ureq::Error::Status(code, response)) => Err(ShipError::Failure {
                 status: code,
-                body: response.into_string().unwrap(),
+                body: response
+                    .into_string()
+                    .expect("body could not be converted to string"),
             }),
             Err(e) => Err(ShipError::Failure {
                 status: 500,

--- a/bottlecap/src/metrics/metric.rs
+++ b/bottlecap/src/metrics/metric.rs
@@ -22,7 +22,7 @@ pub enum Type {
 pub struct Metric {
     /// Name of the metric.
     ///
-    /// Never more bytes than constants::MAX_METRIC_NAME_BYTES,
+    /// Never more bytes than `constants::MAX_METRIC_NAME_BYTES`,
     /// enforced by construction. Note utf8 issues.
     pub(crate) name: Ustr,
     /// What kind/type of metric this is.
@@ -36,12 +36,12 @@ pub struct Metric {
     /// Parsing of the values to an integer type is deferred until the last
     /// moment.
     ///
-    /// Never longer than constants::MAX_VALUE_BYTES. Note utf8 issues.
+    /// Never longer than `constants::MAX_VALUE_BYTES`. Note utf8 issues.
     values: Ustr,
     /// Tags of the metric.
     ///
-    /// The key is never longer than constants::MAX_TAG_KEY_BYTES, the value
-    /// never more than constants::MAX_TAG_VALUE_BYTES. These are enforced by
+    /// The key is never longer than `constants::MAX_TAG_KEY_BYTES`, the value
+    /// never more than `constants::MAX_TAG_VALUE_BYTES`. These are enforced by
     /// the parser. We assume here that tags are not sent in random order by the
     /// clien or that, if they are, the API will tidy that up. That is `a:1,b:2`
     /// is a different tagset from `b:2,a:1`.
@@ -52,7 +52,7 @@ impl Metric {
     /// Parse a metric from given input.
     ///
     /// This function parses a passed `&str` into a `Metric`. We assume that
-    /// DogStatsD metrics must be utf8 and are not ascii or some other encoding.
+    /// `DogStatsD` metrics must be utf8 and are not ascii or some other encoding.
     ///
     /// # Errors
     ///
@@ -136,7 +136,7 @@ impl Metric {
         self.tags
             .unwrap_or_default()
             .split(',')
-            .map(|tag| tag.to_string())
+            .map(std::string::ToString::to_string)
             .collect()
     }
 
@@ -284,7 +284,7 @@ mod tests {
         ) {
             // If there is a ':' in the values we cannot distinguish where the
             // name and the first value are.
-            let value = values.split(":").next().unwrap();
+            let value = values.split(':').next().unwrap();
             let input = if let Some(ref tagset) = tagset {
                 format!("{name}{value}|{mtype}|#{tagset}")
             } else {
@@ -332,16 +332,16 @@ mod tests {
 
             for (k,v) in &tags {
                 tagset1.push_str(k);
-                tagset1.push_str(":");
+                tagset1.push(':');
                 tagset1.push_str(v);
-                tagset1.push_str(",");
+                tagset1.push(',');
             }
             tags.reverse();
             for (k,v) in &tags {
                 tagset2.push_str(k);
-                tagset2.push_str(":");
+                tagset2.push(':');
                 tagset2.push_str(v);
-                tagset2.push_str(",");
+                tagset2.push(',');
             }
             if !tags.is_empty() {
                 tagset1.pop();

--- a/bottlecap/src/telemetry/client.rs
+++ b/bottlecap/src/telemetry/client.rs
@@ -3,12 +3,14 @@ use tracing::debug;
 
 use crate::{base_url, EXTENSION_ID_HEADER, TELEMETRY_SUBSCRIPTION_ROUTE};
 
+#[allow(clippy::module_name_repetitions)]
 pub struct TelemetryApiClient {
     pub extension_id: String,
     pub port: u16,
 }
 
 impl TelemetryApiClient {
+    #[must_use]
     pub fn new(extension_id: String, port: u16) -> Self {
         TelemetryApiClient { extension_id, port }
     }

--- a/bottlecap/src/telemetry/events.rs
+++ b/bottlecap/src/telemetry/events.rs
@@ -12,7 +12,7 @@ pub struct TelemetryEvent {
     pub record: TelemetryRecord,
 }
 
-/// Record in a LambdaTelemetry entry
+/// Record in a `LambdaTelemetry` entry
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(tag = "type", content = "record", rename_all = "lowercase")]
 pub enum TelemetryRecord {
@@ -44,7 +44,7 @@ pub enum TelemetryRecord {
         phase: Option<InitPhase>,
         /// Status of initalization
         status: Status,
-        /// When the status = failure, the error_type describes what kind of error occurred
+        /// When the status = failure, the `error_type` describes what kind of error occurred
         error_type: Option<String>,
     },
 
@@ -74,7 +74,7 @@ pub enum TelemetryRecord {
         request_id: String,
         /// Status of the invocation
         status: Status,
-        /// When unsuccessful, the error_type describes what kind of error occurred
+        /// When unsuccessful, the `error_type` describes what kind of error occurred
         error_type: Option<String>,
         /// Metrics corresponding to the runtime
         metrics: Option<RuntimeDoneMetrics>,
@@ -87,7 +87,7 @@ pub enum TelemetryRecord {
         request_id: String,
         /// Status of the invocation
         status: Status,
-        /// When unsuccessful, the error_type describes what kind of error occurred
+        /// When unsuccessful, the `error_type` describes what kind of error occurred
         error_type: Option<String>,
         metrics: ReportMetrics,
     },
@@ -127,19 +127,19 @@ pub enum TelemetryRecord {
 }
 
 /// Type of Initialization
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum InitType {
     /// Initialised on demand
     OnDemand,
     /// Initialized to meet the provisioned concurrency
     ProvisionedConcurrency,
-    /// SnapStart
+    /// `SnapStart`
     SnapStart,
 }
 
 /// Phase in which initialization occurs
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum InitPhase {
     /// Initialization phase
@@ -149,7 +149,7 @@ pub enum InitPhase {
 }
 
 /// Status of invocation/initialization
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum Status {
     Success,
@@ -159,7 +159,7 @@ pub enum Status {
 }
 
 ///Init report metrics
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct InitReportMetrics {
     /// Duration of initialization
@@ -167,7 +167,7 @@ pub struct InitReportMetrics {
 }
 
 /// Runtime done metrics
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct RuntimeDoneMetrics {
     /// Duration in milliseconds
@@ -177,7 +177,7 @@ pub struct RuntimeDoneMetrics {
 }
 
 /// Report metrics
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ReportMetrics {
     /// Duration in milliseconds

--- a/bottlecap/src/telemetry/listener.rs
+++ b/bottlecap/src/telemetry/listener.rs
@@ -126,7 +126,7 @@ impl TelemetryListener {
     ///
     /// # Errors
     ///
-    /// Fucntion will error if the passed address cannot be bound.
+    /// Function will error if the passed address cannot be bound.
     pub fn run(
         config: &TelemetryListenerConfig,
         event_bus: SyncSender<events::Event>,

--- a/bottlecap/src/telemetry/listener.rs
+++ b/bottlecap/src/telemetry/listener.rs
@@ -20,6 +20,11 @@ const CR: u8 = b'\r';
 const LR: u8 = b'\n';
 
 impl HttpRequestParser {
+    /// Create a `HttpRequestParser` from passed `buf`
+    ///
+    /// # Errors
+    ///
+    /// Function will fail if parsing of headers or body in `buf` fail.
     pub fn from_buf(buf: &[u8]) -> Result<HttpRequestParser, Box<dyn Error>> {
         let mut parser = HttpRequestParser {
             headers: HashMap::new(),
@@ -106,6 +111,7 @@ impl HttpRequestParser {
     }
 }
 
+#[allow(clippy::module_name_repetitions)]
 pub struct TelemetryListener {
     join_handle: std::thread::JoinHandle<()>,
 }
@@ -116,13 +122,18 @@ pub struct TelemetryListenerConfig {
 }
 
 impl TelemetryListener {
+    /// Run the `TelemetryListener`
+    ///
+    /// # Errors
+    ///
+    /// Fucntion will error if the passed address cannot be bound.
     pub fn run(
         config: &TelemetryListenerConfig,
         event_bus: SyncSender<events::Event>,
     ) -> Result<TelemetryListener, Box<dyn Error>> {
         let addr = format!("{}:{}", &config.host, &config.port);
         let listener = TcpListener::bind(addr)?;
-        let buf: [u8; 262144] = [0; 256 * 1024]; // Using the default limit from AWS
+        let buf: [u8; 262_144] = [0; 256 * 1024]; // Using the default limit from AWS
 
         let join_handle = std::thread::spawn(move || {
             debug!("Initializing Telemetry Listener");
@@ -151,7 +162,7 @@ impl TelemetryListener {
 
     fn handle_stream(
         stream: &mut impl Read,
-        mut buf: [u8; 262144],
+        mut buf: [u8; 262_144],
         event_bus: SyncSender<events::Event>,
     ) -> Result<(), Box<dyn Error>> {
         // Read into buffer
@@ -175,7 +186,7 @@ impl TelemetryListener {
         request: Result<(), Box<dyn Error>>,
     ) -> Result<(), Box<dyn Error>> {
         match request {
-            Ok(_) => {
+            Ok(()) => {
                 stream.write(b"HTTP/1.1 200 OK\r\n\r\n")?;
             }
             Err(_) => {
@@ -187,7 +198,7 @@ impl TelemetryListener {
 
     pub fn shutdown(self) {
         match self.join_handle.join() {
-            Ok(_) => {
+            Ok(()) => {
                 debug!("Telemetry Listener thread has been shutdown");
             }
             Err(e) => {
@@ -295,7 +306,7 @@ mod tests {
             data: "POST /path HTTP/1.1\r\nContent-Length: 335\r\nHeader1: Value1\r\n\r\n[{\"time\":\"2024-04-25T17:35:59.944Z\",\"type\":\"platform.initStart\",\"record\":{\"initializationType\":\"on-demand\",\"phase\":\"init\",\"runtimeVersion\":\"nodejs:20.v22\",\"runtimeVersionArn\":\"arn:aws:lambda:us-east-1::runtime:da57c20c4b965d5b75540f6865a35fc8030358e33ec44ecfed33e90901a27a72\",\"functionName\":\"hello-world\",\"functionVersion\":\"$LATEST\"}}]".to_string().into_bytes(),
         };
         let (tx, rx) = std::sync::mpsc::sync_channel(3);
-        let buf = [0; 262144];
+        let buf = [0; 262_144];
         let result = TelemetryListener::handle_stream(&mut stream, buf, tx);
         let event = rx.recv().expect("No events received");
         let telemetry_event = match event {
@@ -308,8 +319,8 @@ mod tests {
         assert_eq!(telemetry_event.record, TelemetryRecord::PlatformInitStart {
             initialization_type: InitType::OnDemand,
             phase: InitPhase::Init,
-            runtime_version: Some("nodejs:20.v22".to_string()), 
-            runtime_version_arn: Some("arn:aws:lambda:us-east-1::runtime:da57c20c4b965d5b75540f6865a35fc8030358e33ec44ecfed33e90901a27a72".to_string()), 
+            runtime_version: Some("nodejs:20.v22".to_string()),
+            runtime_version_arn: Some("arn:aws:lambda:us-east-1::runtime:da57c20c4b965d5b75540f6865a35fc8030358e33ec44ecfed33e90901a27a72".to_string()),
         });
         assert!(result.is_ok());
     }


### PR DESCRIPTION
This commit is a follow-on from a suggestion I had early on to make aggressive use of clippy. The changes here are mostly mechanical however some needless clones, branches have been caught and fixed. I have left some of the precision loss dings in place, note that lib.rs has a section of lints explicitly allowed. These should be an hour or two to grind out. Some of these lints are also a matter of project taste. 

Assumes that https://github.com/DataDog/datadog-lambda-extension/pull/227 will merge. Should be rebased once that PR is in `main`.