### PR TITLE
Move vuln scan action from agent repo.

### DIFF
--- a/.github/workflows/serverless-vuln-scan.yml
+++ b/.github/workflows/serverless-vuln-scan.yml
@@ -1,0 +1,78 @@
+name: "Serverless Vulnerability Scan"
+
+on:
+  pull_request:
+    paths:
+      - 'cmd/serverless/**'
+      - 'cmd/serverless-init/**'
+      - 'pkg/serverless/**'
+      - '.github/workflows/serverless-vuln-scan.yml'
+
+env:
+  VERSION: 1  # env var required when building extension
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout datadog-agent repository
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        with:
+          path: go/src/github.com/DataDog/datadog-agent
+
+      - name: Checkout datadog-lambda-extension repository
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        with:
+          repository: DataDog/datadog-lambda-extension
+          path: go/src/github.com/DataDog/datadog-lambda-extension
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
+
+      - name: Build extension
+        run: |
+          cd go/src/github.com/DataDog/datadog-lambda-extension
+          ./scripts/build_binary_and_layer_dockerized.sh
+
+      - name: Scan amd64 image with trivy
+        uses: aquasecurity/trivy-action@d710430a6722f083d3b36b8339ff66b32f22ee55 # v0.19.0
+        with:
+          image-ref: "datadog/build-lambda-extension-amd64:${{ env.VERSION }}"
+          ignore-unfixed: true
+          exit-code: 1
+          format: table
+
+      - name: Scan arm64 image with trivy
+        uses: aquasecurity/trivy-action@d710430a6722f083d3b36b8339ff66b32f22ee55 # v0.19.0
+        with:
+          image-ref: "datadog/build-lambda-extension-arm64:${{ env.VERSION }}"
+          ignore-unfixed: true
+          exit-code: 1
+          format: table
+
+      - name: Scan amd64 image with grype
+        uses: anchore/scan-action@3343887d815d7b07465f6fdcd395bd66508d486a # v3.6.4
+        with:
+          image: "datadog/build-lambda-extension-amd64:${{ env.VERSION }}"
+          only-fixed: true
+          fail-build: true
+          severity-cutoff: low
+          output-format: table
+
+      - name: Scan arm64 image with grype
+        uses: anchore/scan-action@3343887d815d7b07465f6fdcd395bd66508d486a # v3.6.4
+        with:
+          image: "datadog/build-lambda-extension-arm64:${{ env.VERSION }}"
+          only-fixed: true
+          fail-build: true
+          severity-cutoff: low
+          output-format: table
+
+      - name: Scan binary files with grype
+        uses: anchore/scan-action@3343887d815d7b07465f6fdcd395bd66508d486a # v3.6.4
+        with:
+          path: go/src/github.com/DataDog/datadog-lambda-extension/.layers
+          only-fixed: true
+          fail-build: true
+          severity-cutoff: low
+          output-format: table

--- a/.github/workflows/serverless-vuln-scan.yml
+++ b/.github/workflows/serverless-vuln-scan.yml
@@ -1,12 +1,9 @@
 name: "Serverless Vulnerability Scan"
 
 on:
-  pull_request:
-    paths:
-      - 'cmd/serverless/**'
-      - 'cmd/serverless-init/**'
-      - 'pkg/serverless/**'
-      - '.github/workflows/serverless-vuln-scan.yml'
+  schedule:
+    # daily at midnight
+    - cron: "0 0 * * *"
 
 env:
   VERSION: 1  # env var required when building extension


### PR DESCRIPTION
In order to be more proactive on vulnerabilities in the serverless extension, run a vulnerability scan nightly on the agent `main` branch.

We will be able to subscribe in slack to this workflow which I will do once we're done testing it.