### PR TITLE
feat: Tags 4 logs

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -171,9 +171,16 @@ fn main() -> Result<()> {
         lambda::tags::FUNCTION_ARN_KEY.to_string(),
         function_arn.clone(),
     )]);
-    let tags_provider =
-        Arc::new(provider::Provider::new(Arc::clone(&config), "lambda".to_string(), &metadata_hash));
-    let logs_agent = LogsAgent::run(&function_arn, Arc::clone(&tags_provider), Arc::clone(&config));
+    let tags_provider = Arc::new(provider::Provider::new(
+        Arc::clone(&config),
+        "lambda".to_string(),
+        &metadata_hash,
+    ));
+    let logs_agent = LogsAgent::run(
+        &function_arn,
+        Arc::clone(&tags_provider),
+        Arc::clone(&config),
+    );
     let event_bus = EventBus::run();
     let dogstatsd_config = DogStatsDConfig {
         host: EXTENSION_HOST.to_string(),

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -27,7 +27,8 @@ use bottlecap::{
         self, client::TelemetryApiClient, events::TelemetryRecord, listener::TelemetryListener,
     },
     DOGSTATSD_PORT, EXTENSION_ACCEPT_FEATURE_HEADER, EXTENSION_FEATURES, EXTENSION_HOST,
-    EXTENSION_ID_HEADER, EXTENSION_NAME, EXTENSION_NAME_HEADER, EXTENSION_ROUTE, TELEMETRY_PORT,
+    EXTENSION_ID_HEADER, EXTENSION_NAME, EXTENSION_NAME_HEADER, EXTENSION_ROUTE,
+    LAMBDA_RUNTIME_SLUG, TELEMETRY_PORT,
 };
 
 use serde::Deserialize;
@@ -173,7 +174,7 @@ fn main() -> Result<()> {
     )]);
     let tags_provider = Arc::new(provider::Provider::new(
         Arc::clone(&config),
-        "lambda".to_string(),
+        LAMBDA_RUNTIME_SLUG.to_string(),
         &metadata_hash,
     ));
     let logs_agent = LogsAgent::run(

--- a/bottlecap/src/lib.rs
+++ b/bottlecap/src/lib.rs
@@ -36,6 +36,7 @@ pub const EXTENSION_NAME_HEADER: &str = "Lambda-Extension-Name";
 pub const EXTENSION_ID_HEADER: &str = "Lambda-Extension-Identifier";
 pub const EXTENSION_ACCEPT_FEATURE_HEADER: &str = "Lambda-Extension-Accept-Feature";
 pub const EXTENSION_ROUTE: &str = "2020-01-01/extension";
+pub const LAMBDA_RUNTIME_SLUG: &str = "lambda";
 
 // todo: make sure we can override those with environment variables
 pub const DOGSTATSD_PORT: u16 = 8185;

--- a/bottlecap/src/logs/agent.rs
+++ b/bottlecap/src/logs/agent.rs
@@ -5,10 +5,10 @@ use std::thread;
 use tracing::{debug, error};
 
 use crate::config;
-use crate::tags::provider;
 use crate::logs::aggregator::Aggregator;
 use crate::logs::datadog;
 use crate::logs::processor::Processor;
+use crate::tags::provider;
 use crate::telemetry::events::TelemetryEvent;
 
 #[allow(clippy::module_name_repetitions)]
@@ -21,10 +21,15 @@ pub struct LogsAgent {
 
 impl LogsAgent {
     #[must_use]
-    pub fn run(function_arn: &str, tags_provider: Arc<provider::Provider>, datadog_config: Arc<config::Config>) -> LogsAgent {
+    pub fn run(
+        function_arn: &str,
+        tags_provider: Arc<provider::Provider>,
+        datadog_config: Arc<config::Config>,
+    ) -> LogsAgent {
         let function_arn = function_arn.to_string();
         let aggregator: Arc<Mutex<Aggregator>> = Arc::new(Mutex::new(Aggregator::default()));
-        let mut processor: Processor = Processor::new(function_arn, tags_provider, Arc::clone(&datadog_config));
+        let mut processor: Processor =
+            Processor::new(function_arn, tags_provider, Arc::clone(&datadog_config));
 
         let cloned_aggregator = aggregator.clone();
 

--- a/bottlecap/src/logs/agent.rs
+++ b/bottlecap/src/logs/agent.rs
@@ -5,6 +5,7 @@ use std::thread;
 use tracing::{debug, error};
 
 use crate::config;
+use crate::tags::provider;
 use crate::logs::aggregator::Aggregator;
 use crate::logs::datadog;
 use crate::logs::processor::Processor;
@@ -20,10 +21,10 @@ pub struct LogsAgent {
 
 impl LogsAgent {
     #[must_use]
-    pub fn run(function_arn: &str, datadog_config: Arc<config::Config>) -> LogsAgent {
+    pub fn run(function_arn: &str, tags_provider: Arc<provider::Provider>, datadog_config: Arc<config::Config>) -> LogsAgent {
         let function_arn = function_arn.to_string();
         let aggregator: Arc<Mutex<Aggregator>> = Arc::new(Mutex::new(Aggregator::default()));
-        let mut processor: Processor = Processor::new(function_arn, Arc::clone(&datadog_config));
+        let mut processor: Processor = Processor::new(function_arn, tags_provider, Arc::clone(&datadog_config));
 
         let cloned_aggregator = aggregator.clone();
 

--- a/bottlecap/src/logs/processor.rs
+++ b/bottlecap/src/logs/processor.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex};
 use serde::Serialize;
 
 use crate::config;
+use crate::tags::provider;
 use crate::logs::aggregator::Aggregator;
 use crate::telemetry::events::{TelemetryEvent, TelemetryRecord};
 
@@ -66,9 +67,9 @@ pub struct Processor {
 
 impl Processor {
     #[must_use]
-    pub fn new(function_arn: String, datadog_config: Arc<config::Config>) -> Processor {
+    pub fn new(function_arn: String, tags_provider: Arc<provider::Provider>, datadog_config: Arc<config::Config>) -> Processor {
         let service = datadog_config.service.clone().unwrap_or_default();
-        let tags = datadog_config.tags.clone().unwrap_or_default();
+        let tags = tags_provider.get_tags_string();
         Processor {
             function_arn,
             request_id: None,
@@ -220,6 +221,8 @@ impl Processor {
 #[cfg(test)]
 mod tests {
     use crate::logs::aggregator::Aggregator;
+    use std::collections::hash_map::HashMap;
+    use crate::tags::provider;
     use crate::telemetry::events::{
         InitPhase, InitType, ReportMetrics, RuntimeDoneMetrics, Status,
     };
@@ -235,8 +238,17 @@ mod tests {
                 fn $name() {
                     let (input, expected): (&TelemetryEvent, LambdaMessage) = $value;
 
+                    let config = Arc::new(config::Config {
+                        service: Some("test-service".to_string()),
+                        tags: Some("test:tags".to_string()),
+                        ..config::Config::default()
+                    });
+
+                    let tags_provider = Arc::new(provider::Provider::new(Arc::clone(&config), "lambda".to_string(), &HashMap::new()));
+
                     let mut processor = Processor::new(
                         "arn".to_string(),
+                        tags_provider,
                         Arc::new(config::Config {
                             service: Some("test-service".to_string()),
                             tags: Some("test:tag,env:test".to_string()),
@@ -387,13 +399,17 @@ mod tests {
     // get_intake_log
     #[test]
     fn test_get_intake_log() {
+        let config = Arc::new(config::Config {
+            service: Some("test-service".to_string()),
+            tags: Some("test:tags".to_string()),
+            ..config::Config::default()
+        });
+
+        let tags_provider = Arc::new(provider::Provider::new(Arc::clone(&config), "lambda".to_string(), &HashMap::new()));
         let mut processor = Processor::new(
             "test-arn".to_string(),
-            Arc::new(config::Config {
-                service: Some("test-service".to_string()),
-                tags: Some("test:tags".to_string()),
-                ..config::Config::default()
-            }),
+            tags_provider,
+            Arc::clone(&config),
         );
 
         let event = TelemetryEvent {
@@ -407,35 +423,37 @@ mod tests {
         let lambda_message = processor.get_lambda_message(event.clone()).unwrap();
         let intake_log = processor.get_intake_log(lambda_message).unwrap();
 
+        assert_eq!(intake_log.source, "lambda".to_string());
+        assert_eq!(intake_log.hostname, "test-arn".to_string());
+        assert_eq!(intake_log.service, "test-service".to_string());
+        assert!(intake_log.tags.contains("test:tags"));
         assert_eq!(
-            intake_log,
-            IntakeLog {
-                message: LambdaMessage {
-                    message: "START RequestId: test-request-id Version: test".to_string(),
-                    lambda: Lambda {
-                        arn: "test-arn".to_string(),
-                        request_id: Some("test-request-id".to_string()),
-                    },
-                    timestamp: 1_673_061_827_000,
-                    status: "info".to_string(),
+            intake_log.message,
+            LambdaMessage {
+                message: "START RequestId: test-request-id Version: test".to_string(),
+                lambda: Lambda {
+                    arn: "test-arn".to_string(),
+                    request_id: Some("test-request-id".to_string()),
                 },
-                hostname: "test-arn".to_string(),
-                source: "lambda".to_string(),
-                service: "test-service".to_string(),
-                tags: "test:tags".to_string(),
-            }
+                timestamp: 1_673_061_827_000,
+                status: "info".to_string(),
+            },
         );
     }
 
     #[test]
     fn test_get_intake_log_errors_with_orphan() {
+        let config = Arc::new(config::Config {
+            service: Some("test-service".to_string()),
+            tags: Some("test:tags".to_string()),
+            ..config::Config::default()
+        });
+
+        let tags_provider = Arc::new(provider::Provider::new(Arc::clone(&config), "lambda".to_string(), &HashMap::new()));
         let mut processor = Processor::new(
             "test-arn".to_string(),
-            Arc::new(config::Config {
-                service: Some("test-service".to_string()),
-                tags: Some("test:tags".to_string()),
-                ..config::Config::default()
-            }),
+            tags_provider,
+            Arc::clone(&config),
         );
 
         let event = TelemetryEvent {
@@ -456,15 +474,18 @@ mod tests {
 
     #[test]
     fn test_get_intake_log_no_orphan_after_seeing_request_id() {
+        let config = Arc::new(config::Config {
+            service: Some("test-service".to_string()),
+            tags: Some("test:tags".to_string()),
+            ..config::Config::default()
+        });
+
+        let tags_provider = Arc::new(provider::Provider::new(Arc::clone(&config), "lambda".to_string(), &HashMap::new()));
         let mut processor = Processor::new(
             "test-arn".to_string(),
-            Arc::new(config::Config {
-                service: Some("test-service".to_string()),
-                tags: Some("test:tags".to_string()),
-                ..config::Config::default()
-            }),
+            tags_provider,
+            Arc::clone(&config),
         );
-
         let start_event = TelemetryEvent {
             time: Utc.with_ymd_and_hms(2023, 1, 7, 3, 23, 47).unwrap(),
             record: TelemetryRecord::PlatformStart {
@@ -494,13 +515,17 @@ mod tests {
     #[test]
     fn test_process() {
         let aggregator = Arc::new(Mutex::new(Aggregator::default()));
+        let config = Arc::new(config::Config {
+            service: Some("test-service".to_string()),
+            tags: Some("test:tags".to_string()),
+            ..config::Config::default()
+        });
+
+        let tags_provider = Arc::new(provider::Provider::new(Arc::clone(&config), "lambda".to_string(), &HashMap::new()));
         let mut processor = Processor::new(
             "test-arn".to_string(),
-            Arc::new(config::Config {
-                service: Some("test-service".to_string()),
-                tags: Some("test:tags".to_string()),
-                ..config::Config::default()
-            }),
+            Arc::clone(&tags_provider),
+            Arc::clone(&config),
         );
 
         let event = TelemetryEvent {
@@ -528,7 +553,7 @@ mod tests {
             hostname: "test-arn".to_string(),
             source: "lambda".to_string(),
             service: "test-service".to_string(),
-            tags: "test:tags".to_string(),
+            tags: tags_provider.get_tags_string(),
         };
         let serialized_log = format!("[{}]", serde_json::to_string(&log).unwrap());
         assert_eq!(batch, serialized_log.as_bytes());
@@ -537,13 +562,17 @@ mod tests {
     #[test]
     fn test_process_log_with_no_request_id() {
         let aggregator = Arc::new(Mutex::new(Aggregator::default()));
+        let config = Arc::new(config::Config {
+            service: Some("test-service".to_string()),
+            tags: Some("test:tags".to_string()),
+            ..config::Config::default()
+        });
+
+        let tags_provider = Arc::new(provider::Provider::new(Arc::clone(&config), "lambda".to_string(), &HashMap::new()));
         let mut processor = Processor::new(
             "test-arn".to_string(),
-            Arc::new(config::Config {
-                service: Some("test-service".to_string()),
-                tags: Some("test:tags".to_string()),
-                ..config::Config::default()
-            }),
+            tags_provider,
+            Arc::clone(&config),
         );
 
         let event = TelemetryEvent {
@@ -562,13 +591,17 @@ mod tests {
     #[test]
     fn test_process_logs_after_seeing_request_id() {
         let aggregator = Arc::new(Mutex::new(Aggregator::default()));
+        let config = Arc::new(config::Config {
+            service: Some("test-service".to_string()),
+            tags: Some("test:tags".to_string()),
+            ..config::Config::default()
+        });
+
+        let tags_provider = Arc::new(provider::Provider::new(Arc::clone(&config), "lambda".to_string(), &HashMap::new()));
         let mut processor = Processor::new(
             "test-arn".to_string(),
-            Arc::new(config::Config {
-                service: Some("test-service".to_string()),
-                tags: Some("test:tags".to_string()),
-                ..config::Config::default()
-            }),
+            Arc::clone(&tags_provider),
+            Arc::clone(&config),
         );
 
         let start_event = TelemetryEvent {
@@ -606,7 +639,7 @@ mod tests {
             hostname: "test-arn".to_string(),
             source: "lambda".to_string(),
             service: "test-service".to_string(),
-            tags: "test:tags".to_string(),
+            tags: tags_provider.get_tags_string(),
         };
         let function_log = IntakeLog {
             message: LambdaMessage {
@@ -621,7 +654,7 @@ mod tests {
             hostname: "test-arn".to_string(),
             source: "lambda".to_string(),
             service: "test-service".to_string(),
-            tags: "test:tags".to_string(),
+            tags: tags_provider.get_tags_string(),
         };
         let serialized_log = format!(
             "[{},{}]",

--- a/bottlecap/src/logs/processor.rs
+++ b/bottlecap/src/logs/processor.rs
@@ -4,8 +4,8 @@ use std::sync::{Arc, Mutex};
 use serde::Serialize;
 
 use crate::config;
-use crate::tags::provider;
 use crate::logs::aggregator::Aggregator;
+use crate::tags::provider;
 use crate::telemetry::events::{TelemetryEvent, TelemetryRecord};
 
 const LOGS_SOURCE: &str = "lambda";
@@ -67,7 +67,11 @@ pub struct Processor {
 
 impl Processor {
     #[must_use]
-    pub fn new(function_arn: String, tags_provider: Arc<provider::Provider>, datadog_config: Arc<config::Config>) -> Processor {
+    pub fn new(
+        function_arn: String,
+        tags_provider: Arc<provider::Provider>,
+        datadog_config: Arc<config::Config>,
+    ) -> Processor {
         let service = datadog_config.service.clone().unwrap_or_default();
         let tags = tags_provider.get_tags_string();
         Processor {
@@ -221,11 +225,11 @@ impl Processor {
 #[cfg(test)]
 mod tests {
     use crate::logs::aggregator::Aggregator;
-    use std::collections::hash_map::HashMap;
     use crate::tags::provider;
     use crate::telemetry::events::{
         InitPhase, InitType, ReportMetrics, RuntimeDoneMetrics, Status,
     };
+    use std::collections::hash_map::HashMap;
 
     use super::*;
 
@@ -405,12 +409,13 @@ mod tests {
             ..config::Config::default()
         });
 
-        let tags_provider = Arc::new(provider::Provider::new(Arc::clone(&config), "lambda".to_string(), &HashMap::new()));
-        let mut processor = Processor::new(
-            "test-arn".to_string(),
-            tags_provider,
+        let tags_provider = Arc::new(provider::Provider::new(
             Arc::clone(&config),
-        );
+            "lambda".to_string(),
+            &HashMap::new(),
+        ));
+        let mut processor =
+            Processor::new("test-arn".to_string(), tags_provider, Arc::clone(&config));
 
         let event = TelemetryEvent {
             time: Utc.with_ymd_and_hms(2023, 1, 7, 3, 23, 47).unwrap(),
@@ -449,12 +454,13 @@ mod tests {
             ..config::Config::default()
         });
 
-        let tags_provider = Arc::new(provider::Provider::new(Arc::clone(&config), "lambda".to_string(), &HashMap::new()));
-        let mut processor = Processor::new(
-            "test-arn".to_string(),
-            tags_provider,
+        let tags_provider = Arc::new(provider::Provider::new(
             Arc::clone(&config),
-        );
+            "lambda".to_string(),
+            &HashMap::new(),
+        ));
+        let mut processor =
+            Processor::new("test-arn".to_string(), tags_provider, Arc::clone(&config));
 
         let event = TelemetryEvent {
             time: Utc.with_ymd_and_hms(2023, 1, 7, 3, 23, 47).unwrap(),
@@ -480,12 +486,13 @@ mod tests {
             ..config::Config::default()
         });
 
-        let tags_provider = Arc::new(provider::Provider::new(Arc::clone(&config), "lambda".to_string(), &HashMap::new()));
-        let mut processor = Processor::new(
-            "test-arn".to_string(),
-            tags_provider,
+        let tags_provider = Arc::new(provider::Provider::new(
             Arc::clone(&config),
-        );
+            "lambda".to_string(),
+            &HashMap::new(),
+        ));
+        let mut processor =
+            Processor::new("test-arn".to_string(), tags_provider, Arc::clone(&config));
         let start_event = TelemetryEvent {
             time: Utc.with_ymd_and_hms(2023, 1, 7, 3, 23, 47).unwrap(),
             record: TelemetryRecord::PlatformStart {
@@ -521,7 +528,11 @@ mod tests {
             ..config::Config::default()
         });
 
-        let tags_provider = Arc::new(provider::Provider::new(Arc::clone(&config), "lambda".to_string(), &HashMap::new()));
+        let tags_provider = Arc::new(provider::Provider::new(
+            Arc::clone(&config),
+            "lambda".to_string(),
+            &HashMap::new(),
+        ));
         let mut processor = Processor::new(
             "test-arn".to_string(),
             Arc::clone(&tags_provider),
@@ -568,12 +579,13 @@ mod tests {
             ..config::Config::default()
         });
 
-        let tags_provider = Arc::new(provider::Provider::new(Arc::clone(&config), "lambda".to_string(), &HashMap::new()));
-        let mut processor = Processor::new(
-            "test-arn".to_string(),
-            tags_provider,
+        let tags_provider = Arc::new(provider::Provider::new(
             Arc::clone(&config),
-        );
+            "lambda".to_string(),
+            &HashMap::new(),
+        ));
+        let mut processor =
+            Processor::new("test-arn".to_string(), tags_provider, Arc::clone(&config));
 
         let event = TelemetryEvent {
             time: Utc.with_ymd_and_hms(2023, 1, 7, 3, 23, 47).unwrap(),
@@ -597,7 +609,11 @@ mod tests {
             ..config::Config::default()
         });
 
-        let tags_provider = Arc::new(provider::Provider::new(Arc::clone(&config), "lambda".to_string(), &HashMap::new()));
+        let tags_provider = Arc::new(provider::Provider::new(
+            Arc::clone(&config),
+            "lambda".to_string(),
+            &HashMap::new(),
+        ));
         let mut processor = Processor::new(
             "test-arn".to_string(),
             Arc::clone(&tags_provider),

--- a/bottlecap/src/logs/processor.rs
+++ b/bottlecap/src/logs/processor.rs
@@ -7,8 +7,7 @@ use crate::config;
 use crate::logs::aggregator::Aggregator;
 use crate::tags::provider;
 use crate::telemetry::events::{TelemetryEvent, TelemetryRecord};
-
-const LOGS_SOURCE: &str = "lambda";
+use crate::LAMBDA_RUNTIME_SLUG;
 
 #[derive(Serialize, Debug, Clone, PartialEq)]
 pub struct Lambda {
@@ -181,7 +180,7 @@ impl Processor {
 
         let log = IntakeLog {
             hostname: self.function_arn.clone(),
-            source: LOGS_SOURCE.to_string(),
+            source: LAMBDA_RUNTIME_SLUG.to_string(),
             service: self.service.clone(),
             tags: self.tags.clone(),
             message: lambda_message,
@@ -229,6 +228,7 @@ mod tests {
     use crate::telemetry::events::{
         InitPhase, InitType, ReportMetrics, RuntimeDoneMetrics, Status,
     };
+    use crate::LAMBDA_RUNTIME_SLUG;
     use std::collections::hash_map::HashMap;
 
     use super::*;
@@ -248,7 +248,7 @@ mod tests {
                         ..config::Config::default()
                     });
 
-                    let tags_provider = Arc::new(provider::Provider::new(Arc::clone(&config), "lambda".to_string(), &HashMap::new()));
+                    let tags_provider = Arc::new(provider::Provider::new(Arc::clone(&config), LAMBDA_RUNTIME_SLUG.to_string(), &HashMap::new()));
 
                     let mut processor = Processor::new(
                         "arn".to_string(),
@@ -411,7 +411,7 @@ mod tests {
 
         let tags_provider = Arc::new(provider::Provider::new(
             Arc::clone(&config),
-            "lambda".to_string(),
+            LAMBDA_RUNTIME_SLUG.to_string(),
             &HashMap::new(),
         ));
         let mut processor =
@@ -428,7 +428,7 @@ mod tests {
         let lambda_message = processor.get_lambda_message(event.clone()).unwrap();
         let intake_log = processor.get_intake_log(lambda_message).unwrap();
 
-        assert_eq!(intake_log.source, "lambda".to_string());
+        assert_eq!(intake_log.source, LAMBDA_RUNTIME_SLUG.to_string());
         assert_eq!(intake_log.hostname, "test-arn".to_string());
         assert_eq!(intake_log.service, "test-service".to_string());
         assert!(intake_log.tags.contains("test:tags"));
@@ -456,7 +456,7 @@ mod tests {
 
         let tags_provider = Arc::new(provider::Provider::new(
             Arc::clone(&config),
-            "lambda".to_string(),
+            LAMBDA_RUNTIME_SLUG.to_string(),
             &HashMap::new(),
         ));
         let mut processor =
@@ -488,7 +488,7 @@ mod tests {
 
         let tags_provider = Arc::new(provider::Provider::new(
             Arc::clone(&config),
-            "lambda".to_string(),
+            LAMBDA_RUNTIME_SLUG.to_string(),
             &HashMap::new(),
         ));
         let mut processor =
@@ -530,7 +530,7 @@ mod tests {
 
         let tags_provider = Arc::new(provider::Provider::new(
             Arc::clone(&config),
-            "lambda".to_string(),
+            LAMBDA_RUNTIME_SLUG.to_string(),
             &HashMap::new(),
         ));
         let mut processor = Processor::new(
@@ -562,7 +562,7 @@ mod tests {
                 status: "info".to_string(),
             },
             hostname: "test-arn".to_string(),
-            source: "lambda".to_string(),
+            source: LAMBDA_RUNTIME_SLUG.to_string(),
             service: "test-service".to_string(),
             tags: tags_provider.get_tags_string(),
         };
@@ -581,7 +581,7 @@ mod tests {
 
         let tags_provider = Arc::new(provider::Provider::new(
             Arc::clone(&config),
-            "lambda".to_string(),
+            LAMBDA_RUNTIME_SLUG.to_string(),
             &HashMap::new(),
         ));
         let mut processor =
@@ -611,7 +611,7 @@ mod tests {
 
         let tags_provider = Arc::new(provider::Provider::new(
             Arc::clone(&config),
-            "lambda".to_string(),
+            LAMBDA_RUNTIME_SLUG.to_string(),
             &HashMap::new(),
         ));
         let mut processor = Processor::new(
@@ -653,7 +653,7 @@ mod tests {
                 status: "info".to_string(),
             },
             hostname: "test-arn".to_string(),
-            source: "lambda".to_string(),
+            source: LAMBDA_RUNTIME_SLUG.to_string(),
             service: "test-service".to_string(),
             tags: tags_provider.get_tags_string(),
         };
@@ -668,7 +668,7 @@ mod tests {
                 status: "info".to_string(),
             },
             hostname: "test-arn".to_string(),
-            source: "lambda".to_string(),
+            source: LAMBDA_RUNTIME_SLUG.to_string(),
             service: "test-service".to_string(),
             tags: tags_provider.get_tags_string(),
         };

--- a/bottlecap/src/metrics/aggregator.rs
+++ b/bottlecap/src/metrics/aggregator.rs
@@ -330,6 +330,7 @@ mod tests {
         Aggregator,
     };
     use crate::tags::provider;
+    use crate::LAMBDA_RUNTIME_SLUG;
     use std::collections::hash_map;
     use std::sync::Arc;
 
@@ -337,7 +338,7 @@ mod tests {
         let config = Arc::new(config::Config::default());
         Arc::new(provider::Provider::new(
             Arc::clone(&config),
-            "lambda".to_string(),
+            LAMBDA_RUNTIME_SLUG.to_string(),
             &hash_map::HashMap::new(),
         ))
     }

--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -105,6 +105,16 @@ fn tags_from_env(
     if let Ok(memory_size) = std::env::var(MEMORY_SIZE_VAR) {
         tags_map.insert(MEMORY_SIZE_KEY.to_string(), memory_size);
     }
+
+    if let Some(tags) = &config.tags {
+        for tag in tags.split(',') {
+            let parts = tag.split(':').collect::<Vec<&str>>();
+            if parts.len() == 2 {
+                tags_map.insert(parts[0].to_string(), parts[1].to_string());
+            }
+        }
+    }
+
     tags_map.insert(
         COMPUTE_STATS_KEY.to_string(),
         COMPUTE_STATS_VALUE.to_string(),

--- a/bottlecap/src/tags/provider.rs
+++ b/bottlecap/src/tags/provider.rs
@@ -1,5 +1,5 @@
-use crate::config;
 use crate::tags::lambda::tags::Lambda;
+use crate::{config, LAMBDA_RUNTIME_SLUG};
 use std::collections::hash_map;
 use std::sync::Arc;
 
@@ -22,7 +22,7 @@ impl Provider {
         metadata: &hash_map::HashMap<String, String>,
     ) -> Self {
         match runtime.as_str() {
-            "lambda" => {
+            LAMBDA_RUNTIME_SLUG => {
                 let lambda_tabs = Lambda::new_from_config(config, metadata);
                 Provider {
                     tag_provider: Arc::new(TagProvider::Lambda(lambda_tabs)),
@@ -59,6 +59,7 @@ impl GetTagsVec for TagProvider {
 mod tests {
     use super::*;
     use crate::config::Config;
+    use crate::LAMBDA_RUNTIME_SLUG;
     use std::collections::hash_map::HashMap;
 
     #[test]
@@ -73,7 +74,7 @@ mod tests {
             "function_arn".to_string(),
             "arn:aws:lambda:us-west-2:123456789012:function:my-function".to_string(),
         );
-        let provider = Provider::new(config, "lambda".to_string(), &metadata);
+        let provider = Provider::new(config, LAMBDA_RUNTIME_SLUG.to_string(), &metadata);
         assert!(provider.get_tags_string().contains("service:test-service"));
     }
 }


### PR DESCRIPTION
Adds the tag provider for logs instead of simply the config tags.

This adds global tags like function ARN:
<img width="1307" alt="image" src="https://github.com/DataDog/datadog-lambda-extension/assets/1598537/23e950b9-a075-4b47-ac59-8ca21ddb2b82">