### PR TITLE
feat(bottlecap): add more enhanced metrics

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -31,7 +31,9 @@ use bottlecap::{
     },
     tags::{lambda, provider},
     telemetry::{
-        self, client::TelemetryApiClient, events::Status, events::TelemetryRecord,
+        self,
+        client::TelemetryApiClient,
+        events::{Status, TelemetryRecord},
         listener::TelemetryListener,
     },
     DOGSTATSD_PORT, EXTENSION_ACCEPT_FEATURE_HEADER, EXTENSION_FEATURES, EXTENSION_HOST,
@@ -325,11 +327,16 @@ fn main() -> Result<()> {
                                     if let Some(invocation_context) =
                                         invocation_context_buffer.get(&request_id)
                                     {
-                                        let post_runtime_duration_ms = metrics.duration_ms
-                                            - invocation_context.runtime_duration_ms;
-                                        lambda_enhanced_metrics.set_post_runtime_duration_metric(
-                                            post_runtime_duration_ms,
-                                        );
+                                        if invocation_context.runtime_duration_ms > 0.0 {
+                                            let post_runtime_duration_ms = metrics.duration_ms
+                                                - invocation_context.runtime_duration_ms;
+                                            lambda_enhanced_metrics.set_post_runtime_duration_metric(
+                                                post_runtime_duration_ms,
+                                            );
+                                        } else {
+                                            debug!("Impossible to compute post runtime duration for request_id: {:?}", request_id);
+                                        }
+                                        
                                     }
 
                                     if shutdown {

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -9,11 +9,11 @@
 #![deny(missing_copy_implementations)]
 #![deny(missing_debug_implementations)]
 
+use decrypt::resolve_secrets;
 use lifecycle::{
     flush_control::FlushControl,
     invocation_context::{InvocationContext, InvocationContextBuffer},
 };
-use decrypt::resolve_secrets;
 use std::collections::hash_map;
 use telemetry::listener::TelemetryListenerConfig;
 use tracing::{debug, error, info};

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -325,7 +325,7 @@ fn main() -> Result<()> {
                                         metrics.memory_size_mb,
                                     );
                                     if let Some(invocation_context) =
-                                        invocation_context_buffer.get(&request_id)
+                                        invocation_context_buffer.remove(&request_id)
                                     {
                                         if invocation_context.runtime_duration_ms > 0.0 {
                                             let post_runtime_duration_ms = metrics.duration_ms

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -329,10 +329,6 @@ fn main() -> Result<()> {
                                     request_id, status
                                 );
                                 lambda_enhanced_metrics.set_report_log_metrics(&metrics);
-                                lambda_enhanced_metrics.set_estimated_cost_metric(
-                                    metrics.billed_duration_ms,
-                                    metrics.memory_size_mb,
-                                );
                                 if let Some(invocation_context) =
                                     invocation_context_buffer.remove(&request_id)
                                 {

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -330,13 +330,13 @@ fn main() -> Result<()> {
                                         if invocation_context.runtime_duration_ms > 0.0 {
                                             let post_runtime_duration_ms = metrics.duration_ms
                                                 - invocation_context.runtime_duration_ms;
-                                            lambda_enhanced_metrics.set_post_runtime_duration_metric(
-                                                post_runtime_duration_ms,
-                                            );
+                                            lambda_enhanced_metrics
+                                                .set_post_runtime_duration_metric(
+                                                    post_runtime_duration_ms,
+                                                );
                                         } else {
                                             debug!("Impossible to compute post runtime duration for request_id: {:?}", request_id);
                                         }
-                                        
                                     }
 
                                     if shutdown {

--- a/bottlecap/src/lifecycle/invocation_context.rs
+++ b/bottlecap/src/lifecycle/invocation_context.rs
@@ -36,9 +36,17 @@ impl InvocationContextBuffer {
         }
     }
 
-    fn remove(&mut self, request_id: &String) {
-        self.buffer
-            .retain(|context| context.request_id != *request_id);
+    pub fn remove(&mut self, request_id: &String) -> Option<InvocationContext> {
+        if let Some(i) = self
+            .buffer
+            .iter()
+            .position(|context| context.request_id == *request_id)
+        {
+            return self.buffer.remove(i);
+        }
+        debug!("Context for request_id: {:?} not found", request_id);
+
+        None
     }
 
     #[must_use]

--- a/bottlecap/src/lifecycle/invocation_context.rs
+++ b/bottlecap/src/lifecycle/invocation_context.rs
@@ -1,0 +1,65 @@
+use std::collections::VecDeque;
+
+use tracing::debug;
+
+pub struct InvocationContext {
+    pub request_id: String,
+    pub runtime_duration_ms: f64,
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct InvocationContextBuffer {
+    buffer: VecDeque<InvocationContext>,
+}
+
+impl Default for InvocationContextBuffer {
+    fn default() -> Self {
+        InvocationContextBuffer {
+            buffer: VecDeque::<InvocationContext>::with_capacity(5),
+        }
+    }
+}
+
+impl InvocationContextBuffer {
+    pub fn insert(&mut self, invocation_context: InvocationContext) {
+        if self.buffer.len() == self.buffer.capacity() {
+            debug!(
+                "Buffer is full, dropping context for request_id: {:?}",
+                invocation_context.request_id
+            );
+        } else {
+            if self.get(&invocation_context.request_id).is_some() {
+                self.remove(&invocation_context.request_id);
+            }
+
+            self.buffer.push_back(invocation_context);
+        }
+    }
+
+    fn remove(&mut self, request_id: &String) {
+        self.buffer
+            .retain(|context| context.request_id != *request_id);
+    }
+
+    #[must_use]
+    pub fn get(&self, request_id: &String) -> Option<&InvocationContext> {
+        self.buffer
+            .iter()
+            .find(|context| context.request_id == *request_id)
+    }
+
+    pub fn add_runtime_duration(&mut self, request_id: &String, runtime_duration_ms: f64) {
+        if let Some(context) = self
+            .buffer
+            .iter_mut()
+            .find(|context| context.request_id == *request_id)
+        {
+            context.runtime_duration_ms = runtime_duration_ms;
+        } else {
+            self.insert(InvocationContext {
+                request_id: request_id.to_string(),
+                runtime_duration_ms,
+            });
+        }
+    }
+}

--- a/bottlecap/src/lifecycle/invocation_context.rs
+++ b/bottlecap/src/lifecycle/invocation_context.rs
@@ -23,10 +23,8 @@ impl Default for InvocationContextBuffer {
 impl InvocationContextBuffer {
     pub fn insert(&mut self, invocation_context: InvocationContext) {
         if self.buffer.len() == self.buffer.capacity() {
-            debug!(
-                "Buffer is full, dropping context for request_id: {:?}",
-                invocation_context.request_id
-            );
+            self.buffer.pop_front();
+            self.buffer.push_back(invocation_context);
         } else {
             if self.get(&invocation_context.request_id).is_some() {
                 self.remove(&invocation_context.request_id);

--- a/bottlecap/src/lifecycle/invocation_context.rs
+++ b/bottlecap/src/lifecycle/invocation_context.rs
@@ -2,6 +2,7 @@ use std::collections::VecDeque;
 
 use tracing::debug;
 
+#[derive(Debug, Clone)]
 pub struct InvocationContext {
     pub request_id: String,
     pub runtime_duration_ms: f64,

--- a/bottlecap/src/lifecycle/mod.rs
+++ b/bottlecap/src/lifecycle/mod.rs
@@ -1,2 +1,3 @@
 pub mod flush_control;
+pub mod invocation_context;
 mod invocation_times;

--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -6,6 +6,7 @@ use tracing::error;
 
 use crate::config;
 use crate::events::Event;
+use crate::lifecycle::invocation_context::InvocationContext;
 use crate::logs::aggregator::Aggregator;
 use crate::logs::processor::{Processor, Rule};
 use crate::tags::provider;
@@ -23,17 +24,11 @@ pub struct LambdaProcessor {
     // Global Processing Rules
     rules: Option<Vec<Rule>>,
     // Current Invocation Context
-    execution_context: ExecutionContext,
-    // Main event bus
-    event_bus: Sender<Event>,
-}
-
-#[derive(Clone, Debug)]
-struct ExecutionContext {
-    request_id: Option<String>,
-    runtime_duration_ms: f64,
+    invocation_context: InvocationContext,
     // Logs which don't have a `request_id`
     orphan_logs: Vec<IntakeLog>,
+    // Main event bus
+    event_bus: Sender<Event>,
 }
 
 impl Processor<IntakeLog> for LambdaProcessor {}
@@ -56,11 +51,11 @@ impl LambdaProcessor {
             service,
             tags,
             rules,
-            execution_context: ExecutionContext {
-                request_id: None,
+            invocation_context: InvocationContext {
+                request_id: String::new(),
                 runtime_duration_ms: 0.0,
-                orphan_logs: Vec::new(),
             },
+            orphan_logs: Vec::new(),
             event_bus,
         }
     }
@@ -108,7 +103,7 @@ impl LambdaProcessor {
                     error!("Failed to send PlatformStart to the main event bus: {}", e);
                 }
                 // Set request_id for unprocessed and future logs
-                self.execution_context.request_id = Some(request_id.clone());
+                self.invocation_context.request_id.clone_from(&request_id);
 
                 let version = version.unwrap_or("$LATEST".to_string());
                 Ok(Message::new(
@@ -124,7 +119,7 @@ impl LambdaProcessor {
                 }
 
                 if let Some(metrics) = metrics {
-                    self.execution_context.runtime_duration_ms = metrics.duration_ms;
+                    self.invocation_context.runtime_duration_ms = metrics.duration_ms;
                 }
 
                 Ok(Message::new(
@@ -141,15 +136,15 @@ impl LambdaProcessor {
 
                 let mut post_runtime_duration_ms = 0.0;
                 // Calculate `post_runtime_duration_ms` if we've seen a `runtime_duration_ms`.
-                if self.execution_context.runtime_duration_ms > 0.0 {
-                    post_runtime_duration_ms = metrics.duration_ms - self.execution_context.runtime_duration_ms;
+                if self.invocation_context.runtime_duration_ms > 0.0 {
+                    post_runtime_duration_ms = metrics.duration_ms - self.invocation_context.runtime_duration_ms;
                 }
 
                 let mut message = format!(
                     "REPORT RequestId: {} Duration: {} ms Runtime Duration: {} ms Post Runtime Duration: {} ms Billed Duration: {} ms Memory Size: {} MB Max Memory Used: {} MB",
                     request_id,
                     metrics.duration_ms,
-                    self.execution_context.runtime_duration_ms,
+                    self.invocation_context.runtime_duration_ms,
                     post_runtime_duration_ms,
                     metrics.billed_duration_ms,
                     metrics.memory_size_mb,
@@ -182,7 +177,8 @@ impl LambdaProcessor {
             // Log already has a `request_id`
             Some(request_id) => Some(request_id.clone()),
             // Default to the `request_id` we've seen so far, if any.
-            None => self.execution_context.request_id.clone(),
+            None => (!&self.invocation_context.request_id.is_empty())
+                .then(|| self.invocation_context.request_id.clone()),
         };
 
         lambda_message.lambda.request_id = request_id;
@@ -199,7 +195,7 @@ impl LambdaProcessor {
             Ok(log)
         } else {
             // We haven't seen a `request_id`, this is an orphan log
-            self.execution_context.orphan_logs.push(log);
+            self.orphan_logs.push(log);
             Err("No request_id available, queueing for later".into())
         }
     }
@@ -230,13 +226,9 @@ impl LambdaProcessor {
                 }
 
                 // Process orphan logs, since we have a `request_id` now
-                for mut orphan_log in self.execution_context.orphan_logs.drain(..) {
-                    orphan_log.message.lambda.request_id = Some(
-                        self.execution_context
-                            .request_id
-                            .clone()
-                            .expect("unable to retrieve request ID"),
-                    );
+                for mut orphan_log in self.orphan_logs.drain(..) {
+                    orphan_log.message.lambda.request_id =
+                        Some(self.invocation_context.request_id.clone());
                     if should_send_log {
                         if let Ok(serialized_log) = serde_json::to_string(&log) {
                             to_send.push(serialized_log);
@@ -513,7 +505,7 @@ mod tests {
             intake_log.to_string(),
             "No request_id available, queueing for later"
         );
-        assert_eq!(processor.execution_context.orphan_logs.len(), 1);
+        assert_eq!(processor.orphan_logs.len(), 1);
     }
 
     #[tokio::test]
@@ -635,7 +627,7 @@ mod tests {
         };
 
         processor.process(vec![event.clone()], &aggregator).await;
-        assert_eq!(processor.execution_context.orphan_logs.len(), 1);
+        assert_eq!(processor.orphan_logs.len(), 1);
 
         let mut aggregator_lock = aggregator.lock().unwrap();
         let batch = aggregator_lock.get_batch();
@@ -674,8 +666,8 @@ mod tests {
             .process(vec![start_event.clone()], &aggregator)
             .await;
         assert_eq!(
-            processor.execution_context.request_id,
-            Some("test-request-id".to_string())
+            processor.invocation_context.request_id,
+            "test-request-id".to_string()
         );
 
         // This could be any event that doesn't have a `request_id`

--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -104,7 +104,7 @@ impl LambdaProcessor {
                 request_id,
                 version,
             } => {
-                if let Err(e) = self.event_bus.send(Event::Telemetry(copy)) {
+                if let Err(e) = self.event_bus.send(Event::Telemetry(copy)).await {
                     error!("Failed to send PlatformStart to the main event bus: {}", e);
                 }
                 // Set request_id for unprocessed and future logs

--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -104,6 +104,9 @@ impl LambdaProcessor {
                 request_id,
                 version,
             } => {
+                if let Err(e) = self.event_bus.send(Event::Telemetry(copy)) {
+                    error!("Failed to send PlatformStart to the main event bus: {}", e);
+                }
                 // Set request_id for unprocessed and future logs
                 self.execution_context.request_id = Some(request_id.clone());
 

--- a/bottlecap/src/metrics/enhanced/constants.rs
+++ b/bottlecap/src/metrics/enhanced/constants.rs
@@ -3,6 +3,7 @@ pub const BASE_LAMBDA_INVOCATION_PRICE: f64 = 0.000_000_2;
 pub const X86_LAMBDA_PRICE_PER_GB_SECOND: f64 = 0.000_016_666_7;
 pub const ARM_LAMBDA_PRICE_PER_GB_SECOND: f64 = 0.000_013_333_4;
 pub const MS_TO_SEC: f64 = 0.001;
+pub const MB_TO_GB: f64 = 1024.0;
 
 // Enhanced metrics
 pub const MAX_MEMORY_USED_METRIC: &str = "aws.lambda.enhanced.max_memory_used";

--- a/bottlecap/src/metrics/enhanced/lambda.rs
+++ b/bottlecap/src/metrics/enhanced/lambda.rs
@@ -149,6 +149,18 @@ impl Lambda {
         if let Err(e) = aggr.insert(&metric) {
             error!("failed to insert memory size metric: {}", e);
         }
+
+        let cost_usd =
+            Self::calculate_estimated_cost_usd(metrics.billed_duration_ms, metrics.memory_size_mb);
+        let metric = metric::Metric::new(
+            constants::ESTIMATED_COST_METRIC.into(),
+            metric::Type::Distribution,
+            cost_usd.to_string().into(),
+            None,
+        );
+        if let Err(e) = aggr.insert(&metric) {
+            error!("failed to insert estimated cost metric: {}", e);
+        }
     }
 }
 


### PR DESCRIPTION
# What?

Adds three new enhanced metrics:
- `runtime_duration`,
- `post_runtime_duration`, and
- `estimated_cost`.

<img width="1259" alt="Screenshot 2024-06-07 at 2 43 00 PM" src="https://github.com/DataDog/datadog-lambda-extension/assets/30836115/ca1dc8a7-f085-4483-a20a-9d8f34e89546">

# Motivation

[SVLS-4906](https://datadoghq.atlassian.net/browse/SVLS-4906), [SVLS-4907](https://datadoghq.atlassian.net/browse/SVLS-4907), and [SVLS-4908](https://datadoghq.atlassian.net/browse/SVLS-4908)

# How?



Added an `InvocationContext` buffer which keeps the latest 5 invocations to tracks data to calculate metrics as needed.


[SVLS-4906]: https://datadoghq.atlassian.net/browse/SVLS-4906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SVLS-4907]: https://datadoghq.atlassian.net/browse/SVLS-4907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SVLS-4908]: https://datadoghq.atlassian.net/browse/SVLS-4908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ