### PR TITLE
Svls 4825 support kms.all secrets

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -40,6 +40,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,6 +79,12 @@ checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -112,6 +133,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -201,9 +228,30 @@ version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
+ "windows-targets 0.52.5",
 ]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cpufeatures"
@@ -265,6 +313,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +376,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -405,6 +477,25 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "h2"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "hashbrown"
@@ -525,6 +616,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2",
  "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
@@ -553,6 +645,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,6 +678,29 @@ dependencies = [
  "tower",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -726,6 +857,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
+name = "native-tls"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,6 +907,50 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "openssl"
+version = "0.10.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "ordered-float"
@@ -864,6 +1056,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,7 +1107,7 @@ checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.5.0",
  "lazy_static",
  "num-traits",
  "rand",
@@ -1086,7 +1284,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -1141,19 +1339,23 @@ checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
 dependencies = [
  "base64 0.22.0",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -1164,7 +1366,9 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
+ "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tower-service",
  "url",
@@ -1202,7 +1406,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1269,10 +1473,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+dependencies = [
+ "bitflags 2.5.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -1405,6 +1641,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,6 +1755,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,6 +1782,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
  "pin-project-lite",
  "tokio",
 ]
@@ -1748,6 +2028,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1872,6 +2158,15 @@ dependencies = [
  "home",
  "once_cell",
  "rustix",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.5",
 ]
 
 [[package]]

--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -132,6 +132,7 @@ dependencies = [
 name = "bottlecap"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.0",
  "chrono",
  "datadog-protos",
  "ddsketch-agent",

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -5,34 +5,34 @@ edition = "2021"
 publish = false
 
 [dependencies]
-chrono = { version = "0.4.38", features = ["serde", "std", "now"], default-features = false}
-datadog-protos = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/" }
-ddsketch-agent = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/" }
-figment = { version = "0.10.15", default-features = false, features = ["yaml", "env"] }
+chrono = { version = "0.4.38", features = ["serde"] }
+datadog-protos = { git = "https://github.com/DataDog/saluki/", version = "0.1.0", default-features = false }
+ddsketch-agent = { git = "https://github.com/DataDog/saluki/", version = "0.1.0", default-features = false }
+figment = { version = "0.10.15", features = ["yaml", "env"] }
 fnv = { version = "1.0.7", default-features = false }
 hashbrown = { version = "0.14.3", default-features = false, features = ["inline-more"] }
-log = { version = "0.4.21", default-features = false }
+log = { version = "0.4.21", default-features = false, features = [] }
 protobuf = { version = "3.4.0", default-features = false }
 regex = { version = "1.10.4", default-features = false }
-serde = { version = "1.0.197", default-features = false, features = ["derive"] }
-serde_json = { version = "1.0.116", default-features = false, features = ["alloc"] }
+serde = { version = "1.0.197", features = ["derive"], default-features = false }
+serde_json = { version = "1.0.116", features = ["alloc"], default-features = false }
 thiserror = { version = "1.0.58", default-features = false }
 tracing = { version = "0.1.40", default-features = false }
 tracing-core = { version = "0.1.32", default-features = false }
 tracing-log = { version = "0.2.0", default-features = false, features = ["std", "log-tracer"] }
 tracing-subscriber = { version = "0.3.18", default-features = false, features = ["fmt", "env-filter"] }
-ureq = { version = "2.9.7", default-features = false, features = ["tls", "json"] }
+ureq = { version = "2.9.7", features = ["tls", "json"], default-features = false }
 ustr = { version = "1.0.0", default-features = false }
-hmac = { version = "0.12.1", default-features = false }
-reqwest = { version = "0.12.4", default-features = false, features = ["json", "blocking", "rustls-tls"] }
-sha2 = { version = "0.10.8", default-features = false }
-hex = { version = "0.4.3", default-features = false, features = ["std"] }
+hmac = "0.12.1"
+reqwest = { version = "0.12.4", features = ["json", "blocking", "rustls-tls"] }
+sha2 = "0.10.8"
+hex = "0.4.3"
 base64 = { version = "0.22.0", default-features = false }
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.5"
 
 [dev-dependencies]
-figment = { version = "0.10.15", default-features = false, features = ["yaml", "env", "test"] }
+figment = { version = "0.10.15", features = ["yaml", "env", "test"] }
 proptest = "1.4.0"
 
 [[bin]]

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -27,6 +27,7 @@ hmac = { version = "0.12.1", default-features = false }
 reqwest = { version = "0.12.4", default-features = false, features = ["json", "blocking", "rustls-tls"] }
 sha2 = { version = "0.10.8", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
+base64 = { version = "0.22.0", default-features = false }
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.5"
 

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -46,9 +46,9 @@ use std::sync::{Arc, Mutex};
 use std::{os::unix::process::CommandExt, path::Path, process::Command};
 
 use bottlecap::secrets::decrypt;
+use bottlecap::secrets::decrypt::resolve_all_secrets;
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
-use bottlecap::secrets::decrypt::resolve_all_secrets;
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]
@@ -236,10 +236,10 @@ fn main() -> Result<()> {
         let evt = next_event(&r.extension_id);
         match evt {
             Ok(NextEventResponse::Invoke {
-                   request_id,
-                   deadline_ms,
-                   invoked_function_arn,
-               }) => {
+                request_id,
+                deadline_ms,
+                invoked_function_arn,
+            }) => {
                 info!(
                     "[bottlecap] Invoke event {}; deadline: {}, invoked_function_arn: {}",
                     request_id, deadline_ms, invoked_function_arn
@@ -249,9 +249,9 @@ fn main() -> Result<()> {
                 }
             }
             Ok(NextEventResponse::Shutdown {
-                   shutdown_reason,
-                   deadline_ms,
-               }) => {
+                shutdown_reason,
+                deadline_ms,
+            }) => {
                 println!("Exiting: {shutdown_reason}, deadline: {deadline_ms}");
                 shutdown = true;
             }

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -105,7 +105,7 @@ fn map_stripped_env_by_suffix(suffix: &str) -> HashMap<String, (String, String)>
             } else {
                 k
             };
-            (key, (v, "".to_string()))
+            (key, (v, String::new()))
         })
         .collect::<HashMap<String, (String, String)>>()
 }
@@ -356,36 +356,36 @@ pub mod tests {
     fn test_kms_env_var() {
         figment::Jail::expect_with(|jail| {
             jail.clear_env();
-            jail.set_env(
-                "DD_SOMEKEY1_KMS_ENCRYPTED",
-                "secret1",
-            );
-            jail.set_env(
-                "DD_SOMEKEY2_KMS_ENCRYPTED",
-                "secret2",
-            );
-            jail.set_env(
-                "DD_SOMEKEY3_KMS_ENCRYPTED",
-                "secret3",
-            );
-            jail.set_env(
-                "DD_SOMEKEY4_SECRET_ARN",
-                "secret4",
-            );
-            jail.set_env(
-                "DD_SOMEKEY5_SECRET_ARN",
-                "secret5",
-            );
+            jail.set_env("DD_SOMEKEY1_KMS_ENCRYPTED", "secret1");
+            jail.set_env("DD_SOMEKEY2_KMS_ENCRYPTED", "secret2");
+            jail.set_env("DD_SOMEKEY3_KMS_ENCRYPTED", "secret3");
+            jail.set_env("DD_SOMEKEY4_SECRET_ARN", "secret4");
+            jail.set_env("DD_SOMEKEY5_SECRET_ARN", "secret5");
             let config = get_config(Path::new("")).expect("should parse config");
 
             let mut expected_kms_env_map = HashMap::new();
-            expected_kms_env_map.insert("SOMEKEY1_KMS_ENCRYPTED".to_string(), ("secret1".to_string(), "".to_string()));
-            expected_kms_env_map.insert("SOMEKEY2_KMS_ENCRYPTED".to_string(), ("secret2".to_string(), "".to_string()));
-            expected_kms_env_map.insert("SOMEKEY3_KMS_ENCRYPTED".to_string(), ("secret3".to_string(), "".to_string()));
+            expected_kms_env_map.insert(
+                "SOMEKEY1_KMS_ENCRYPTED".to_string(),
+                ("secret1".to_string(), String::new()),
+            );
+            expected_kms_env_map.insert(
+                "SOMEKEY2_KMS_ENCRYPTED".to_string(),
+                ("secret2".to_string(), String::new()),
+            );
+            expected_kms_env_map.insert(
+                "SOMEKEY3_KMS_ENCRYPTED".to_string(),
+                ("secret3".to_string(), String::new()),
+            );
 
             let mut expected_secret_arn_env_map = HashMap::new();
-            expected_secret_arn_env_map.insert("SOMEKEY4_SECRET_ARN".to_string(), ("secret4".to_string(), "".to_string()));
-            expected_secret_arn_env_map.insert("SOMEKEY5_SECRET_ARN".to_string(), ("secret5".to_string(), "".to_string()));
+            expected_secret_arn_env_map.insert(
+                "SOMEKEY4_SECRET_ARN".to_string(),
+                ("secret4".to_string(), String::new()),
+            );
+            expected_secret_arn_env_map.insert(
+                "SOMEKEY5_SECRET_ARN".to_string(),
+                ("secret5".to_string(), String::new()),
+            );
 
             let mut expected_config = Config::default();
             expected_config.kms_env_map = expected_kms_env_map;

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -22,8 +22,8 @@ pub struct Config {
     pub api_key: String,
     // DD_KMS_API_KEY is the only KMS var that does not follow the suffix pattern
     pub kms_api_key: Option<String>,
-    pub kms_env_map: HashMap<String, String>,
-    pub secret_arn_env_map: HashMap<String, String>,
+    pub kms_env_map: HashMap<String, (String, String)>,
+    pub secret_arn_env_map: HashMap<String, (String, String)>,
     pub env: Option<String>,
     pub service: Option<String>,
     pub version: Option<String>,
@@ -94,7 +94,7 @@ pub fn get_config(config_directory: &Path) -> Result<Config, ConfigError> {
     })
 }
 
-fn map_stripped_env_by_suffix(suffix: &str) -> HashMap<String, String> {
+fn map_stripped_env_by_suffix(suffix: &str) -> HashMap<String, (String, String)> {
     std::env::vars()
         .filter(|(k, _)| k.ends_with(suffix))
         .map(|(k, v)| {
@@ -105,9 +105,9 @@ fn map_stripped_env_by_suffix(suffix: &str) -> HashMap<String, String> {
             } else {
                 k
             };
-            (key, v)
+            (key, (v, "".to_string()))
         })
-        .collect::<HashMap<String, String>>()
+        .collect::<HashMap<String, (String, String)>>()
 }
 
 #[cfg(test)]
@@ -379,13 +379,13 @@ pub mod tests {
             let config = get_config(Path::new("")).expect("should parse config");
 
             let mut expected_kms_env_map = HashMap::new();
-            expected_kms_env_map.insert("SOMEKEY1_KMS_ENCRYPTED".to_string(), "secret1".to_string());
-            expected_kms_env_map.insert("SOMEKEY2_KMS_ENCRYPTED".to_string(), "secret2".to_string());
-            expected_kms_env_map.insert("SOMEKEY3_KMS_ENCRYPTED".to_string(), "secret3".to_string());
+            expected_kms_env_map.insert("SOMEKEY1_KMS_ENCRYPTED".to_string(), ("secret1".to_string(), "".to_string()));
+            expected_kms_env_map.insert("SOMEKEY2_KMS_ENCRYPTED".to_string(), ("secret2".to_string(), "".to_string()));
+            expected_kms_env_map.insert("SOMEKEY3_KMS_ENCRYPTED".to_string(), ("secret3".to_string(), "".to_string()));
 
             let mut expected_secret_arn_env_map = HashMap::new();
-            expected_secret_arn_env_map.insert("SOMEKEY4_SECRET_ARN".to_string(), "secret4".to_string());
-            expected_secret_arn_env_map.insert("SOMEKEY5_SECRET_ARN".to_string(), "secret5".to_string());
+            expected_secret_arn_env_map.insert("SOMEKEY4_SECRET_ARN".to_string(), ("secret4".to_string(), "".to_string()));
+            expected_secret_arn_env_map.insert("SOMEKEY5_SECRET_ARN".to_string(), ("secret5".to_string(), "".to_string()));
 
             let mut expected_config = Config::default();
             expected_config.kms_env_map = expected_kms_env_map;

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -21,6 +21,7 @@ pub struct Config {
     pub site: String,
     pub api_key: String,
     pub api_key_secret_arn: String,
+    pub kms_api_key: String,
     pub env: Option<String>,
     pub service: Option<String>,
     pub version: Option<String>,
@@ -41,6 +42,7 @@ impl Default for Config {
             site: "datadoghq.com".to_string(),
             api_key: String::default(),
             api_key_secret_arn: String::default(),
+            kms_api_key: String::default(),
             serverless_flush_strategy: FlushStrategy::Default,
             // Unified Tagging
             env: None,

--- a/bottlecap/src/secrets/decrypt.rs
+++ b/bottlecap/src/secrets/decrypt.rs
@@ -252,7 +252,7 @@ mod tests {
                 function_name: "arn:some-function".to_string(),
             },
             RequestArgs {
-                service: "secretsmanager.us-east-1.amazonaws.com".to_string(),
+                service: "secretsmanager".to_string(),
                 body: &serde_json::json!({ "SecretId": "arn:aws:secretsmanager:region:account-id:secret:secret-name"}),
                 time,
                 x_amz_target: "secretsmanager.GetSecretValue".to_string(),

--- a/bottlecap/src/secrets/decrypt.rs
+++ b/bottlecap/src/secrets/decrypt.rs
@@ -34,7 +34,7 @@ pub fn resolve_secrets(config: Config) -> Result<Config> {
                 .expect("AWS_LAMBDA_FUNCTION_NAME is not set!"),
         };
 
-        let resolved_key: String = if config.api_key_secret_arn.is_empty() {
+        let decrypted_key: String = if config.api_key_secret_arn.is_empty() {
             decrypt_aws_kms(client, config.kms_api_key.clone(), aws_config).expect("Failed to decrypt secret")
         } else {
             decrypt_aws_sm(client, config.api_key_secret_arn.clone(), aws_config).expect("Failed to decrypt secret")
@@ -43,7 +43,7 @@ pub fn resolve_secrets(config: Config) -> Result<Config> {
         debug!("Decrypt took {}ms", before_decrypt.elapsed().as_millis());
 
         Ok(Config {
-            api_key: resolved_key,
+            api_key: decrypted_key,
             ..config.clone()
         })
     } else {

--- a/bottlecap/src/secrets/decrypt.rs
+++ b/bottlecap/src/secrets/decrypt.rs
@@ -1,6 +1,8 @@
 use crate::config::Config;
+use base64::prelude::*;
 use chrono::{DateTime, Utc};
 use hmac::{Hmac, Mac};
+use reqwest::blocking::Client;
 use reqwest::header::{HeaderMap, HeaderValue};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -13,23 +15,34 @@ pub fn resolve_secrets(config: Config) -> Result<Config> {
     if !config.api_key.is_empty() {
         debug!("DD_API_KEY found, not trying to resolve secrets");
         Ok(config)
-    } else if !config.api_key_secret_arn.is_empty() {
-        let before_manual = Instant::now();
+    } else if !config.api_key_secret_arn.is_empty() || !config.kms_api_key.is_empty() {
+        let before_decrypt = Instant::now();
 
-        let resolved_key = manual_decrypt(
-            config.api_key_secret_arn.clone(),
-            AwsConfig {
-                region: env::var("AWS_DEFAULT_REGION").expect("AWS_DEFAULT_REGION not set"),
-                aws_access_key_id: env::var("AWS_ACCESS_KEY_ID")
-                    .expect("AWS_ACCESS_KEY_ID not set"),
-                aws_secret_access_key: env::var("AWS_SECRET_ACCESS_KEY")
-                    .expect("AWS_SECRET_ACCESS_KEY not set"),
-                aws_session_token: env::var("AWS_SESSION_TOKEN")
-                    .expect("AWS_SESSION_TOKEN is not set!"),
-            },
-        )
-        .expect("Failed to decrypt secret");
-        debug!("AWS decrypt took {}ms", before_manual.elapsed().as_millis());
+        let client = Client::builder()
+            .use_rustls_tls()
+            .build()
+            .expect("Failed to create reqwest client for aws decrypt");
+
+        let aws_config = AwsConfig {
+            region: env::var("AWS_DEFAULT_REGION").expect("AWS_DEFAULT_REGION not set"),
+            aws_access_key_id: env::var("AWS_ACCESS_KEY_ID").expect("AWS_ACCESS_KEY_ID not set"),
+            aws_secret_access_key: env::var("AWS_SECRET_ACCESS_KEY")
+                .expect("AWS_SECRET_ACCESS_KEY not set"),
+            aws_session_token: env::var("AWS_SESSION_TOKEN")
+                .expect("AWS_SESSION_TOKEN is not set!"),
+            function_name: env::var("AWS_LAMBDA_FUNCTION_NAME")
+                .expect("AWS_LAMBDA_FUNCTION_NAME is not set!"),
+        };
+
+        let decrypt_method = if config.api_key_secret_arn.is_empty() {
+            decrypt_aws_kms
+        } else {
+            decrypt_aws_sm
+        };
+
+        let resolved_key = decrypt_method(client, config.api_key_secret_arn.clone(), aws_config)
+            .expect("Failed to decrypt secret");
+        debug!("Decrypt took {}ms", before_decrypt.elapsed().as_millis());
 
         Ok(Config {
             api_key: resolved_key,
@@ -43,23 +56,73 @@ pub fn resolve_secrets(config: Config) -> Result<Config> {
     }
 }
 
+
+struct RequestArgs<'a> {
+    service: String,
+    body: &'a Value,
+    time: DateTime<Utc>,
+    x_amz_target: String,
+}
+
 struct AwsConfig {
     region: String,
     aws_access_key_id: String,
     aws_secret_access_key: String,
     aws_session_token: String,
+    function_name: String,
 }
 
-fn manual_decrypt(secret_arn: String, aws_config: AwsConfig) -> Result<String> {
+fn decrypt_aws_kms(client: Client, kms_key: String, aws_config: AwsConfig) -> Result<String> {
+    let decoded_key = BASE64_STANDARD
+        .decode(kms_key)
+        .expect("Failed to decode base64 string");
+    let decoded_key_str = String::from_utf8(decoded_key).expect("Failed to convert to String");
+
+    let json_body = &serde_json::json!({ "CiphertextBlob": decoded_key_str });
+
+    let headers = build_get_secret_signed_headers(
+        &aws_config,
+        RequestArgs {
+            service: format!("kms.{}.amazonaws.com", aws_config.region),
+            body: json_body,
+            time: Utc::now(),
+            x_amz_target: "TrentService.Decrypt".to_string(),
+        },
+    );
+
+    let v = request(json_body, headers, client);
+
+    return if let Some(secret_string) = v["CiphertextBlob"].as_str() {
+        debug!("{}", secret_string.to_string());
+        Ok(secret_string.to_string())
+    } else {
+        Err(Error::new(std::io::ErrorKind::InvalidData, v.to_string()))
+    };
+}
+
+fn decrypt_aws_sm(client: Client, secret_arn: String, aws_config: AwsConfig) -> Result<String> {
     let json_body = &serde_json::json!({ "SecretId": secret_arn});
 
-    let headers = build_get_secret_signed_headers(&aws_config, json_body, Utc::now());
+    let headers = build_get_secret_signed_headers(
+        &aws_config,
+        RequestArgs {
+            service: "secretsmanager".to_string(),
+            body: json_body,
+            time: Utc::now(),
+            x_amz_target: "secretsmanager.GetSecretValue".to_string(),
+        },
+    );
 
-    let client = reqwest::blocking::Client::builder()
-        .use_rustls_tls()
-        .build()
-        .expect("Failed to create reqwest client for aws decrypt");
+    let v = request(json_body, headers, client);
 
+    return if let Some(secret_string) = v["SecretString"].as_str() {
+        Ok(secret_string.to_string())
+    } else {
+        Err(Error::new(std::io::ErrorKind::InvalidData, v.to_string()))
+    };
+}
+
+fn request(json_body: &Value, headers: HeaderMap, client: Client) -> Value {
     let req = client
         .post(format!(
             "https://{}",
@@ -74,32 +137,28 @@ fn manual_decrypt(secret_arn: String, aws_config: AwsConfig) -> Result<String> {
         .text()
         .expect("Cannot deserialize body");
     let v: Value = serde_json::from_str(&body).expect("Failed to parse JSON");
-
-    return if let Some(secret_string) = v["SecretString"].as_str() {
-        Ok(secret_string.to_string())
-    } else {
-        Err(Error::new(std::io::ErrorKind::InvalidData, v.to_string()))
-    };
+    v
 }
 
 fn build_get_secret_signed_headers(
     aws_config: &AwsConfig,
-    json_body: &Value,
-    t: DateTime<Utc>,
+    header_values: RequestArgs,
 ) -> HeaderMap {
-    let service = "secretsmanager";
-    let amz_date = t.format("%Y%m%dT%H%M%SZ").to_string();
-    let date_stamp = t.format("%Y%m%d").to_string();
-    let host = format!("{}.{}.amazonaws.com", service, aws_config.region);
+    let amz_date = header_values.time.format("%Y%m%dT%H%M%SZ").to_string();
+    let date_stamp = header_values.time.format("%Y%m%d").to_string();
+    let host = format!(
+        "{}.{}.amazonaws.com",
+        header_values.service, aws_config.region
+    );
 
     let canonical_uri = "/";
     let canonical_querystring = "";
     let canonical_headers = format!(
-        "content-type:application/x-amz-json-1.1\nhost:{}\nx-amz-date:{}\nx-amz-security-token:{}\nx-amz-target:secretsmanager.GetSecretValue",
-        host, amz_date, aws_config.aws_session_token);
+        "content-type:application/x-amz-json-1.1\nhost:{}\nx-amz-date:{}\nx-amz-security-token:{}\nx-amz-target:{}",
+        host, amz_date, aws_config.aws_session_token, header_values.x_amz_target);
     let signed_headers = "content-type;host;x-amz-date;x-amz-security-token;x-amz-target";
 
-    let payload_hash = Sha256::digest(json_body.to_string().as_bytes());
+    let payload_hash = Sha256::digest(header_values.body.to_string().as_bytes());
     let payload_hash_hex = hex::encode(payload_hash);
 
     let canonical_request = format!(
@@ -108,7 +167,7 @@ fn build_get_secret_signed_headers(
     let algorithm = "AWS4-HMAC-SHA256";
     let credential_scope = format!(
         "{}/{}/{}/aws4_request",
-        date_stamp, aws_config.region, service
+        date_stamp, aws_config.region, header_values.service
     );
     let string_to_sign = format!(
         "{}\n{}\n{}\n{}",
@@ -122,7 +181,7 @@ fn build_get_secret_signed_headers(
         &aws_config.aws_secret_access_key,
         &date_stamp,
         aws_config.region.as_str(),
-        service,
+        header_values.service.as_str(),
     );
 
     let signature = hex::encode(sign(&signing_key, &string_to_sign));
@@ -147,7 +206,7 @@ fn build_get_secret_signed_headers(
     );
     headers.insert(
         "x-amz-target",
-        HeaderValue::from_str("secretsmanager.GetSecretValue").expect("invalid x-amz-target"),
+        HeaderValue::from_str(header_values.x_amz_target.as_str()).expect("invalid x-amz-target"),
     );
     headers.insert(
         "x-amz-security-token",
@@ -190,9 +249,14 @@ mod tests {
                 aws_access_key_id: "AKIDEXAMPLE".to_string(),
                 aws_secret_access_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".to_string(),
                 aws_session_token: "AQoDYXdzEJr...<remainder of session token>".to_string(),
+                function_name: "arn:some-function".to_string(),
             },
-            &serde_json::json!({ "SecretId": "arn:aws:secretsmanager:region:account-id:secret:secret-name"}),
-            time,
+            RequestArgs {
+                service: "secretsmanager.us-east-1.amazonaws.com".to_string(),
+                body: &serde_json::json!({ "SecretId": "arn:aws:secretsmanager:region:account-id:secret:secret-name"}),
+                time,
+                x_amz_target: "secretsmanager.GetSecretValue".to_string(),
+            },
         );
 
         let mut expected_headers = HeaderMap::new();

--- a/bottlecap/src/secrets/decrypt.rs
+++ b/bottlecap/src/secrets/decrypt.rs
@@ -92,7 +92,7 @@ fn decrypt_aws_kms(client: Client, kms_key: String, aws_config: AwsConfig) -> Re
 
     let v = request(json_body, headers, client);
 
-    return if let Some(secret_string) = v["CiphertextBlob"].as_str() {
+    return if let Some(secret_string) = v["Plaintext"].as_str() {
         debug!("{}", secret_string.to_string());
         Ok(secret_string.to_string())
     } else {

--- a/scripts/bottlecap/launch.sh
+++ b/scripts/bottlecap/launch.sh
@@ -48,9 +48,8 @@ call() {
 
 format () {
   cd ../../bottlecap
+  cargo clippy --fix --workspace --all-features
   cargo fmt
-  cargo clippy --workspace --all-features
-  cargo clippy --fix
 }
 
 "$@"


### PR DESCRIPTION
Goals
1- accept an unknown number of unknown env variable with `DD_`/`DATADOG_` prefix and `__KMS`\`_KMS_ENCRYPTED` suffix
2- decrypt them

Tactics
- remove error on undefined env variable in Config, to allow arbitrary values
- use a map of `string key` to tuple of  `string encrypted, string decrypted` to store the secrets in the config

Next step
- initialize client and aws config only once using a generic secret manager
- async secret resolution (after tokio merge)

Open questions
- using Config as a single source of truth for these async operation doesn't sound right. But it's a placeholder while waiting for tokio and async secret resolution
- what is the role/example of the arbitrary secrets? Should they be set in the os environment to be used from other processes? Or only internally in the datadog process?