### PR TITLE
feat: Cache cargo debs to compile faster

### DIFF
--- a/scripts/Dockerfile.bottlecap.build
+++ b/scripts/Dockerfile.bottlecap.build
@@ -13,7 +13,8 @@ RUN rustup component add rust-src --toolchain nightly-$PLATFORM-unknown-linux-gn
 RUN mkdir -p /tmp/dd
 COPY ./bottlecap /tmp/dd/bottlecap
 ENV RUSTFLAGS="-C panic=abort -Zlocation-detail=none"
-RUN cd /tmp/dd/bottlecap && cargo +nightly build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --release --target $PLATFORM-unknown-linux-gnu
+WORKDIR /tmp/dd/bottlecap
+RUN --mount=type=cache,target=/tmp/dd/bottlecap/target --mount=type=cache,target=/usr/local/cargo/registry cargo +nightly build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --release --target $PLATFORM-unknown-linux-gnu
 RUN cp /tmp/dd/bottlecap/target/$PLATFORM-unknown-linux-gnu/release/bottlecap /tmp/dd/bottlecap/bottlecap
 
 # zip the extension


### PR DESCRIPTION
Cache cargo deps to compile faster. Roughly 3x improvement.

Before:
<img width="491" alt="image" src="https://github.com/DataDog/datadog-lambda-extension/assets/1598537/703266bb-ea35-4796-b93b-1666f9bda5c3">

After:
<img width="515" alt="image" src="https://github.com/DataDog/datadog-lambda-extension/assets/1598537/c34f2113-62ec-418a-9aa6-6d218dbd1401">

