### PR TITLE
chore(bottlecap): subscribe to `extension` telemetry events

### DIFF
--- a/bottlecap/src/telemetry/client.rs
+++ b/bottlecap/src/telemetry/client.rs
@@ -28,7 +28,7 @@ impl TelemetryApiClient {
                     "protocol": "HTTP",
                     "URI": format!("http://sandbox:{}/", &self.port),
                 },
-                "types": ["function", "platform"],
+                "types": ["extension", "function", "platform"],
                 "buffering": { // TODO: re evaluate using default values
                     "maxItems": 1000,
                     "maxBytes": 256 * 1024,


### PR DESCRIPTION
# What?

Add `extension` as part of the events to subscribe to from the [Telemetry API](https://docs.aws.amazon.com/lambda/latest/dg/telemetry-api.html#telemetry-api-subscription).

# Motivation

We were not subscribing because I was avoiding spamming our logs.
