### PR TITLE
feat: Set duration metrics from report log.

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -293,12 +293,16 @@ fn main() -> Result<()> {
                                     break;
                                 }
                                 TelemetryRecord::PlatformReport {
-                                    request_id, status, ..
+                                    request_id,
+                                    status,
+                                    metrics,
+                                    ..
                                 } => {
                                     debug!(
                                         "Platform report for request_id: {:?} with status: {:?}",
                                         request_id, status
                                     );
+                                    lambda_enhanced_metrics.set_report_log_metrics(&metrics);
                                     if shutdown {
                                         break;
                                     }

--- a/bottlecap/src/metrics/aggregator.rs
+++ b/bottlecap/src/metrics/aggregator.rs
@@ -324,6 +324,26 @@ impl<const CONTEXTS: usize> Aggregator<CONTEXTS> {
         }
         series
     }
+
+    #[cfg(test)]
+    pub fn get_value_by_id(
+        &mut self,
+        name: Ustr,
+        tags: Option<Ustr>,
+    ) -> Option<ddsketch_agent::DDSketch> {
+        let id = metric::id(name, tags);
+
+        match self.map.entry(
+            id,
+            |m| m.id == id,
+            |m| crate::metrics::metric::id(m.name, m.tags),
+        ) {
+            hash_table::Entry::Vacant(_) => None,
+            hash_table::Entry::Occupied(entry) => {
+                Some(entry.get().metric_value.get_sketch().clone())
+            }
+        }
+    }
 }
 
 fn tags_string_to_vector(tags: Option<Ustr>) -> Vec<String> {

--- a/bottlecap/src/metrics/enhanced/lambda.rs
+++ b/bottlecap/src/metrics/enhanced/lambda.rs
@@ -1,7 +1,9 @@
 use super::constants;
 use crate::metrics::aggregator::Aggregator;
 use crate::metrics::{errors, metric};
+use crate::telemetry::events::ReportMetrics;
 use std::sync::{Arc, Mutex};
+use tracing::error;
 
 pub struct Lambda {
     pub aggregator: Arc<Mutex<Aggregator<1024>>>,
@@ -36,6 +38,62 @@ impl Lambda {
             .lock()
             .expect("lock poisoned")
             .insert(&metric)
+    }
+
+    pub fn set_report_log_metrics(&self, metrics: &ReportMetrics) {
+        let mut aggr = self.aggregator.lock().expect("lock poisoned");
+        let metric = metric::Metric::new(
+            constants::DURATION_METRIC.into(),
+            metric::Type::Distribution,
+            (metrics.duration_ms * constants::MS_TO_SEC)
+                .to_string()
+                .into(),
+            None,
+        );
+        if let Err(e) = aggr.insert(&metric) {
+            error!("failed to insert duration metric: {}", e);
+        }
+        let metric = metric::Metric::new(
+            constants::BILLED_DURATION_METRIC.into(),
+            metric::Type::Distribution,
+            (metrics.billed_duration_ms as f64 * constants::MS_TO_SEC)
+                .to_string()
+                .into(),
+            None,
+        );
+        if let Err(e) = aggr.insert(&metric) {
+            error!("failed to insert billed duration metric: {}", e);
+        }
+        let metric = metric::Metric::new(
+            constants::MAX_MEMORY_USED_METRIC.into(),
+            metric::Type::Distribution,
+            (metrics.max_memory_used_mb as f64).to_string().into(),
+            None,
+        );
+        if let Err(e) = aggr.insert(&metric) {
+            error!("failed to insert max memory used metric: {}", e);
+        }
+        let metric = metric::Metric::new(
+            constants::MEMORY_SIZE_METRIC.into(),
+            metric::Type::Distribution,
+            (metrics.memory_size_mb as f64).to_string().into(),
+            None,
+        );
+        if let Err(e) = aggr.insert(&metric) {
+            error!("failed to insert memory size metric: {}", e);
+        }
+        if let Some(init_duration_ms) = metrics.init_duration_ms {
+            let metric = metric::Metric::new(
+                constants::INIT_DURATION_METRIC.into(),
+                metric::Type::Distribution,
+                (init_duration_ms * constants::MS_TO_SEC).to_string().into(),
+                None,
+            );
+            if let Err(e) = aggr.insert(&metric) {
+                error!("failed to insert memory size metric: {}", e);
+            }
+        }
+        // TODO(astuyve): estimated cost metric, post runtime duration metric.
     }
 }
 
@@ -89,5 +147,55 @@ mod tests {
         let _ = pbuf.sketches().iter().map(|sketch| {
             assert_eq!(sketch.metric, constants::ERRORS_METRIC.into());
         });
+    }
+
+    #[test]
+    fn test_set_report_log_metrics() {
+        let metrics_aggr = setup();
+        let lambda = Lambda::new(metrics_aggr.clone());
+        let report_metrics = ReportMetrics {
+            duration_ms: 100.0,
+            billed_duration_ms: 100,
+            max_memory_used_mb: 128,
+            memory_size_mb: 256,
+            init_duration_ms: Some(50.0),
+            restore_duration_ms: None,
+        };
+        lambda.set_report_log_metrics(&report_metrics);
+        let mut aggr = metrics_aggr.lock().expect("lock poisoned");
+
+        let mut ms_sketch = ddsketch_agent::DDSketch::default();
+        ms_sketch.insert(0.1);
+        assert_eq!(
+            aggr.get_value_by_id(constants::DURATION_METRIC.into(), None)
+                .unwrap(),
+            ms_sketch
+        );
+        assert_eq!(
+            aggr.get_value_by_id(constants::BILLED_DURATION_METRIC.into(), None)
+                .unwrap(),
+            ms_sketch
+        );
+        let mut mem_used_sketch = ddsketch_agent::DDSketch::default();
+        mem_used_sketch.insert(128.0);
+        assert_eq!(
+            aggr.get_value_by_id(constants::MAX_MEMORY_USED_METRIC.into(), None)
+                .unwrap(),
+            mem_used_sketch
+        );
+        let mut max_mem_sketch = ddsketch_agent::DDSketch::default();
+        max_mem_sketch.insert(256.0);
+        assert_eq!(
+            aggr.get_value_by_id(constants::MEMORY_SIZE_METRIC.into(), None)
+                .unwrap(),
+            max_mem_sketch
+        );
+        let mut init_duration_sketch = ddsketch_agent::DDSketch::default();
+        init_duration_sketch.insert(0.05);
+        assert_eq!(
+            aggr.get_value_by_id(constants::INIT_DURATION_METRIC.into(), None)
+                .unwrap(),
+            init_duration_sketch
+        );
     }
 }


### PR DESCRIPTION
- Sets duration, billed duration, max memory used, memory provisioned, and init duration metrics
- Need some calculations for post-runtime duration
- defines an aggregator test method to fetch sketches from the aggregator without compaction