### PR TITLE
feat(bottlecap): add runtime and post runtime duration to logs

### DIFF
--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -393,7 +393,7 @@ mod tests {
                 }
             },
             Message {
-                    message: "REPORT RequestId: test-request-id Duration: 100 ms Billed Duration: 128 ms Memory Size: 256 MB Max Memory Used: 64 MB Init Duration: 50 ms".to_string(),
+                    message: "REPORT RequestId: test-request-id Duration: 100 ms Runtime Duration: 0 ms Post Runtime Duration: 0 ms Billed Duration: 128 ms Memory Size: 256 MB Max Memory Used: 64 MB Init Duration: 50 ms".to_string(),
                     lambda: Lambda {
                         arn: "test-arn".to_string(),
                         request_id: Some("test-request-id".to_string()),

--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -112,8 +112,8 @@ impl LambdaProcessor {
             },
             TelemetryRecord::PlatformReport { request_id, metrics, .. } => { // TODO: check what to do with rest of the fields
                 let mut post_runtime_duration_ms = 0.0;
+                // Calculate `post_runtime_duration_ms` if we've seen a `runtime_duration_ms`.
                 if self.execution_context.runtime_duration_ms > 0.0 {
-                    // We've seen a `runtime_duration_ms` in the `PlatformRuntimeDone` event
                     post_runtime_duration_ms = metrics.duration_ms - self.execution_context.runtime_duration_ms;
                 }
 

--- a/bottlecap/src/telemetry/events.rs
+++ b/bottlecap/src/telemetry/events.rs
@@ -170,7 +170,7 @@ pub struct InitReportMetrics {
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct RuntimeDoneMetrics {
-    /// Duration in milliseconds
+    /// Runtime duration in milliseconds
     pub duration_ms: f64,
     /// Number of bytes produced as a result of the invocation
     pub produced_bytes: Option<u64>,
@@ -180,7 +180,8 @@ pub struct RuntimeDoneMetrics {
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ReportMetrics {
-    /// Duration in milliseconds
+    /// Total duration in milliseconds, includes Extension
+    /// and Lambda execution time.
     pub duration_ms: f64,
     /// Billed duration in milliseconds
     pub billed_duration_ms: u64,


### PR DESCRIPTION
# What?

Adds Runtime and Post Runtime Duration to the Report Log.
<img width="643" alt="Screenshot 2024-05-20 at 6 06 00 PM" src="https://github.com/DataDog/datadog-lambda-extension/assets/30836115/2ad30fff-4a5d-4c24-836e-e364dd6607fc">

# How?

Modified the Lambda Logs Processor to have an `ExecutionContext` struct to house this fields for further calculation on report event, start and end metrics set on platform start and platform runtime done, respectively.

# Motivation
Parity with Go and [SVLS-4861](https://datadoghq.atlassian.net/browse/SVLS-4861)



[SVLS-4861]: https://datadoghq.atlassian.net/browse/SVLS-4861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ