### PR TITLE
fix: Use resolved API key

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -276,11 +276,13 @@ async fn extension_loop_active(
             obfuscation_config::ObfuscationConfig::new()
                 .map_err(|e| Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?,
         ),
+        resolved_api_key: resolved_api_key.clone(),
     });
 
     let stats_flusher = Arc::new(stats_flusher::ServerlessStatsFlusher {
         buffer: Arc::new(TokioMutex::new(Vec::new())),
         config: Arc::clone(config),
+        resolved_api_key: resolved_api_key.clone(),
     });
     let stats_processor = Arc::new(stats_processor::ServerlessStatsProcessor {});
 

--- a/bottlecap/src/traces/stats_flusher.rs
+++ b/bottlecap/src/traces/stats_flusher.rs
@@ -29,6 +29,7 @@ pub trait StatsFlusher {
 pub struct ServerlessStatsFlusher {
     pub buffer: Arc<Mutex<Vec<pb::ClientStatsPayload>>>,
     pub config: Arc<config::Config>,
+    pub resolved_api_key: String,
 }
 
 #[async_trait]
@@ -73,7 +74,7 @@ impl StatsFlusher for ServerlessStatsFlusher {
 
         let endpoint = Endpoint {
             url: hyper::Uri::from_str(&stats_url).expect("can't make URI from stats url, exiting"),
-            api_key: Some(self.config.api_key.clone().into()),
+            api_key: Some(self.resolved_api_key.clone().into()),
         };
 
         match stats_utils::send_stats_payload(

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -39,6 +39,7 @@ pub trait TraceProcessor {
 #[allow(clippy::module_name_repetitions)]
 pub struct ServerlessTraceProcessor {
     pub obfuscation_config: Arc<obfuscation_config::ObfuscationConfig>,
+    pub resolved_api_key: String,
 }
 
 #[async_trait]
@@ -112,7 +113,7 @@ impl TraceProcessor for ServerlessTraceProcessor {
         let intake_url = trace_intake_url(&config.site);
         let endpoint = Endpoint {
             url: hyper::Uri::from_str(&intake_url).expect("can't parse trace intake URL, exiting"),
-            api_key: Some(config.api_key.clone().into()),
+            api_key: Some(self.resolved_api_key.clone().into()),
         };
 
         let send_data = SendData::new(body_size, payload, tracer_header_tags, &endpoint);
@@ -274,6 +275,7 @@ mod tests {
             .unwrap();
 
         let trace_processor = trace_processor::ServerlessTraceProcessor {
+            resolved_api_key: "foo".to_string(),
             obfuscation_config: Arc::new(ObfuscationConfig::new().unwrap()),
         };
         let config = create_test_config();


### PR DESCRIPTION
My mistake, I thought the API key would be updated on the config.

Instead we just need to pass the resolved key.
