### PR TITLE
Specify repo to check out in vulnerability scan.

### DIFF
--- a/.github/workflows/serverless-vuln-scan.yml
+++ b/.github/workflows/serverless-vuln-scan.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Checkout datadog-agent repository
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
+          repository: DataDog/datadog-agent
           path: go/src/github.com/DataDog/datadog-agent
 
       - name: Checkout datadog-lambda-extension repository


### PR DESCRIPTION
I copied this file from the agent repo. When you don't specify the repo to check out, it checks out the one in which the test is running. So, without specifying the repo, it was attempting to check out datadog-lambda-extension instead of datadog-agent.