### PR TITLE
feat: Require DD_EXTENSION_VERSION: next

### DIFF
--- a/bottlecap/src/config/log_level.rs
+++ b/bottlecap/src/config/log_level.rs
@@ -1,6 +1,7 @@
 use serde::Deserialize;
 
 #[derive(Clone, Copy, Debug, PartialEq, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
 pub enum LogLevel {
     /// Designates very serious errors.
     Error,

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -42,6 +42,7 @@ pub struct Config {
     pub logs_injection: bool,
     pub merge_xray_traces: bool,
     pub serverless_appsec_enabled: bool,
+    pub extension_version: Option<String>,
 }
 
 impl Default for Config {
@@ -73,6 +74,7 @@ impl Default for Config {
             logs_injection: false,
             merge_xray_traces: false,
             serverless_appsec_enabled: false,
+            extension_version: None,
         }
     }
 }
@@ -107,6 +109,16 @@ pub fn get_config(config_directory: &Path) -> Result<Config, ConfigError> {
     if config.serverless_appsec_enabled {
         log_failover_reason("appsec_enabled");
         return Err(ConfigError::UnsupportedField("appsec_enabled".to_string()));
+    }
+
+    match config.extension_version.as_deref() {
+        Some("next") => {}
+        Some(&_) | None => {
+            log_failover_reason("extension_version");
+            return Err(ConfigError::UnsupportedField(
+                "extension_version".to_string(),
+            ));
+        }
     }
 
     Ok(config)


### PR DESCRIPTION
1. Requires `DD_EXTENSION_VERSION: next` to be set, otherwise we fail over to the main extension.
2. Fixes an issue where `DD_LOG_LEVEL` was case sensitive.
