### PR TITLE
Use jemalloc as global allocator

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "tikv-jemallocator",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -937,6 +938,26 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -23,6 +23,9 @@ tracing-subscriber = { version = "0.3.18", default-features = false, features = 
 ureq = { version = "2.9.7", features = ["tls", "json"], default-features = false }
 ustr = { version = "1.0.0", default-features = false }
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.5"
+
 [dev-dependencies]
 figment = { version = "0.10.15", features = ["yaml", "env", "test"] }
 proptest = "1.4.0"

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -36,6 +36,13 @@ use std::io::Result;
 use std::sync::Arc;
 use std::{os::unix::process::CommandExt, path::Path, process::Command};
 
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 #[derive(Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct RegisterResponse {


### PR DESCRIPTION
I imagine that the libc allocator in a lambda environment is glibc. While it's improved over time jemalloc is often a better all-around allocator. This commit also demonstrates how one sets a global allocator for a Rust project, park it in the `main.rs` of your binary and everything linked into that binary -- except for C code, as the allocator has a prefix and doesn't overwrite `malloc` et al -- uses the allocator.