### PR TITLE
chore(bottlecap): update where the release binary is being copied from

### DIFF
--- a/scripts/Dockerfile.bottlecap.build
+++ b/scripts/Dockerfile.bottlecap.build
@@ -15,7 +15,7 @@ COPY ./bottlecap /tmp/dd/bottlecap
 ENV RUSTFLAGS="-C panic=abort -Zlocation-detail=none"
 WORKDIR /tmp/dd/bottlecap
 RUN --mount=type=cache,target=/tmp/dd/bottlecap/target --mount=type=cache,target=/usr/local/cargo/registry cargo +nightly build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --release --target $PLATFORM-unknown-linux-gnu
-RUN cp /tmp/dd/bottlecap/target/$PLATFORM-unknown-linux-gnu/release/bottlecap /tmp/dd/bottlecap/bottlecap
+RUN cp /tmp/dd/bottlecap/target/release/bottlecap /tmp/dd/bottlecap/bottlecap
 
 # zip the extension
 FROM ubuntu:latest as compresser


### PR DESCRIPTION
# What?

Updates the build to not consider the platform, from #269 

# Motivation

It doesn't build