### PR TITLE
Update Go version to 1.22.5

### DIFF
--- a/local_tests/golang/go.mod
+++ b/local_tests/golang/go.mod
@@ -1,6 +1,6 @@
 module app
 
-go 1.20
+go 1.22
 
 require (
 	github.com/DataDog/datadog-lambda-go v1.8.0

--- a/scripts/Dockerfile.alpine.build
+++ b/scripts/Dockerfile.alpine.build
@@ -7,7 +7,7 @@ ARG CMD_PATH
 ARG BUILD_TAGS
 
 RUN apk add --no-cache git make musl-dev gcc
-COPY --from=golang:1.21-alpine /usr/local/go/ /usr/lib/go
+COPY --from=golang:1.22-alpine /usr/local/go/ /usr/lib/go
 
 ENV GOROOT /usr/lib/go
 ENV GOPATH /go
@@ -29,7 +29,7 @@ WORKDIR /tmp/dd/datadog-agent/"${CMD_PATH}"
 # add the current version number to the tags package before compilation
 
 RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \ 
+    --mount=type=cache,target=/root/.cache/go-build \
     /usr/lib/go/bin/go build -ldflags="-w \
     -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
     -tags "${BUILD_TAGS}" -o datadog-agent;

--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -15,8 +15,8 @@ RUN arch="$(uname -m)"; \
     if [ "${arch}" = 'x86_64' ]; then \
     arch='amd64'; \
     fi; \
-    wget -O go1.21.9.linux-${arch}.tar.gz https://go.dev/dl/go1.21.9.linux-${arch}.tar.gz; \
-    tar -C /usr/local -xzf go1.21.9.linux-${arch}.tar.gz
+    wget -O go1.22.5.linux-${arch}.tar.gz https://go.dev/dl/go1.22.5.linux-${arch}.tar.gz; \
+    tar -C /usr/local -xzf go1.22.5.linux-${arch}.tar.gz
 
 # cache dependencies
 COPY ./scripts/.cache/go.mod /tmp/dd/datadog-agent

--- a/scripts/Dockerfile.race.build
+++ b/scripts/Dockerfile.race.build
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:experimental
 
-FROM golang:1.21 as builder
+FROM golang:1.22 as builder
 ARG EXTENSION_VERSION
 ARG ENABLE_RACE_DETECTION
 ARG AGENT_VERSION

--- a/scripts_v2/Dockerfile.build
+++ b/scripts_v2/Dockerfile.build
@@ -14,8 +14,8 @@ RUN arch="$(uname -m)"; \
     if [ "${arch}" = 'x86_64' ]; then \
     arch='amd64'; \
     fi; \
-    wget -O go1.21.7.linux-${arch}.tar.gz https://go.dev/dl/go1.21.7.linux-${arch}.tar.gz; \
-    tar -C /usr/local -xzf go1.21.7.linux-${arch}.tar.gz
+    wget -O go1.22.5.linux-${arch}.tar.gz https://go.dev/dl/go1.22.5.linux-${arch}.tar.gz; \
+    tar -C /usr/local -xzf go1.22.5.linux-${arch}.tar.gz
 
 RUN mkdir -p /tmp/dd
 
@@ -26,7 +26,7 @@ WORKDIR /tmp/dd/datadog-agent/"${CMD_PATH}"
 # add the current version number to the tags package before compilation
 
 RUN --mount=type=cache,target=/root/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \ 
+    --mount=type=cache,target=/root/.cache/go-build \
     if [ -z "$AGENT_VERSION" ]; then \
     /usr/local/go/bin/go build -ldflags="-w \
     -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \


### PR DESCRIPTION
The agent now uses Go `1.22.5`, this repo should also use `1.22.x`.