### PR TITLE
fix(bottlecap): fix how Telemetry API stream is being read

### DIFF
--- a/bottlecap/src/telemetry/listener.rs
+++ b/bottlecap/src/telemetry/listener.rs
@@ -439,4 +439,13 @@ mod tests {
 
         assert_eq!(parser.body, "[{\"time\":\"2024-04-25T17:35:59.944Z\",\"type\":\"platform.initStart\",\"record\":{\"initializationType\":\"on-demand\",\"phase\":\"init\",\"runtimeVersion\":\"nodejs:20.v22\",\"runtimeVersionArn\":\"arn:aws:lambda:us-east-1::runtime:da57c20c4b965d5b75540f6865a35fc8030358e33ec44ecfed33e90901a27a72\",\"functionName\":\"hello-world\",\"functionVersion\":\"$LATEST\"}}]".to_string());
     }
+
+    #[test]
+    #[should_panic]
+    fn test_from_stream_invalid_data() {
+        let stream = get_stream([0; 1024].to_vec());
+
+        let mut buf = [0; MAX_BUFFER_SIZE];
+        HttpRequestParser::from_stream(&stream, &mut buf).unwrap();
+    }
 }

--- a/bottlecap/src/telemetry/listener.rs
+++ b/bottlecap/src/telemetry/listener.rs
@@ -60,7 +60,7 @@ impl HttpRequestParser {
         let content_length = parser
             .headers
             .get("content-length")
-            .expect("unfallible")
+            .expect("infallible")
             .parse::<usize>()?;
         let body_bytes_read = headers_buf.len() - body_start_index;
         let missing_body_lenght = content_length - body_bytes_read;


### PR DESCRIPTION
# How?

Created a new `from_stream` method, which reads headers until `content-length` is found, and proceeds to read the exact remaining body size.

# Motivation

- Data loss and timeouts were happening due to a stream hanging waiting for data
- Stream sometimes received the data chunked, which we were never reading.

First developed in #256, also [SVLS-4932](https://datadoghq.atlassian.net/browse/SVLS-4932)

<img width="1256" alt="Screenshot 2024-05-31 at 2 39 34 PM" src="https://github.com/DataDog/datadog-lambda-extension/assets/30836115/7b8b5422-a4d5-44d3-ae37-6dac641dfae9">



[SVLS-4932]: https://datadoghq.atlassian.net/browse/SVLS-4932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ