### PR TITLE
chore(bottlecap): update `Function|Extension` log parsing

### DIFF
--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -466,7 +466,10 @@ mod tests {
 
         let result = processor.get_message(event).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Unable to parse log"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Unable to parse log"));
     }
 
     // get_intake_log

--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -64,13 +64,14 @@ impl LambdaProcessor {
         let copy = event.clone();
         match event.record {
             TelemetryRecord::Function(v) | TelemetryRecord::Extension(v) => {
-                let mut message = String::new();
-                if v.is_object() {
-                    message = serde_json::to_string(&v).unwrap_or_default();
-                } else if v.is_string() {
-                    message = v.as_str().unwrap_or_default().to_string();
-                } else {
-                    Err("Unable to parse log message")?;
+                let message = match v {
+                    serde_json::Value::Object(obj) => serde_json::to_string(&obj).unwrap_or_default(),
+                    serde_json::Value::String(s) => s,
+                    _ => String::new(),
+                };
+
+                if message.is_empty() {
+                    return Err("Unable to parse log".into());
                 }
 
                 Ok(Message::new(

--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -60,6 +60,7 @@ impl LambdaProcessor {
         }
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn get_message(&mut self, event: TelemetryEvent) -> Result<Message, Box<dyn Error>> {
         let copy = event.clone();
         match event.record {

--- a/bottlecap/src/telemetry/events.rs
+++ b/bottlecap/src/telemetry/events.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 
 use serde::Deserialize;
+use serde_json::Value;
 
 /// Payload received from the Telemetry API
 #[derive(Clone, Debug, Deserialize, PartialEq)]
@@ -17,10 +18,10 @@ pub struct TelemetryEvent {
 #[serde(tag = "type", content = "record", rename_all = "lowercase")]
 pub enum TelemetryRecord {
     /// Function log records
-    Function(String),
+    Function(Value),
 
     /// Extension log records
-    Extension(String),
+    Extension(Value),
 
     /// Platform init start record
     #[serde(rename = "platform.initStart", rename_all = "camelCase")]
@@ -219,13 +220,20 @@ mod tests {
         // function
         function: (
             r#"{"time": "2024-04-24T12:34:56.789Z","type": "function", "record": "datadog <3 serverless"}"#,
-            TelemetryRecord::Function("datadog <3 serverless".to_string()),
+            TelemetryRecord::Function(Value::String("datadog <3 serverless".to_string())),
+        ),
+
+        function_with_json: (
+            r#"{"time": "2024-04-24T12:34:56.789Z","type": "function", "record": {"hello": "world"}}"#,
+            TelemetryRecord::Function(Value::Object(
+                serde_json::from_str(r#"{"hello": "world"}"#).unwrap()
+            )),
         ),
 
         // extension
         extension: (
             r#"{"time": "2024-04-24T12:34:56.789Z","type": "extension", "record": "datadog <3 serverless"}"#,
-            TelemetryRecord::Extension("datadog <3 serverless".to_string()),
+            TelemetryRecord::Extension(Value::String("datadog <3 serverless".to_string())),
         ),
 
         // platform.initStart


### PR DESCRIPTION
# What?
Instead of using a `String`, we now accept any JSON valid value for `Function|Extension` logs

# Notes

Also removed the `request_id` on `RuntimeDone` so no orphan logs get it from older invocations.

# Motivation
Error when setting Lambda logs to be JSON formatted, also [SVLS-4971](https://datadoghq.atlassian.net/browse/SVLS-4971)

[SVLS-4971]: https://datadoghq.atlassian.net/browse/SVLS-4971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ