### PR TITLE
Alexgallotta/svls 4840 fix metric limit

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -1,5 +1,4 @@
 #![deny(clippy::all)]
-#![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::unwrap_used)]
 #![deny(unused_extern_crates)]
@@ -45,7 +44,7 @@ use bottlecap::{
         flusher::Flusher as MetricsFlusher,
     },
     secrets::decrypt,
-    tags::{lambda, provider},
+    tags::{lambda, provider::Provider as TagProvider},
     telemetry::{
         self,
         client::TelemetryApiClient,
@@ -420,14 +419,14 @@ fn setup_tag_provider(
     aws_config: &AwsConfig,
     config: &Arc<Config>,
     account_id: &str,
-) -> Arc<provider::Provider> {
+) -> Arc<TagProvider> {
     let function_arn =
         build_function_arn(account_id, &aws_config.region, &aws_config.function_name);
     let metadata_hash = hash_map::HashMap::from([(
         lambda::tags::FUNCTION_ARN_KEY.to_string(),
         function_arn.clone(),
     )]);
-    Arc::new(provider::Provider::new(
+    Arc::new(TagProvider::new(
         Arc::clone(config),
         LAMBDA_RUNTIME_SLUG.to_string(),
         &metadata_hash,
@@ -437,7 +436,7 @@ fn setup_tag_provider(
 fn start_logs_agent(
     config: &Arc<Config>,
     resolved_api_key: String,
-    tags_provider: &Arc<provider::Provider>,
+    tags_provider: &Arc<TagProvider>,
     event_bus: Sender<Event>,
 ) -> (Sender<Vec<TelemetryEvent>>, LogsFlusher) {
     let mut logs_agent = LogsAgent::new(Arc::clone(tags_provider), Arc::clone(config), event_bus);

--- a/bottlecap/src/metrics/aggregator.rs
+++ b/bottlecap/src/metrics/aggregator.rs
@@ -279,7 +279,8 @@ impl<const CONTEXTS: usize> Aggregator<CONTEXTS> {
 
             if serialized_metric_size > 0 {
                 if (series_payload.series.len() >= self.max_batch_entries_single_metric)
-                    || (this_batch_size + serialized_metric_size >= self.max_batch_bytes_single_metric)
+                    || (this_batch_size + serialized_metric_size
+                        >= self.max_batch_bytes_single_metric)
                 {
                     if this_batch_size == 0 {
                         warn!("Only one metric exceeds max batch size, adding it anyway: {:?} with {}", metric.metric, serialized_metric_size);

--- a/bottlecap/src/metrics/aggregator.rs
+++ b/bottlecap/src/metrics/aggregator.rs
@@ -1,15 +1,17 @@
 //! The aggregation of metrics.
 
-use crate::metrics::metric;
-use crate::metrics::{
-    constants, datadog, errors,
-    metric::{Metric, Type},
+use crate::{
+    metrics::{constants, datadog, errors, metric},
+    tags::provider,
 };
+use datadog::Metric as DatadogMetric;
+use metric::{Metric, Type};
 use std::sync::Arc;
 
-use crate::tags::provider;
 use datadog_protos::metrics::{Dogsketch, Sketch, SketchPayload};
+use ddsketch_agent::DDSketch;
 use hashbrown::hash_table;
+use protobuf::Message;
 use std::time;
 use tracing::error;
 use ustr::Ustr;
@@ -33,126 +35,57 @@ struct Entry {
     id: u64,
     name: Ustr,
     tags: Option<Ustr>,
-    kind: metric::Type,
     metric_value: MetricValue,
 }
 
 #[derive(Debug, Clone)]
-struct DistributionMetric {
-    sketch: ddsketch_agent::DDSketch,
-}
-
-#[derive(Debug, Clone)]
-struct CountMetric {
-    value: f64,
-}
-
-#[derive(Debug, Clone)]
-struct GaugeMetric {
-    value: f64,
-}
-
-#[derive(Debug, Clone)]
 enum MetricValue {
-    Count(CountMetric),
-    Gauge(GaugeMetric),
-    Distribution(DistributionMetric),
+    Count(f64),
+    Gauge(f64),
+    Distribution(DDSketch),
 }
 
-trait InsertMetric {
-    fn insert_metric(&mut self, metric: &Metric);
-}
-
-trait GetValue {
-    fn get_value(&self) -> f64;
-}
-
-trait GetSketch {
-    fn get_sketch(&self) -> &ddsketch_agent::DDSketch;
-}
-
-impl InsertMetric for MetricValue {
+impl MetricValue {
     fn insert_metric(&mut self, metric: &Metric) {
+        // safe because we know there's at least one value when we parse
         match self {
-            MetricValue::Count(count_metric) => {
-                count_metric.insert_metric(metric);
-            }
-            MetricValue::Gauge(gauge_metric) => {
-                gauge_metric.insert_metric(metric);
-            }
-            MetricValue::Distribution(distribution_metric) => {
-                distribution_metric.insert_metric(metric);
+            MetricValue::Count(count) => *count += metric.first_value().unwrap_or_default(),
+            MetricValue::Gauge(gauge) => *gauge = metric.first_value().unwrap_or_default(),
+            MetricValue::Distribution(distribution) => {
+                distribution.insert(metric.first_value().unwrap_or_default());
             }
         }
     }
-}
 
-impl GetSketch for MetricValue {
-    fn get_sketch(&self) -> &ddsketch_agent::DDSketch {
+    fn get_value(&self) -> Option<f64> {
         match self {
-            MetricValue::Count(_) | MetricValue::Gauge(_) => unreachable!(),
-            MetricValue::Distribution(distribution_metric) => &distribution_metric.sketch,
+            MetricValue::Count(count) => Some(*count),
+            MetricValue::Gauge(gauge) => Some(*gauge),
+            MetricValue::Distribution(_) => None,
         }
     }
-}
 
-impl GetValue for MetricValue {
-    fn get_value(&self) -> f64 {
+    fn get_sketch(&self) -> Option<&DDSketch> {
         match self {
-            MetricValue::Count(count_metric) => count_metric.value,
-            MetricValue::Gauge(gauge_metric) => gauge_metric.value,
-            MetricValue::Distribution(_distribution_metric) => unreachable!(),
+            MetricValue::Distribution(distribution) => Some(distribution),
+            _ => None,
         }
-    }
-}
-
-impl InsertMetric for DistributionMetric {
-    fn insert_metric(&mut self, metric: &Metric) {
-        // safe because we know there's at least one value when we parse
-        self.sketch.insert(metric.first_value().unwrap_or_default());
-    }
-}
-
-impl InsertMetric for GaugeMetric {
-    fn insert_metric(&mut self, metric: &Metric) {
-        // safe because we know there's at least one value when we parse
-        self.value = metric.first_value().unwrap_or_default();
-    }
-}
-
-impl InsertMetric for CountMetric {
-    fn insert_metric(&mut self, metric: &Metric) {
-        // safe because we know there's at least one value when we parse
-        self.value += metric.first_value().unwrap_or_default();
     }
 }
 
 impl Entry {
     fn new_from_metric(id: u64, metric: &Metric) -> Self {
-        let new_metric_value = metric.first_value().unwrap_or_else(|e| {
-            error!("failed to parse metric: {:?}", e);
-            0.0
-        });
+        let mut metric_value = match metric.kind {
+            Type::Count => MetricValue::Count(0.0),
+            Type::Gauge => MetricValue::Gauge(0.0),
+            Type::Distribution => MetricValue::Distribution(DDSketch::default()),
+        };
+        metric_value.insert_metric(metric);
         Self {
             id,
-            metric_value: match metric.kind {
-                Type::Count => MetricValue::Count(CountMetric {
-                    value: new_metric_value,
-                }),
-                Type::Gauge => MetricValue::Gauge(GaugeMetric {
-                    value: new_metric_value,
-                }),
-                Type::Distribution => {
-                    let mut empty_sketch = MetricValue::Distribution(DistributionMetric {
-                        sketch: ddsketch_agent::DDSketch::default(),
-                    });
-                    empty_sketch.insert_metric(metric);
-                    empty_sketch
-                }
-            },
             name: metric.name,
             tags: metric.tags,
-            kind: metric.kind,
+            metric_value,
         }
     }
 
@@ -174,6 +107,8 @@ impl Entry {
 pub struct Aggregator<const CONTEXTS: usize> {
     tags_provider: Arc<provider::Provider>,
     map: hash_table::HashTable<Entry>,
+    max_batch_entries_size: usize,
+    max_content_size_bytes: usize,
 }
 
 impl<const CONTEXTS: usize> Aggregator<CONTEXTS> {
@@ -193,6 +128,8 @@ impl<const CONTEXTS: usize> Aggregator<CONTEXTS> {
         Ok(Self {
             tags_provider,
             map: hash_table::HashTable::new(),
+            max_batch_entries_size: constants::MAX_ENTRIES_NUMBER,
+            max_content_size_bytes: constants::MAX_CONTENT_SIZE_BYTES,
         })
     }
 
@@ -206,11 +143,10 @@ impl<const CONTEXTS: usize> Aggregator<CONTEXTS> {
         let id = metric::id(metric.name, metric.tags);
         let len = self.map.len();
 
-        match self.map.entry(
-            id,
-            |m| m.id == id,
-            |m| crate::metrics::metric::id(m.name, m.tags),
-        ) {
+        match self
+            .map
+            .entry(id, |m| m.id == id, |m| metric::id(m.name, m.tags))
+        {
             hash_table::Entry::Vacant(entry) => {
                 if len >= CONTEXTS {
                     return Err(errors::Insert::Overflow);
@@ -239,30 +175,74 @@ impl<const CONTEXTS: usize> Aggregator<CONTEXTS> {
             .try_into()
             .unwrap_or_default();
         for entry in &self.map {
-            if entry.kind != metric::Type::Distribution {
+            let Some(sketch) = self.build_sketch(now, entry) else {
                 continue;
-            }
-            let sketch = entry.metric_value.get_sketch();
-            let mut dogsketch = Dogsketch::default();
-            sketch.merge_to_dogsketch(&mut dogsketch);
-            // TODO(Astuyve) allow users to specify timestamp
-            dogsketch.set_ts(now);
-            let mut sketch = Sketch::default();
-            sketch.set_dogsketches(vec![dogsketch]);
-            let name = entry.name.to_string();
-            sketch.set_metric(name.clone().into());
-            let mut base_tag_vec = self.tags_provider.get_tags_vec();
-            let mut tags = tags_string_to_vector(entry.tags);
-            base_tag_vec.append(&mut tags); // TODO split on comma
-            sketch.set_tags(
-                base_tag_vec
-                    .into_iter()
-                    .map(std::convert::Into::into)
-                    .collect(),
-            );
+            };
             sketch_payload.sketches.push(sketch);
         }
         sketch_payload
+    }
+
+    #[must_use]
+    pub fn distributions_to_protobuf_serialized(&self) -> Vec<u8> {
+        let mut buffer: Vec<u8> = Vec::with_capacity(self.max_content_size_bytes);
+        let mut count_entries = 0;
+        let now = time::SystemTime::now()
+            .duration_since(time::UNIX_EPOCH)
+            .expect("unable to poll clock, unrecoverable")
+            .as_secs()
+            .try_into()
+            .unwrap_or_default();
+        for entry in &self.map {
+            let Some(sketch) = self.build_sketch(now, entry) else {
+                continue;
+            };
+            if sketch.compute_size() + buffer.len() as u64 > self.max_content_size_bytes as u64 {
+                break;
+            }
+
+            let serialized_metric = match sketch.write_to_bytes() {
+                Ok(serialized_sketch) => serialized_sketch,
+                Err(e) => {
+                    error!("failed to serialize metric: {:?}", e);
+                    continue;
+                }
+            };
+
+            buffer.extend(serialized_metric);
+            count_entries += 1;
+
+            if count_entries >= self.max_batch_entries_size {
+                break;
+            }
+        }
+        buffer
+    }
+
+    fn build_sketch(&self, now: i64, entry: &Entry) -> Option<Sketch> {
+        if let MetricValue::Distribution(_) = entry.metric_value {
+        } else {
+            return None;
+        };
+        let sketch = entry.metric_value.get_sketch()?;
+        let mut dogsketch = Dogsketch::default();
+        sketch.merge_to_dogsketch(&mut dogsketch);
+        // TODO(Astuyve) allow users to specify timestamp
+        dogsketch.set_ts(now);
+        let mut sketch = Sketch::default();
+        sketch.set_dogsketches(vec![dogsketch]);
+        let name = entry.name.to_string();
+        sketch.set_metric(name.clone().into());
+        let mut base_tag_vec = self.tags_provider.get_tags_vec();
+        let mut tags = tags_string_to_vector(entry.tags);
+        base_tag_vec.append(&mut tags); // TODO split on comma
+        sketch.set_tags(
+            base_tag_vec
+                .into_iter()
+                .map(std::convert::Into::into)
+                .collect(),
+        );
+        Some(sketch)
     }
 
     #[allow(clippy::cast_precision_loss)]
@@ -274,60 +254,104 @@ impl<const CONTEXTS: usize> Aggregator<CONTEXTS> {
             series: Vec::with_capacity(1_024),
         };
         for entry in &self.map {
-            if entry.kind == metric::Type::Distribution {
+            let Some(metric) = self.build_metric(entry) else {
                 continue;
-            }
-            let mut resources = Vec::with_capacity(constants::MAX_TAGS);
-            for (name, kind) in entry.tag() {
-                let resource = datadog::Resource {
-                    name: name.as_str(),
-                    kind: kind.as_str(),
-                };
-                resources.push(resource);
-            }
-            let kind = match entry.kind {
-                metric::Type::Count => datadog::DdMetricKind::Count,
-                metric::Type::Gauge => datadog::DdMetricKind::Gauge,
-                metric::Type::Distribution => unreachable!(),
-            };
-            let point = datadog::Point {
-                value: entry.metric_value.get_value(),
-                // TODO(astuyve) allow user to specify timestamp
-                timestamp: time::SystemTime::now()
-                    .duration_since(time::UNIX_EPOCH)
-                    .expect("unable to poll clock, unrecoverable")
-                    .as_secs(),
-            };
-
-            let mut final_tags = Vec::new();
-            // TODO
-            // These tags are interned so we don't need to clone them here but we're just doing it
-            // because it's easier than dealing with the lifetimes.
-            if let Some(tags) = entry.tags {
-                final_tags = tags
-                    .split(',')
-                    .map(std::string::ToString::to_string)
-                    .collect();
-            }
-            final_tags.append(&mut self.tags_provider.get_tags_vec());
-            let metric = datadog::Metric {
-                metric: entry.name.as_str(),
-                resources,
-                kind,
-                points: [point; 1],
-                tags: final_tags,
             };
             series.series.push(metric);
         }
         series
     }
 
+    fn build_metric(&self, entry: &Entry) -> Option<DatadogMetric> {
+        if let MetricValue::Distribution(_) = entry.metric_value {
+            return None;
+        };
+        let mut resources = Vec::with_capacity(constants::MAX_TAGS);
+        for (name, kind) in entry.tag() {
+            let resource = datadog::Resource {
+                name: name.as_str(),
+                kind: kind.as_str(),
+            };
+            resources.push(resource);
+        }
+        let kind = match entry.metric_value {
+            MetricValue::Count(_) => datadog::DdMetricKind::Count,
+            MetricValue::Gauge(_) => datadog::DdMetricKind::Gauge,
+            MetricValue::Distribution(_) => unreachable!(),
+        };
+        let point = datadog::Point {
+            value: entry.metric_value.get_value()?,
+            // TODO(astuyve) allow user to specify timestamp
+            timestamp: time::SystemTime::now()
+                .duration_since(time::UNIX_EPOCH)
+                .expect("unable to poll clock, unrecoverable")
+                .as_secs(),
+        };
+
+        let mut final_tags = Vec::new();
+        // TODO
+        // These tags are interned so we don't need to clone them here but we're just doing it
+        // because it's easier than dealing with the lifetimes.
+        if let Some(tags) = entry.tags {
+            final_tags = tags
+                .split(',')
+                .map(std::string::ToString::to_string)
+                .collect();
+        }
+        final_tags.append(&mut self.tags_provider.get_tags_vec());
+        Some(DatadogMetric {
+            metric: entry.name.as_str(),
+            resources,
+            kind,
+            points: [point; 1],
+            tags: final_tags,
+        })
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    #[must_use]
+    pub fn to_series_serialized(&self) -> Vec<u8> {
+        let mut buffer: Vec<u8> = Vec::with_capacity(self.max_content_size_bytes);
+        let mut count_entries = 0;
+        for entry in &self.map {
+            let Some(metric) = self.build_metric(entry) else {
+                continue;
+            };
+            let serialized_metric = match serde_json::to_vec(&metric) {
+                Ok(serialized_metric) => serialized_metric,
+                Err(e) => {
+                    error!("failed to serialize metric: {:?}", e);
+                    continue;
+                }
+            };
+            if serialized_metric.len() + buffer.len() > self.max_content_size_bytes {
+                break;
+            }
+            buffer.extend(serialized_metric);
+            count_entries += 1;
+
+            if count_entries >= self.max_batch_entries_size {
+                break;
+            }
+        }
+        buffer
+    }
+
     #[cfg(test)]
-    pub fn get_value_by_id(
-        &mut self,
-        name: Ustr,
-        tags: Option<Ustr>,
-    ) -> Option<ddsketch_agent::DDSketch> {
+    pub fn get_sketch_by_id(&mut self, name: Ustr, tags: Option<Ustr>) -> Option<DDSketch> {
+        let id = metric::id(name, tags);
+
+        match self
+            .map
+            .entry(id, |m| m.id == id, |m| metric::id(m.name, m.tags))
+        {
+            hash_table::Entry::Vacant(_) => None,
+            hash_table::Entry::Occupied(entry) => entry.get().metric_value.get_sketch().cloned(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn get_value_by_id(&mut self, name: Ustr, tags: Option<Ustr>) -> Option<f64> {
         let id = metric::id(name, tags);
 
         match self.map.entry(
@@ -336,9 +360,7 @@ impl<const CONTEXTS: usize> Aggregator<CONTEXTS> {
             |m| crate::metrics::metric::id(m.name, m.tags),
         ) {
             hash_table::Entry::Vacant(_) => None,
-            hash_table::Entry::Occupied(entry) => {
-                Some(entry.get().metric_value.get_sketch().clone())
-            }
+            hash_table::Entry::Occupied(entry) => entry.get().metric_value.get_value(),
         }
     }
 }
@@ -362,6 +384,7 @@ mod tests {
     };
     use crate::tags::provider;
     use crate::LAMBDA_RUNTIME_SLUG;
+    use hashbrown::hash_table;
     use std::collections::hash_map;
     use std::sync::Arc;
 
@@ -434,13 +457,21 @@ mod tests {
     fn clear() {
         let mut aggregator = Aggregator::<2>::new(create_tags_provider()).unwrap();
 
-        let metric1 = Metric::parse("test:1|c|k:v").expect("metric parse failed");
-        let metric2 = Metric::parse("foo:1|c|k:v").expect("metric parse failed");
+        let metric1 = Metric::parse("test:3|c|k:v").expect("metric parse failed");
+        let metric2 = Metric::parse("foo:5|c|k:v").expect("metric parse failed");
 
         assert!(aggregator.insert(&metric1).is_ok());
         assert!(aggregator.insert(&metric2).is_ok());
 
         assert_eq!(aggregator.map.len(), 2);
+        assert_eq!(
+            aggregator.get_value_by_id("foo".into(), None).unwrap(),
+            5f64
+        );
+        assert_eq!(
+            aggregator.get_value_by_id("test".into(), None).unwrap(),
+            3f64
+        );
         aggregator.clear();
         assert_eq!(aggregator.map.len(), 0);
     }
@@ -477,9 +508,116 @@ mod tests {
         assert!(aggregator.insert(&metric2).is_ok());
 
         assert_eq!(aggregator.map.len(), 2);
-        assert_eq!(aggregator.distributions_to_protobuf().sketches.len(), 2);
+        assert_eq!(aggregator.distributions_to_protobuf().sketches().len(), 2);
         assert_eq!(aggregator.map.len(), 2);
-        assert_eq!(aggregator.distributions_to_protobuf().sketches.len(), 2);
+        assert_eq!(aggregator.distributions_to_protobuf().sketches().len(), 2);
         assert_eq!(aggregator.map.len(), 2);
+    }
+
+    #[test]
+    fn distributions_to_protobuf_serialized() {
+        let mut aggregator = Aggregator::<1_000> {
+            tags_provider: create_tags_provider(),
+            map: hash_table::HashTable::new(),
+            max_batch_entries_size: 100,
+            max_content_size_bytes: 1500,
+        };
+
+        assert_eq!(aggregator.distributions_to_protobuf_serialized().len(), 0);
+
+        assert!(aggregator
+            .insert(
+                &Metric::parse("test1:1|d|k:v".to_string().as_str()).expect("metric parse failed")
+            )
+            .is_ok());
+        assert_eq!(aggregator.distributions_to_protobuf_serialized().len(), 100);
+
+        assert!(aggregator
+            .insert(&Metric::parse("foo:1|c|k:v").expect("metric parse failed"))
+            .is_ok());
+        assert_eq!(aggregator.distributions_to_protobuf_serialized().len(), 100);
+
+        for i in 10..20 {
+            assert!(aggregator
+                .insert(
+                    &Metric::parse(format!("test{i}:{i}|d|k:v").as_str())
+                        .expect("metric parse failed")
+                )
+                .is_ok());
+        }
+
+        assert_eq!(
+            aggregator.distributions_to_protobuf_serialized().len(),
+            1110
+        );
+
+        aggregator = Aggregator::<1_000> {
+            tags_provider: create_tags_provider(),
+            map: hash_table::HashTable::new(),
+            max_batch_entries_size: 5,
+            max_content_size_bytes: 1500,
+        };
+
+        for i in 10..20 {
+            assert!(aggregator
+                .insert(
+                    &Metric::parse(format!("test{i}:{i}|d|k:v").as_str())
+                        .expect("metric parse failed")
+                )
+                .is_ok());
+        }
+        assert_eq!(aggregator.distributions_to_protobuf_serialized().len(), 505);
+    }
+
+    #[test]
+    fn to_series_serialized() {
+        let mut aggregator = Aggregator::<1_000> {
+            tags_provider: create_tags_provider(),
+            map: hash_table::HashTable::new(),
+            max_batch_entries_size: 100,
+            max_content_size_bytes: 1500,
+        };
+
+        assert_eq!(aggregator.distributions_to_protobuf_serialized().len(), 0);
+
+        assert!(aggregator
+            .insert(
+                &Metric::parse("test1:1|c|k:v".to_string().as_str()).expect("metric parse failed")
+            )
+            .is_ok());
+        assert_eq!(aggregator.to_series_serialized().len(), 143);
+
+        assert!(aggregator
+            .insert(&Metric::parse("foo:1|d|k:v").expect("metric parse failed"))
+            .is_ok());
+        assert_eq!(aggregator.to_series_serialized().len(), 143);
+
+        for i in 10..20 {
+            assert!(aggregator
+                .insert(
+                    &Metric::parse(format!("test{i}:{i}|c|k:v").as_str())
+                        .expect("metric parse failed")
+                )
+                .is_ok());
+        }
+
+        assert_eq!(aggregator.to_series_serialized().len(), 1448);
+
+        aggregator = Aggregator::<1_000> {
+            tags_provider: create_tags_provider(),
+            map: hash_table::HashTable::new(),
+            max_batch_entries_size: 5,
+            max_content_size_bytes: 1500,
+        };
+
+        for i in 10..20 {
+            assert!(aggregator
+                .insert(
+                    &Metric::parse(format!("test{i}:{i}|c|k:v").as_str())
+                        .expect("metric parse failed")
+                )
+                .is_ok());
+        }
+        assert_eq!(aggregator.to_series_serialized().len(), 725);
     }
 }

--- a/bottlecap/src/metrics/aggregator.rs
+++ b/bottlecap/src/metrics/aggregator.rs
@@ -107,8 +107,10 @@ impl Entry {
 pub struct Aggregator<const CONTEXTS: usize> {
     tags_provider: Arc<provider::Provider>,
     map: hash_table::HashTable<Entry>,
-    max_batch_entries_size: usize,
-    max_content_size_bytes: usize,
+    max_batch_entries_size_single_metric: usize,
+    max_content_size_bytes_single_metric: usize,
+    max_batch_entries_size_sketch_metric: usize,
+    max_content_size_bytes_sketch_metric: usize,
 }
 
 impl<const CONTEXTS: usize> Aggregator<CONTEXTS> {
@@ -128,8 +130,10 @@ impl<const CONTEXTS: usize> Aggregator<CONTEXTS> {
         Ok(Self {
             tags_provider,
             map: hash_table::HashTable::new(),
-            max_batch_entries_size: constants::MAX_ENTRIES_NUMBER,
-            max_content_size_bytes: constants::MAX_CONTENT_SIZE_BYTES,
+            max_batch_entries_size_single_metric: constants::MAX_ENTRIES_NUMBER_SINGLE_METRIC,
+            max_content_size_bytes_single_metric: constants::MAX_CONTENT_SIZE_BYTES_SINGLE_METRIC,
+            max_batch_entries_size_sketch_metric: constants::MAX_ENTRIES_NUMBER_SKETCH_METRIC,
+            max_content_size_bytes_sketch_metric: constants::MAX_CONTENT_SIZE_SKETCH_METRIC,
         })
     }
 
@@ -185,7 +189,7 @@ impl<const CONTEXTS: usize> Aggregator<CONTEXTS> {
 
     #[must_use]
     pub fn distributions_to_protobuf_serialized(&self) -> Vec<u8> {
-        let mut buffer: Vec<u8> = Vec::with_capacity(self.max_content_size_bytes);
+        let mut buffer: Vec<u8> = Vec::with_capacity(self.max_content_size_bytes_sketch_metric);
         let mut count_entries = 0;
         let now = time::SystemTime::now()
             .duration_since(time::UNIX_EPOCH)
@@ -197,7 +201,9 @@ impl<const CONTEXTS: usize> Aggregator<CONTEXTS> {
             let Some(sketch) = self.build_sketch(now, entry) else {
                 continue;
             };
-            if sketch.compute_size() + buffer.len() as u64 > self.max_content_size_bytes as u64 {
+            if sketch.compute_size() + buffer.len() as u64
+                > self.max_content_size_bytes_sketch_metric as u64
+            {
                 break;
             }
 
@@ -212,7 +218,7 @@ impl<const CONTEXTS: usize> Aggregator<CONTEXTS> {
             buffer.extend(serialized_metric);
             count_entries += 1;
 
-            if count_entries >= self.max_batch_entries_size {
+            if count_entries >= self.max_batch_entries_size_sketch_metric {
                 break;
             }
         }
@@ -311,7 +317,7 @@ impl<const CONTEXTS: usize> Aggregator<CONTEXTS> {
     #[allow(clippy::cast_precision_loss)]
     #[must_use]
     pub fn to_series_serialized(&self) -> Vec<u8> {
-        let mut buffer: Vec<u8> = Vec::with_capacity(self.max_content_size_bytes);
+        let mut buffer: Vec<u8> = Vec::with_capacity(self.max_content_size_bytes_single_metric);
         let mut count_entries = 0;
         for entry in &self.map {
             let Some(metric) = self.build_metric(entry) else {
@@ -324,13 +330,13 @@ impl<const CONTEXTS: usize> Aggregator<CONTEXTS> {
                     continue;
                 }
             };
-            if serialized_metric.len() + buffer.len() > self.max_content_size_bytes {
+            if serialized_metric.len() + buffer.len() > self.max_content_size_bytes_single_metric {
                 break;
             }
             buffer.extend(serialized_metric);
             count_entries += 1;
 
-            if count_entries >= self.max_batch_entries_size {
+            if count_entries >= self.max_batch_entries_size_single_metric {
                 break;
             }
         }
@@ -519,8 +525,10 @@ mod tests {
         let mut aggregator = Aggregator::<1_000> {
             tags_provider: create_tags_provider(),
             map: hash_table::HashTable::new(),
-            max_batch_entries_size: 100,
-            max_content_size_bytes: 1500,
+            max_batch_entries_size_single_metric: 1_000,
+            max_content_size_bytes_single_metric: 1_000,
+            max_batch_entries_size_sketch_metric: 100,
+            max_content_size_bytes_sketch_metric: 1_500,
         };
 
         assert_eq!(aggregator.distributions_to_protobuf_serialized().len(), 0);
@@ -554,8 +562,10 @@ mod tests {
         aggregator = Aggregator::<1_000> {
             tags_provider: create_tags_provider(),
             map: hash_table::HashTable::new(),
-            max_batch_entries_size: 5,
-            max_content_size_bytes: 1500,
+            max_batch_entries_size_single_metric: 1_000,
+            max_content_size_bytes_single_metric: 1_000,
+            max_batch_entries_size_sketch_metric: 5,
+            max_content_size_bytes_sketch_metric: 1_500,
         };
 
         for i in 10..20 {
@@ -570,12 +580,14 @@ mod tests {
     }
 
     #[test]
-    fn to_series_serialized() {
+    fn to_series_serialized_ignore_distribution() {
         let mut aggregator = Aggregator::<1_000> {
             tags_provider: create_tags_provider(),
             map: hash_table::HashTable::new(),
-            max_batch_entries_size: 100,
-            max_content_size_bytes: 1500,
+            max_batch_entries_size_single_metric: 100,
+            max_content_size_bytes_single_metric: 1_500,
+            max_batch_entries_size_sketch_metric: 1_000,
+            max_content_size_bytes_sketch_metric: 1_000,
         };
 
         assert_eq!(aggregator.distributions_to_protobuf_serialized().len(), 0);
@@ -591,23 +603,17 @@ mod tests {
             .insert(&Metric::parse("foo:1|d|k:v").expect("metric parse failed"))
             .is_ok());
         assert_eq!(aggregator.to_series_serialized().len(), 143);
+    }
 
-        for i in 10..20 {
-            assert!(aggregator
-                .insert(
-                    &Metric::parse(format!("test{i}:{i}|c|k:v").as_str())
-                        .expect("metric parse failed")
-                )
-                .is_ok());
-        }
-
-        assert_eq!(aggregator.to_series_serialized().len(), 1448);
-
-        aggregator = Aggregator::<1_000> {
+    #[test]
+    fn to_series_serialized_reach_max() {
+        let mut aggregator = Aggregator::<1_000> {
             tags_provider: create_tags_provider(),
             map: hash_table::HashTable::new(),
-            max_batch_entries_size: 5,
-            max_content_size_bytes: 1500,
+            max_batch_entries_size_single_metric: 5,
+            max_content_size_bytes_single_metric: 1_500,
+            max_batch_entries_size_sketch_metric: 1_000,
+            max_content_size_bytes_sketch_metric: 1_000,
         };
 
         for i in 10..20 {

--- a/bottlecap/src/metrics/constants.rs
+++ b/bottlecap/src/metrics/constants.rs
@@ -4,3 +4,7 @@ pub const MAX_TAGS: usize = 32;
 pub const CONTEXTS: usize = 1024;
 
 pub static MAX_CONTEXTS: usize = 65_536; // 2**16, arbitrary
+
+pub(crate) const MAX_ENTRIES_NUMBER: usize = 1_000;
+
+pub(crate) const MAX_CONTENT_SIZE_BYTES: usize = 5 * 1_024 * 1_024;

--- a/bottlecap/src/metrics/constants.rs
+++ b/bottlecap/src/metrics/constants.rs
@@ -5,12 +5,12 @@ pub const CONTEXTS: usize = 1024;
 
 pub static MAX_CONTEXTS: usize = 65_536; // 2**16, arbitrary
 
-const MB: usize = 1_024 * 1_024;
+const MB: u64 = 1_024 * 1_024;
 
 pub(crate) const MAX_ENTRIES_SINGLE_METRIC: usize = 1_000;
 
-pub(crate) const MAX_SIZE_BYTES_SINGLE_METRIC: usize = 5 * MB;
+pub(crate) const MAX_SIZE_BYTES_SINGLE_METRIC: u64 = 5 * MB;
 
 pub(crate) const MAX_ENTRIES_SKETCH_METRIC: usize = 1_000;
 
-pub(crate) const MAX_SIZE_SKETCH_METRIC: usize = 62 * MB;
+pub(crate) const MAX_SIZE_SKETCH_METRIC: u64 = 62 * MB;

--- a/bottlecap/src/metrics/constants.rs
+++ b/bottlecap/src/metrics/constants.rs
@@ -5,6 +5,12 @@ pub const CONTEXTS: usize = 1024;
 
 pub static MAX_CONTEXTS: usize = 65_536; // 2**16, arbitrary
 
-pub(crate) const MAX_ENTRIES_NUMBER: usize = 1_000;
+const MB: usize = 1_024 * 1_024;
 
-pub(crate) const MAX_CONTENT_SIZE_BYTES: usize = 5 * 1_024 * 1_024;
+pub(crate) const MAX_ENTRIES_NUMBER_SINGLE_METRIC: usize = 1_000;
+
+pub(crate) const MAX_CONTENT_SIZE_BYTES_SINGLE_METRIC: usize = 5 * MB;
+
+pub(crate) const MAX_ENTRIES_NUMBER_SKETCH_METRIC: usize = 1_000;
+
+pub(crate) const MAX_CONTENT_SIZE_SKETCH_METRIC: usize = 62 * MB;

--- a/bottlecap/src/metrics/constants.rs
+++ b/bottlecap/src/metrics/constants.rs
@@ -7,10 +7,10 @@ pub static MAX_CONTEXTS: usize = 65_536; // 2**16, arbitrary
 
 const MB: usize = 1_024 * 1_024;
 
-pub(crate) const MAX_ENTRIES_NUMBER_SINGLE_METRIC: usize = 1_000;
+pub(crate) const MAX_ENTRIES_SINGLE_METRIC: usize = 1_000;
 
-pub(crate) const MAX_CONTENT_SIZE_BYTES_SINGLE_METRIC: usize = 5 * MB;
+pub(crate) const MAX_SIZE_BYTES_SINGLE_METRIC: usize = 5 * MB;
 
-pub(crate) const MAX_ENTRIES_NUMBER_SKETCH_METRIC: usize = 1_000;
+pub(crate) const MAX_ENTRIES_SKETCH_METRIC: usize = 1_000;
 
-pub(crate) const MAX_CONTENT_SIZE_SKETCH_METRIC: usize = 62 * MB;
+pub(crate) const MAX_SIZE_SKETCH_METRIC: usize = 62 * MB;

--- a/bottlecap/src/metrics/enhanced/lambda.rs
+++ b/bottlecap/src/metrics/enhanced/lambda.rs
@@ -193,13 +193,14 @@ mod tests {
         let metrics_aggr = setup();
         let lambda = Lambda::new(metrics_aggr.clone());
         lambda.increment_invocation_metric().unwrap();
-        let pbuf = metrics_aggr
+        match metrics_aggr
             .lock()
             .expect("lock poisoned")
-            .distributions_to_protobuf();
-        let _ = pbuf.sketches().iter().map(|sketch| {
-            assert_eq!(sketch.metric, constants::INVOCATIONS_METRIC.into());
-        });
+            .get_sketch_by_id(constants::INVOCATIONS_METRIC.into(), None)
+        {
+            Some(pbuf) => assert_eq!(1f64, pbuf.sum().unwrap()),
+            None => panic!("failed to get value by id"),
+        };
     }
 
     #[test]
@@ -207,13 +208,14 @@ mod tests {
         let metrics_aggr = setup();
         let lambda = Lambda::new(metrics_aggr.clone());
         lambda.increment_errors_metric().unwrap();
-        let pbuf = metrics_aggr
+        match metrics_aggr
             .lock()
             .expect("lock poisoned")
-            .distributions_to_protobuf();
-        let _ = pbuf.sketches().iter().map(|sketch| {
-            assert_eq!(sketch.metric, constants::ERRORS_METRIC.into());
-        });
+            .get_sketch_by_id(constants::ERRORS_METRIC.into(), None)
+        {
+            Some(pbuf) => assert_eq!(1f64, pbuf.sum().unwrap()),
+            None => panic!("failed to get value by id"),
+        };
     }
 
     #[test]
@@ -234,26 +236,26 @@ mod tests {
         let mut ms_sketch = ddsketch_agent::DDSketch::default();
         ms_sketch.insert(0.1);
         assert_eq!(
-            aggr.get_value_by_id(constants::DURATION_METRIC.into(), None)
+            aggr.get_sketch_by_id(constants::DURATION_METRIC.into(), None)
                 .unwrap(),
             ms_sketch
         );
         assert_eq!(
-            aggr.get_value_by_id(constants::BILLED_DURATION_METRIC.into(), None)
+            aggr.get_sketch_by_id(constants::BILLED_DURATION_METRIC.into(), None)
                 .unwrap(),
             ms_sketch
         );
         let mut mem_used_sketch = ddsketch_agent::DDSketch::default();
         mem_used_sketch.insert(128.0);
         assert_eq!(
-            aggr.get_value_by_id(constants::MAX_MEMORY_USED_METRIC.into(), None)
+            aggr.get_sketch_by_id(constants::MAX_MEMORY_USED_METRIC.into(), None)
                 .unwrap(),
             mem_used_sketch
         );
         let mut max_mem_sketch = ddsketch_agent::DDSketch::default();
         max_mem_sketch.insert(256.0);
         assert_eq!(
-            aggr.get_value_by_id(constants::MEMORY_SIZE_METRIC.into(), None)
+            aggr.get_sketch_by_id(constants::MEMORY_SIZE_METRIC.into(), None)
                 .unwrap(),
             max_mem_sketch
         );

--- a/bottlecap/src/metrics/flusher.rs
+++ b/bottlecap/src/metrics/flusher.rs
@@ -18,7 +18,10 @@ impl Flusher {
     pub async fn flush(&mut self) {
         let (all_series, all_distributions) = {
             let mut aggregator = self.aggregator.lock().expect("lock poisoned");
-            (aggregator.consume_metrics(), aggregator.consume_distributions())
+            (
+                aggregator.consume_metrics(),
+                aggregator.consume_distributions(),
+            )
         };
         for a_batch in all_series {
             debug!("flushing {} series to datadog", a_batch.series.len());

--- a/bottlecap/src/metrics/flusher.rs
+++ b/bottlecap/src/metrics/flusher.rs
@@ -29,7 +29,7 @@ impl Flusher {
             current_points = locked_aggr.to_series_api_limited();
             // TODO(astuyve) retry and do not panic
         }
-        let mut current_distribution_points = locked_aggr.distributions_to_protobuf();
+        let mut current_distribution_points = locked_aggr.distributions_to_protobuf_api_limited();
         while !current_distribution_points.sketches().is_empty() {
             match &self
                 .dd_api
@@ -41,7 +41,7 @@ impl Flusher {
                     debug!("failed to ship distributions to datadog: {:?}", e);
                 }
             }
-            current_distribution_points = locked_aggr.distributions_to_protobuf();
+            current_distribution_points = locked_aggr.distributions_to_protobuf_api_limited();
         }
         locked_aggr.clear();
     }

--- a/bottlecap/src/metrics/flusher.rs
+++ b/bottlecap/src/metrics/flusher.rs
@@ -17,31 +17,23 @@ impl Flusher {
 
     pub async fn flush(&mut self) {
         let locked_aggr = &mut self.aggregator.lock().expect("lock poisoned");
-        let mut current_points = locked_aggr.to_series_api_limited();
-        while !current_points.series.is_empty() {
-            debug!("flushing {} series to datadog", current_points.series.len());
-            match &self.dd_api.ship_series(&current_points).await {
+        for a_batch in locked_aggr.metrics_to_series_api_limited() {
+            debug!("flushing {} series to datadog", a_batch.series.len());
+            match &self.dd_api.ship_series(&a_batch).await {
                 Ok(()) => {}
                 Err(e) => {
                     debug!("failed to ship metrics to datadog: {:?}", e);
                 }
             }
-            current_points = locked_aggr.to_series_api_limited();
             // TODO(astuyve) retry and do not panic
         }
-        let mut current_distribution_points = locked_aggr.distributions_to_protobuf_api_limited();
-        while !current_distribution_points.sketches().is_empty() {
-            match &self
-                .dd_api
-                .ship_distributions(&current_distribution_points)
-                .await
-            {
+        for a_batch in locked_aggr.distributions_to_protobuf_api_limited() {
+            match &self.dd_api.ship_distributions(&a_batch).await {
                 Ok(()) => {}
                 Err(e) => {
                     debug!("failed to ship distributions to datadog: {:?}", e);
                 }
             }
-            current_distribution_points = locked_aggr.distributions_to_protobuf_api_limited();
         }
         locked_aggr.clear();
     }

--- a/bottlecap/src/metrics/flusher.rs
+++ b/bottlecap/src/metrics/flusher.rs
@@ -17,7 +17,7 @@ impl Flusher {
 
     pub async fn flush(&mut self) {
         let locked_aggr = &mut self.aggregator.lock().expect("lock poisoned");
-        let mut current_points = locked_aggr.to_series_serialized();
+        let mut current_points = locked_aggr.to_series_api_limited();
         while !current_points.is_empty() {
             debug!("flushing {} series to datadog", current_points.len());
             match &self.dd_api.ship_series(current_points).await {
@@ -26,10 +26,10 @@ impl Flusher {
                     debug!("failed to ship metrics to datadog: {:?}", e);
                 }
             }
-            current_points = locked_aggr.to_series_serialized();
+            current_points = locked_aggr.to_series_api_limited();
             // TODO(astuyve) retry and do not panic
         }
-        let mut current_distribution_points = locked_aggr.distributions_to_protobuf_serialized();
+        let mut current_distribution_points = locked_aggr.distributions_to_protobuf_api_limited();
         while !current_distribution_points.is_empty() {
             match &self
                 .dd_api
@@ -41,7 +41,7 @@ impl Flusher {
                     debug!("failed to ship distributions to datadog: {:?}", e);
                 }
             }
-            current_distribution_points = locked_aggr.distributions_to_protobuf_serialized();
+            current_distribution_points = locked_aggr.distributions_to_protobuf_api_limited();
         }
         locked_aggr.clear();
     }

--- a/bottlecap/src/metrics/flusher.rs
+++ b/bottlecap/src/metrics/flusher.rs
@@ -17,7 +17,7 @@ impl Flusher {
 
     pub async fn flush(&mut self) {
         let locked_aggr = &mut self.aggregator.lock().expect("lock poisoned");
-        for a_batch in locked_aggr.metrics_to_series_api_limited() {
+        for a_batch in locked_aggr.consume_metrics() {
             debug!("flushing {} series to datadog", a_batch.series.len());
             match &self.dd_api.ship_series(&a_batch).await {
                 Ok(()) => {}
@@ -27,7 +27,7 @@ impl Flusher {
             }
             // TODO(astuyve) retry and do not panic
         }
-        for a_batch in locked_aggr.distributions_to_protobuf_api_limited() {
+        for a_batch in locked_aggr.consume_distributions() {
             match &self.dd_api.ship_distributions(&a_batch).await {
                 Ok(()) => {}
                 Err(e) => {

--- a/bottlecap/src/metrics/flusher.rs
+++ b/bottlecap/src/metrics/flusher.rs
@@ -19,7 +19,7 @@ impl Flusher {
         let all_series;
         let all_distributions;
         {
-            let locked_aggr = &mut self.aggregator.lock().expect("lock poisoned").clone();
+            let locked_aggr = &mut self.aggregator.lock().expect("lock poisoned");
             all_series = locked_aggr.consume_metrics();
             all_distributions = locked_aggr.consume_distributions();
         }

--- a/bottlecap/src/metrics/flusher.rs
+++ b/bottlecap/src/metrics/flusher.rs
@@ -17,22 +17,23 @@ impl Flusher {
 
     pub async fn flush(&mut self) {
         let locked_aggr = &mut self.aggregator.lock().expect("lock poisoned");
-        let current_points = locked_aggr.to_series();
-        let current_distribution_points = locked_aggr.distributions_to_protobuf();
-        if !current_points.series.is_empty() {
-            debug!("flushing {} series to datadog", current_points.series.len());
-            match &self.dd_api.ship_series(&current_points).await {
+        let mut current_points = locked_aggr.to_series_serialized();
+        while !current_points.is_empty() {
+            debug!("flushing {} series to datadog", current_points.len());
+            match &self.dd_api.ship_series(current_points).await {
                 Ok(()) => {}
                 Err(e) => {
                     debug!("failed to ship metrics to datadog: {:?}", e);
                 }
             }
+            current_points = locked_aggr.to_series_serialized();
             // TODO(astuyve) retry and do not panic
         }
-        if !current_distribution_points.sketches.is_empty() {
+        let mut current_distribution_points = locked_aggr.distributions_to_protobuf_serialized();
+        while !current_distribution_points.is_empty() {
             match &self
                 .dd_api
-                .ship_distributions(&current_distribution_points)
+                .ship_distributions(current_distribution_points)
                 .await
             {
                 Ok(()) => {}
@@ -40,6 +41,7 @@ impl Flusher {
                     debug!("failed to ship distributions to datadog: {:?}", e);
                 }
             }
+            current_distribution_points = locked_aggr.distributions_to_protobuf_serialized();
         }
         locked_aggr.clear();
     }


### PR DESCRIPTION
- re-applyed changes for metric limits
- consume the entries when shipping payloads
- creating a vec of payloads, each within the batch entry/size limit
- there is a corner case: when 1 element is bigger than the max bytes size, it is added anyway in a separate batch. It should not be realistic though