### PR TITLE
feat: move build from debian buster to al2 so it runs on all versions in Lambda

### DIFF
--- a/scripts/Dockerfile.bottlecap.build
+++ b/scripts/Dockerfile.bottlecap.build
@@ -1,8 +1,13 @@
 # syntax = docker/dockerfile:experimental
 
-FROM rust:1.77-buster as bottlecap-builder
-RUN apt-get update
-RUN apt-get install -y protobuf-compiler
+FROM public.ecr.aws/lambda/provided:al2 as bottlecap-builder
+RUN yum install -y curl gcc gcc-c++ make unzip
+# Install Protocol Buffers compiler by hand, since AL2 does not have a recent enough version.
+COPY ./scripts/install-protoc.sh /
+RUN chmod +x /install-protoc.sh && /install-protoc.sh
+RUN curl https://sh.rustup.rs -sSf | \
+    sh -s -- --default-toolchain stable -y
+    ENV PATH=/root/.cargo/bin:$PATH
 RUN mkdir -p /tmp/dd
 COPY ./bottlecap /tmp/dd/bottlecap
 RUN cd /tmp/dd/bottlecap && cargo build --release

--- a/scripts/install-protoc.sh
+++ b/scripts/install-protoc.sh
@@ -1,0 +1,57 @@
+#! /usr/bin/env bash
+set -o errexit -o verbose
+
+# Protoc. No guard because we want to override Ubuntu's old version in
+# case it is already installed by a dependency.
+#
+# Basis of script copied from:
+# https://github.com/paxosglobal/asdf-protoc/blob/46c2f9349b8420144b197cfd064a9677d21cfb0c/bin/install
+
+# shellcheck disable=SC2155
+readonly TMP_DIR="$(mktemp -d -t "protoc_XXXX")"
+trap 'rm -rf "${TMP_DIR?}"' EXIT
+
+get_platform() {
+  local os
+  os=$(uname)
+  if [[ "${os}" == "Darwin" ]]; then
+    echo "osx"
+  elif [[ "${os}" == "Linux" ]]; then
+    echo "linux"
+  else
+    >&2 echo "unsupported os: ${os}" && exit 1
+  fi
+}
+
+get_arch() {
+  local os
+  local arch
+  os=$(uname)
+  arch=$(uname -m)
+  # On ARM Macs, uname -m returns "arm64", but in protoc releases this architecture is called "aarch_64"
+  if [[ "${os}" == "Darwin" && "${arch}" == "arm64" ]]; then
+    echo "aarch_64"
+  elif [[ "${os}" == "Linux" && "${arch}" == "aarch64" ]]; then
+    echo "aarch_64"
+  else
+    echo "${arch}"
+  fi
+}
+
+install_protoc() {
+  local version=$1
+  local install_path=$2
+
+  local base_url="https://github.com/protocolbuffers/protobuf/releases/download"
+  local url
+  url="${base_url}/v${version}/protoc-${version}-$(get_platform)-$(get_arch).zip"
+  local download_path="${TMP_DIR}/protoc.zip"
+
+  echo "Downloading ${url}"
+  curl -fsSL "${url}" -o "${download_path}"
+
+  unzip -qq "${download_path}" -d "${TMP_DIR}"
+  mv --force --verbose "${TMP_DIR}/bin/protoc" "${install_path}"
+}
+
+install_protoc "3.19.5" "/usr/bin/protoc"


### PR DESCRIPTION
Fixes an issue where the build would panic on older versions of Lambda runtimes where glibc maxed out at 2.26.

Requires a custom script from Saluki to compile protobuf
