### PR TITLE
fix: use minimal profile to avoid x86 cargo-docs segmentation fault i…

### DIFF
--- a/scripts/Dockerfile.bottlecap.build
+++ b/scripts/Dockerfile.bottlecap.build
@@ -7,8 +7,8 @@ RUN yum install -y curl gcc gcc-c++ make unzip openssl openssl-devel
 COPY ./scripts/install-protoc.sh /
 RUN chmod +x /install-protoc.sh && /install-protoc.sh
 RUN curl https://sh.rustup.rs -sSf | \
-    sh -s -- --default-toolchain nightly-$PLATFORM-unknown-linux-gnu -y
-    ENV PATH=/root/.cargo/bin:$PATH
+    sh -s -- --profile minimal --default-toolchain nightly-$PLATFORM-unknown-linux-gnu -y
+ENV PATH=/root/.cargo/bin:$PATH
 RUN rustup component add rust-src --toolchain nightly-$PLATFORM-unknown-linux-gnu
 RUN mkdir -p /tmp/dd
 COPY ./bottlecap/src /tmp/dd/bottlecap/src


### PR DESCRIPTION
…ssue

Developers using m1 macs suddenly ran into segfault issues installing rust in docker.

As this doesn't affect users on ubuntu machines, we expect this to be a docker issue and not a rust issue.

Regardless, the segfault comes from installing `rust-docs` which can be ignored for the purposes of our builder, so this fixes the issue.

https://github.com/docker/for-mac/issues/7295