### PR TITLE
Svls 4840 metrics api limit

### DIFF
--- a/bottlecap/src/metrics/aggregator.rs
+++ b/bottlecap/src/metrics/aggregator.rs
@@ -1,15 +1,16 @@
 //! The aggregation of metrics.
 
-use crate::metrics::metric;
-use crate::metrics::{
-    constants, datadog, errors,
-    metric::{Metric, Type},
+use crate::{
+    metrics::{constants, datadog, errors, metric},
+    tags::provider,
 };
+use datadog::Metric as DatadogMetric;
+use metric::{Metric, Type};
 use std::sync::Arc;
 
-use crate::tags::provider;
 use datadog_protos::metrics::{Dogsketch, Sketch, SketchPayload};
 use hashbrown::hash_table;
+use protobuf::Message;
 use std::time;
 use tracing::error;
 use ustr::Ustr;
@@ -176,6 +177,8 @@ impl Entry {
 pub struct Aggregator<const CONTEXTS: usize> {
     tags_provider: Arc<provider::Provider>,
     map: hash_table::HashTable<Entry>,
+    max_batch_entries_size: usize,
+    max_content_size_bytes: usize,
 }
 
 impl<const CONTEXTS: usize> Aggregator<CONTEXTS> {
@@ -195,6 +198,8 @@ impl<const CONTEXTS: usize> Aggregator<CONTEXTS> {
         Ok(Self {
             tags_provider,
             map: hash_table::HashTable::new(),
+            max_batch_entries_size: constants::MAX_ENTRIES_NUMBER,
+            max_content_size_bytes: constants::MAX_CONTENT_SIZE_BYTES,
         })
     }
 
@@ -241,30 +246,76 @@ impl<const CONTEXTS: usize> Aggregator<CONTEXTS> {
             .try_into()
             .unwrap_or_default();
         for entry in &self.map {
-            if entry.kind != metric::Type::Distribution {
+            let Some(sketch) = self.build_sketch(now, entry) else {
                 continue;
-            }
-            let sketch = entry.metric_value.get_sketch();
-            let mut dogsketch = Dogsketch::default();
-            sketch.merge_to_dogsketch(&mut dogsketch);
-            // TODO(Astuyve) allow users to specify timestamp
-            dogsketch.set_ts(now);
-            let mut sketch = Sketch::default();
-            sketch.set_dogsketches(vec![dogsketch]);
-            let name = entry.name.to_string();
-            sketch.set_metric(name.clone().into());
-            let mut base_tag_vec = self.tags_provider.get_tags_vec();
-            let mut tags = tags_string_to_vector(entry.tags);
-            base_tag_vec.append(&mut tags); // TODO split on comma
-            sketch.set_tags(
-                base_tag_vec
-                    .into_iter()
-                    .map(std::convert::Into::into)
-                    .collect(),
-            );
+            };
             sketch_payload.sketches.push(sketch);
         }
         sketch_payload
+    }
+
+    #[must_use]
+    pub fn distributions_to_protobuf_serialized(&self) -> Vec<u8> {
+        let mut buffer: Vec<u8> = Vec::with_capacity(self.max_content_size_bytes);
+        let mut count_entries = 0;
+        let now = time::SystemTime::now()
+            .duration_since(time::UNIX_EPOCH)
+            .expect("unable to poll clock, unrecoverable")
+            .as_secs()
+            .try_into()
+            .unwrap_or_default();
+        for entry in &self.map {
+            let Some(sketch) = self.build_sketch(now, entry) else {
+                continue;
+            };
+            let pb_size = sketch.compute_size();
+            if pb_size > self.max_content_size_bytes as u64
+                || pb_size + buffer.len() as u64 > self.max_content_size_bytes as u64
+            {
+                break;
+            }
+
+            let serialized_metric = match sketch.write_to_bytes() {
+                Ok(serialized_sketch) => serialized_sketch,
+                Err(e) => {
+                    error!("failed to serialize metric: {:?}", e);
+                    continue;
+                }
+            };
+
+            buffer.extend(serialized_metric);
+            count_entries += 1;
+
+            if count_entries >= self.max_batch_entries_size {
+                break;
+            }
+        }
+        buffer
+    }
+
+    fn build_sketch(&self, now: i64, entry: &Entry) -> Option<Sketch> {
+        if entry.kind != metric::Type::Distribution {
+            return None;
+        }
+        let sketch = entry.metric_value.get_sketch();
+        let mut dogsketch = Dogsketch::default();
+        sketch.merge_to_dogsketch(&mut dogsketch);
+        // TODO(Astuyve) allow users to specify timestamp
+        dogsketch.set_ts(now);
+        let mut sketch = Sketch::default();
+        sketch.set_dogsketches(vec![dogsketch]);
+        let name = entry.name.to_string();
+        sketch.set_metric(name.clone().into());
+        let mut base_tag_vec = self.tags_provider.get_tags_vec();
+        let mut tags = tags_string_to_vector(entry.tags);
+        base_tag_vec.append(&mut tags); // TODO split on comma
+        sketch.set_tags(
+            base_tag_vec
+                .into_iter()
+                .map(std::convert::Into::into)
+                .collect(),
+        );
+        Some(sketch)
     }
 
     #[allow(clippy::cast_precision_loss)]
@@ -276,56 +327,92 @@ impl<const CONTEXTS: usize> Aggregator<CONTEXTS> {
             series: Vec::with_capacity(1_024),
         };
         for entry in &self.map {
-            if entry.kind == metric::Type::Distribution {
+            let Some(metric) = self.build_metric(entry) else {
                 continue;
-            }
-            let mut resources = Vec::with_capacity(constants::MAX_TAGS);
-            for (name, kind) in entry.tag() {
-                let resource = datadog::Resource {
-                    name: name.as_str(),
-                    kind: kind.as_str(),
-                };
-                resources.push(resource);
-            }
-            let kind = match entry.kind {
-                metric::Type::Count => datadog::DdMetricKind::Count,
-                metric::Type::Gauge => datadog::DdMetricKind::Gauge,
-                metric::Type::Distribution => unreachable!(),
-            };
-            let point = datadog::Point {
-                value: entry.metric_value.get_value(),
-                // TODO(astuyve) allow user to specify timestamp
-                timestamp: time::SystemTime::now()
-                    .duration_since(time::UNIX_EPOCH)
-                    .expect("unable to poll clock, unrecoverable")
-                    .as_secs(),
-            };
-
-            let mut final_tags = Vec::new();
-            // TODO
-            // These tags are interned so we don't need to clone them here but we're just doing it
-            // because it's easier than dealing with the lifetimes.
-            if let Some(tags) = entry.tags {
-                final_tags = tags
-                    .split(',')
-                    .map(std::string::ToString::to_string)
-                    .collect();
-            }
-            final_tags.append(&mut self.tags_provider.get_tags_vec());
-            let metric = datadog::Metric {
-                metric: entry.name.as_str(),
-                resources,
-                kind,
-                points: [point; 1],
-                tags: final_tags,
             };
             series.series.push(metric);
         }
         series
     }
 
+    fn build_metric(&self, entry: &Entry) -> Option<DatadogMetric> {
+        if entry.kind == metric::Type::Distribution {
+            return None;
+        }
+        let mut resources = Vec::with_capacity(constants::MAX_TAGS);
+        for (name, kind) in entry.tag() {
+            let resource = datadog::Resource {
+                name: name.as_str(),
+                kind: kind.as_str(),
+            };
+            resources.push(resource);
+        }
+        let kind = match entry.kind {
+            metric::Type::Count => datadog::DdMetricKind::Count,
+            metric::Type::Gauge => datadog::DdMetricKind::Gauge,
+            metric::Type::Distribution => unreachable!(),
+        };
+        let point = datadog::Point {
+            value: entry.metric_value.get_value(),
+            // TODO(astuyve) allow user to specify timestamp
+            timestamp: time::SystemTime::now()
+                .duration_since(time::UNIX_EPOCH)
+                .expect("unable to poll clock, unrecoverable")
+                .as_secs(),
+        };
+
+        let mut final_tags = Vec::new();
+        // TODO
+        // These tags are interned so we don't need to clone them here but we're just doing it
+        // because it's easier than dealing with the lifetimes.
+        if let Some(tags) = entry.tags {
+            final_tags = tags
+                .split(',')
+                .map(std::string::ToString::to_string)
+                .collect();
+        }
+        final_tags.append(&mut self.tags_provider.get_tags_vec());
+        Some(DatadogMetric {
+            metric: entry.name.as_str(),
+            resources,
+            kind,
+            points: [point; 1],
+            tags: final_tags,
+        })
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    #[must_use]
+    pub fn to_series_serialized(&self) -> Vec<u8> {
+        let mut buffer: Vec<u8> = Vec::with_capacity(self.max_content_size_bytes);
+        let mut count_entries = 0;
+        for entry in &self.map {
+            if entry.kind == metric::Type::Distribution {
+                continue;
+            }
+            let metric = self.build_metric(entry);
+            let serialized_metric = match serde_json::to_vec(&metric) {
+                Ok(serialized_metric) => serialized_metric,
+                Err(e) => {
+                    error!("failed to serialize metric: {:?}", e);
+                    continue;
+                }
+            };
+            if serialized_metric.len() + buffer.len() > self.max_content_size_bytes {
+                break;
+            }
+            buffer.extend(serialized_metric);
+            count_entries += 1;
+
+            if count_entries >= self.max_batch_entries_size {
+                break;
+            }
+        }
+        buffer
+    }
+
     #[cfg(test)]
-    pub fn get_value_by_id(
+    pub fn get_sketch_by_id(
         &mut self,
         name: Ustr,
         tags: Option<Ustr>,
@@ -341,6 +428,20 @@ impl<const CONTEXTS: usize> Aggregator<CONTEXTS> {
             hash_table::Entry::Occupied(entry) => {
                 Some(entry.get().metric_value.get_sketch().clone())
             }
+        }
+    }
+
+    #[cfg(test)]
+    pub fn get_value_by_id(&mut self, name: Ustr, tags: Option<Ustr>) -> Option<f64> {
+        let id = metric::id(name, tags);
+
+        match self.map.entry(
+            id,
+            |m| m.id == id,
+            |m| crate::metrics::metric::id(m.name, m.tags),
+        ) {
+            hash_table::Entry::Vacant(_) => None,
+            hash_table::Entry::Occupied(entry) => Some(entry.get().metric_value.get_value()),
         }
     }
 }
@@ -362,8 +463,10 @@ mod tests {
         metric::{self, Metric},
         Aggregator,
     };
+    use crate::metrics::constants;
     use crate::tags::provider;
     use crate::LAMBDA_RUNTIME_SLUG;
+    use hashbrown::hash_table;
     use std::collections::hash_map;
     use std::sync::Arc;
 
@@ -436,13 +539,21 @@ mod tests {
     fn clear() {
         let mut aggregator = Aggregator::<2>::new(create_tags_provider()).unwrap();
 
-        let metric1 = Metric::parse("test:1|c|k:v").expect("metric parse failed");
-        let metric2 = Metric::parse("foo:1|c|k:v").expect("metric parse failed");
+        let metric1 = Metric::parse("test:3|c|k:v").expect("metric parse failed");
+        let metric2 = Metric::parse("foo:5|c|k:v").expect("metric parse failed");
 
         assert!(aggregator.insert(&metric1).is_ok());
         assert!(aggregator.insert(&metric2).is_ok());
 
         assert_eq!(aggregator.map.len(), 2);
+        assert_eq!(
+            aggregator.get_value_by_id("foo".into(), None).unwrap(),
+            5f64
+        );
+        assert_eq!(
+            aggregator.get_value_by_id("test".into(), None).unwrap(),
+            3f64
+        );
         aggregator.clear();
         assert_eq!(aggregator.map.len(), 0);
     }
@@ -479,9 +590,55 @@ mod tests {
         assert!(aggregator.insert(&metric2).is_ok());
 
         assert_eq!(aggregator.map.len(), 2);
-        assert_eq!(aggregator.distributions_to_protobuf().sketches.len(), 2);
+        assert_eq!(aggregator.distributions_to_protobuf().sketches().len(), 2);
         assert_eq!(aggregator.map.len(), 2);
-        assert_eq!(aggregator.distributions_to_protobuf().sketches.len(), 2);
+        assert_eq!(aggregator.distributions_to_protobuf().sketches().len(), 2);
         assert_eq!(aggregator.map.len(), 2);
+    }
+
+    #[test]
+    fn distributions_to_protobuf_serialized() {
+        let mut aggregator = Aggregator::<2> {
+            tags_provider: create_tags_provider(),
+            map: hash_table::HashTable::new(),
+            max_batch_entries_size: constants::MAX_ENTRIES_NUMBER,
+            max_content_size_bytes: constants::MAX_CONTENT_SIZE_BYTES,
+        };
+
+        let metric1 = Metric::parse("test:1|d|k:v").expect("metric parse failed");
+        let metric2 = Metric::parse("foo:1|d|k:v").expect("metric parse failed");
+
+        assert!(aggregator.insert(&metric1).is_ok());
+        assert!(aggregator.insert(&metric2).is_ok());
+
+        assert_eq!(aggregator.distributions_to_protobuf_serialized().len(), 197);
+
+        let metric3 = Metric::parse("foo:1|c|k:v").expect("metric parse failed");
+        assert!(aggregator.insert(&metric3).is_ok());
+
+        assert_eq!(aggregator.distributions_to_protobuf_serialized().len(), 197);
+    }
+
+    #[test]
+    fn to_series_serialized() {
+        let mut aggregator = Aggregator::<2> {
+            tags_provider: create_tags_provider(),
+            map: hash_table::HashTable::new(),
+            max_batch_entries_size: constants::MAX_ENTRIES_NUMBER,
+            max_content_size_bytes: constants::MAX_CONTENT_SIZE_BYTES,
+        };
+
+        let metric1 = Metric::parse("test:1|c|k:v").expect("metric parse failed");
+        let metric2 = Metric::parse("foo:1|g|k:v").expect("metric parse failed");
+
+        assert!(aggregator.insert(&metric1).is_ok());
+        assert!(aggregator.insert(&metric2).is_ok());
+
+        assert_eq!(aggregator.to_series_serialized().len(), 283);
+
+        let metric3 = Metric::parse("foo:1|d|k:v").expect("metric parse failed");
+        assert!(aggregator.insert(&metric3).is_ok());
+
+        assert_eq!(aggregator.to_series_serialized().len(), 283);
     }
 }

--- a/bottlecap/src/metrics/aggregator.rs
+++ b/bottlecap/src/metrics/aggregator.rs
@@ -43,11 +43,13 @@ struct DistributionMetric {
 }
 
 #[derive(Debug, Clone)]
+#[repr(transparent)]
 struct CountMetric {
     value: f64,
 }
 
 #[derive(Debug, Clone)]
+#[repr(transparent)]
 struct GaugeMetric {
     value: f64,
 }

--- a/bottlecap/src/metrics/aggregator.rs
+++ b/bottlecap/src/metrics/aggregator.rs
@@ -268,10 +268,7 @@ impl<const CONTEXTS: usize> Aggregator<CONTEXTS> {
             let Some(sketch) = self.build_sketch(now, entry) else {
                 continue;
             };
-            let pb_size = sketch.compute_size();
-            if pb_size > self.max_content_size_bytes as u64
-                || pb_size + buffer.len() as u64 > self.max_content_size_bytes as u64
-            {
+            if sketch.compute_size() + buffer.len() as u64 > self.max_content_size_bytes as u64 {
                 break;
             }
 

--- a/bottlecap/src/metrics/constants.rs
+++ b/bottlecap/src/metrics/constants.rs
@@ -4,3 +4,7 @@ pub const MAX_TAGS: usize = 32;
 pub const CONTEXTS: usize = 1024;
 
 pub static MAX_CONTEXTS: usize = 65_536; // 2**16, arbitrary
+
+pub(crate) const MAX_ENTRIES_NUMBER: usize = 1_000;
+
+pub(crate) const MAX_CONTENT_SIZE_BYTES: usize = 5 * 1_024 * 1_024;

--- a/bottlecap/src/metrics/enhanced/lambda.rs
+++ b/bottlecap/src/metrics/enhanced/lambda.rs
@@ -193,13 +193,14 @@ mod tests {
         let metrics_aggr = setup();
         let lambda = Lambda::new(metrics_aggr.clone());
         lambda.increment_invocation_metric().unwrap();
-        let pbuf = metrics_aggr
+        match metrics_aggr
             .lock()
             .expect("lock poisoned")
-            .distributions_to_protobuf();
-        let _ = pbuf.sketches().iter().map(|sketch| {
-            assert_eq!(sketch.metric, constants::INVOCATIONS_METRIC.into());
-        });
+            .get_sketch_by_id(constants::INVOCATIONS_METRIC.into(), None)
+        {
+            Some(pbuf) => assert_eq!(1f64, pbuf.sum().unwrap()),
+            None => panic!("failed to get value by id"),
+        };
     }
 
     #[test]
@@ -207,13 +208,14 @@ mod tests {
         let metrics_aggr = setup();
         let lambda = Lambda::new(metrics_aggr.clone());
         lambda.increment_errors_metric().unwrap();
-        let pbuf = metrics_aggr
+        match metrics_aggr
             .lock()
             .expect("lock poisoned")
-            .distributions_to_protobuf();
-        let _ = pbuf.sketches().iter().map(|sketch| {
-            assert_eq!(sketch.metric, constants::ERRORS_METRIC.into());
-        });
+            .get_sketch_by_id(constants::ERRORS_METRIC.into(), None)
+        {
+            Some(pbuf) => assert_eq!(1f64, pbuf.sum().unwrap()),
+            None => panic!("failed to get value by id"),
+        };
     }
 
     #[test]
@@ -234,26 +236,26 @@ mod tests {
         let mut ms_sketch = ddsketch_agent::DDSketch::default();
         ms_sketch.insert(0.1);
         assert_eq!(
-            aggr.get_value_by_id(constants::DURATION_METRIC.into(), None)
+            aggr.get_sketch_by_id(constants::DURATION_METRIC.into(), None)
                 .unwrap(),
             ms_sketch
         );
         assert_eq!(
-            aggr.get_value_by_id(constants::BILLED_DURATION_METRIC.into(), None)
+            aggr.get_sketch_by_id(constants::BILLED_DURATION_METRIC.into(), None)
                 .unwrap(),
             ms_sketch
         );
         let mut mem_used_sketch = ddsketch_agent::DDSketch::default();
         mem_used_sketch.insert(128.0);
         assert_eq!(
-            aggr.get_value_by_id(constants::MAX_MEMORY_USED_METRIC.into(), None)
+            aggr.get_sketch_by_id(constants::MAX_MEMORY_USED_METRIC.into(), None)
                 .unwrap(),
             mem_used_sketch
         );
         let mut max_mem_sketch = ddsketch_agent::DDSketch::default();
         max_mem_sketch.insert(256.0);
         assert_eq!(
-            aggr.get_value_by_id(constants::MEMORY_SIZE_METRIC.into(), None)
+            aggr.get_sketch_by_id(constants::MEMORY_SIZE_METRIC.into(), None)
                 .unwrap(),
             max_mem_sketch
         );


### PR DESCRIPTION
- create methods for serializing the payload within byte size/entry size limits. Not sure if the entry size limit makes sense though

From the docs of `api/v2/series` there is only a byte restriction https://docs.datadoghq.com/api/latest/metrics/#submit-metrics. For the `api/beta/sketches` there is no public docs available I think

- flusher loops over them until everything that can be send, is sent. The skipped metrics/sketches will still pollute the buffer though
- flusher should not lock for all that time. A good solution to avoid excess mutex usage could be to copy the outgoing buffer