### PR TITLE
feat(bottlecap): add logs processing rules

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -100,6 +100,7 @@ dependencies = [
  "log",
  "proptest",
  "protobuf",
+ "regex",
  "serde",
  "serde_json",
  "thiserror",

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -13,6 +13,7 @@ fnv = { version = "1.0.7", default-features = false }
 hashbrown = { version = "0.14.3", default-features = false, features = ["inline-more"] }
 log = { version = "0.4.21", default-features = false, features = [] }
 protobuf = { version = "3.4.0", default-features = false }
+regex = { version = "1.10.4", default-features = false }
 serde = { version = "1.0.197", features = ["derive"], default-features = false }
 serde_json = { version = "1.0.116", features = ["alloc"], default-features = false }
 thiserror = { version = "1.0.58", default-features = false }

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -304,25 +304,24 @@ pub mod tests {
     }
 
     #[test]
-    fn test_parse_logs_config_processing_rules() {
+    fn test_parse_logs_config_processing_rules_from_yaml() {
         figment::Jail::expect_with(|jail| {
             jail.clear_env();
             // TODO(duncanista): Update to use YAML configuration field `logs_config`: `processing_rules`: - ...
             jail.create_file(
                 "datadog.yaml",
                 r#"
-                logs_config:
-                    processing_rules:
-                     - type: exclude_at_match
-                       name: "exclude"
-                       pattern: "exclude"
-                     - type: include_at_match
-                       name: "include"
-                       pattern: "include"
-                     - type: mask_sequences
-                       name: "mask"
-                       pattern: "mask"
-                       replace_placeholder: "REPLACED"
+                logs_config_processing_rules:
+                   - type: exclude_at_match
+                     name: "exclude"
+                     pattern: "exclude"
+                   - type: include_at_match
+                     name: "include"
+                     pattern: "include"
+                   - type: mask_sequences
+                     name: "mask"
+                     pattern: "mask"
+                     replace_placeholder: "REPLACED"
             "#,
             )?;
             let config = get_config(Path::new("")).expect("should parse config");

--- a/bottlecap/src/config/processing_rule.rs
+++ b/bottlecap/src/config/processing_rule.rs
@@ -1,0 +1,49 @@
+use serde::{Deserialize, Deserializer};
+use serde_json::Value as JsonValue;
+
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Kind {
+    ExcludeAtMatch,
+    IncludeAtMatch,
+    MaskSequences,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+pub struct ProcessingRule {
+    #[serde(rename = "type")]
+    pub kind: Kind,
+    pub name: String,
+    pub pattern: String,
+    pub replace_placeholder: Option<String>,
+}
+
+pub fn deserialize_processing_rules<'de, D>(
+    deserializer: D,
+) -> Result<Option<Vec<ProcessingRule>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // Deserialize the JSON value using serde_json::Value
+    let value: JsonValue = Deserialize::deserialize(deserializer)?;
+
+    match value {
+        JsonValue::String(s) => {
+            let values: Vec<ProcessingRule> = serde_json::from_str(&s).map_err(|e| {
+                serde::de::Error::custom(format!("Failed to deserialize processing rules: {e}"))
+            })?;
+            Ok(Some(values))
+        }
+        JsonValue::Array(a) => {
+            let mut values = Vec::new();
+            for v in a {
+                let rule: ProcessingRule = serde_json::from_value(v).map_err(|e| {
+                    serde::de::Error::custom(format!("Failed to deserialize processing rule: {e}"))
+                })?;
+                values.push(rule);
+            }
+            Ok(Some(values))
+        }
+        _ => Ok(None),
+    }
+}


### PR DESCRIPTION
# What?

Allows users to set `DD_LOGS_PROCESSING_RULES` to mask, exclude, or include, logs as desired.

An AWS Lambda with the configuration:
```
DD_LOGS=PROCESSING_RULES=[{"type": "mask_sequences", "name": "masked_value", "replace_placeholder": "masked", "pattern": "my-secret-value"},{"type": "exclude_at_match", "name": "exclude", "pattern": "exclude-me"}]
```
And the following lines in the code:
```js
console.log('this is my secret value: my-secret-value')
console.log('this log will be excluded because it matches the pattern "exclude-me"');
```
Will produce the following logs:
<img width="674" alt="Screenshot 2024-05-15 at 1 50 52 PM" src="https://github.com/DataDog/datadog-lambda-extension/assets/30836115/9682feb5-a894-41d3-8502-6eb397663a8f">

Where the first log was masked, and the second one was omitted.

# How?

Created a new module under `config`: `processing_rules.rs` which should use a custom deserializer set on the config.

# Motivation
Parity and [SLS-4807](https://datadoghq.atlassian.net/browse/SVLS-4807)

# Notes:
1. This doesn't work properly for YAML, since the field is defined as:
```yaml
// ... rest of config
logs_config:
    processing_rules:
        - type: exclude_at_match
           name: "exclude"
           pattern: "exclude-me"
        // ... more rules
```
And our current config doesn't support nested fields. This will be an issue for `trace_config`, and others, in the future.