### PR TITLE
aj/add hello route

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -37,11 +37,11 @@ use bottlecap::{
         listener::TelemetryListener,
     },
     traces::{
+        hello_agent,
         stats_flusher::{self, StatsFlusher},
         stats_processor, trace_agent,
         trace_flusher::{self, TraceFlusher},
         trace_processor,
-        hello_agent,
     },
     DOGSTATSD_PORT, EXTENSION_ACCEPT_FEATURE_HEADER, EXTENSION_FEATURES, EXTENSION_HOST,
     EXTENSION_ID_HEADER, EXTENSION_NAME, EXTENSION_NAME_HEADER, EXTENSION_ROUTE,

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -41,6 +41,7 @@ use bottlecap::{
         stats_processor, trace_agent,
         trace_flusher::{self, TraceFlusher},
         trace_processor,
+        hello_agent,
     },
     DOGSTATSD_PORT, EXTENSION_ACCEPT_FEATURE_HEADER, EXTENSION_FEATURES, EXTENSION_HOST,
     EXTENSION_ID_HEADER, EXTENSION_NAME, EXTENSION_NAME_HEADER, EXTENSION_ROUTE,
@@ -313,6 +314,15 @@ async fn extension_loop_active(
             error!("Error starting trace agent: {e:?}");
         }
     });
+
+    // TODO(astuyve): deprioritize this task after the first request
+    tokio::spawn(async move {
+        let res = hello_agent::start_handler().await;
+        if let Err(e) = res {
+            error!("Error starting hello agent: {e:?}");
+        }
+    });
+
     let lambda_enhanced_metrics = enhanced_metrics::new(Arc::clone(&metrics_aggr));
     let dogstatsd_cancel_token = start_dogstatsd(event_bus.get_sender_copy(), &metrics_aggr).await;
 

--- a/bottlecap/src/lib.rs
+++ b/bottlecap/src/lib.rs
@@ -44,7 +44,7 @@ pub const LAMBDA_RUNTIME_SLUG: &str = "lambda";
 pub const DOGSTATSD_PORT: u16 = 8125;
 
 pub const TELEMETRY_SUBSCRIPTION_ROUTE: &str = "2022-07-01/telemetry";
-// todo(astuyve) should be 8124 on /lambda/logs but 
+// todo(astuyve) should be 8124 on /lambda/logs but
 // telemetry is implemented on a raw socket now and
 // does not multiplex routes on the same port.
 pub const TELEMETRY_PORT: u16 = 8999;

--- a/bottlecap/src/lib.rs
+++ b/bottlecap/src/lib.rs
@@ -44,7 +44,10 @@ pub const LAMBDA_RUNTIME_SLUG: &str = "lambda";
 pub const DOGSTATSD_PORT: u16 = 8185;
 
 pub const TELEMETRY_SUBSCRIPTION_ROUTE: &str = "2022-07-01/telemetry";
-pub const TELEMETRY_PORT: u16 = 8124;
+// todo(astuyve) should be 8124 on /lambda/logs but 
+// telemetry is implemented on a raw socket now and
+// does not multiplex routes on the same port.
+pub const TELEMETRY_PORT: u16 = 8999;
 
 /// Return the base URL for the lambda runtime API
 ///

--- a/bottlecap/src/lib.rs
+++ b/bottlecap/src/lib.rs
@@ -41,7 +41,7 @@ pub const EXTENSION_ROUTE: &str = "2020-01-01/extension";
 pub const LAMBDA_RUNTIME_SLUG: &str = "lambda";
 
 // todo: make sure we can override those with environment variables
-pub const DOGSTATSD_PORT: u16 = 8185;
+pub const DOGSTATSD_PORT: u16 = 8125;
 
 pub const TELEMETRY_SUBSCRIPTION_ROUTE: &str = "2022-07-01/telemetry";
 // todo(astuyve) should be 8124 on /lambda/logs but 

--- a/bottlecap/src/metrics/dogstatsd.rs
+++ b/bottlecap/src/metrics/dogstatsd.rs
@@ -65,6 +65,10 @@ impl DogStatsD {
                     continue;
                 }
             };
+            if parsed_metric.name == "aws.lambda.enhanced.invocations" {
+                debug!("dropping invocation metric from layer, as it's set by agent");
+                continue;
+            }
             let first_value = match parsed_metric.first_value() {
                 Ok(val) => val,
                 Err(e) => {
@@ -85,6 +89,7 @@ impl DogStatsD {
             // Don't publish until after validation and adding metric_event to buff
             let _ = self.event_bus.send(Event::Metric(metric_event)).await; // todo check the result
             if self.cancel_token.is_cancelled() {
+                debug!("closing dogstatsd listener");
                 break;
             }
         }

--- a/bottlecap/src/traces/hello_agent.rs
+++ b/bottlecap/src/traces/hello_agent.rs
@@ -1,0 +1,58 @@
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+// TODO(Astuyve): Deprecate.
+// older clients require the 127.0.0.1:8126/lambda/hello route
+// to identify the presence of the extension.
+
+use hyper::service::{make_service_fn, service_fn};
+use hyper::{http, Body, Method, Request, Response, Server, StatusCode};
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use tracing::error;
+use serde_json::json;
+
+const HELLO_PATH: &str = "/lambda/hello";
+const AGENT_PORT: usize = 8126;
+
+pub async fn start_handler() -> Result<(), Box<dyn std::error::Error>> {
+    let make_svc = make_service_fn(move |_| {
+        let service = service_fn(move |req| {
+            hello_handler(
+                req,
+            )
+        });
+
+        async move { Ok::<_, Infallible>(service) }
+    });
+
+    let port = u16::try_from(AGENT_PORT).expect("AGENT_PORT is too large");
+    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    let server_builder = Server::try_bind(&addr)?;
+
+    let server = server_builder.serve(make_svc);
+
+    // start hyper http server
+    if let Err(e) = server.await {
+        error!("Server error: {e}");
+        return Err(e.into());
+    }
+
+    Ok(())
+
+}
+
+async fn hello_handler(req: Request<Body>) -> http::Result<Response<Body>> {
+    match (req.method(), req.uri().path()) {
+        (&Method::GET, HELLO_PATH) => {
+            Response::builder()
+                .status(200)
+                .body(Body::from(json!({}).to_string()))
+        },
+        _ => {
+            let mut not_found = Response::default();
+            *not_found.status_mut() = StatusCode::NOT_FOUND;
+            Ok(not_found)
+        }
+    }
+}

--- a/bottlecap/src/traces/hello_agent.rs
+++ b/bottlecap/src/traces/hello_agent.rs
@@ -13,7 +13,7 @@ use std::net::SocketAddr;
 use tracing::error;
 
 const HELLO_PATH: &str = "/lambda/hello";
-const AGENT_PORT: usize = 8126;
+const AGENT_PORT: usize = 8124;
 
 pub async fn start_handler() -> Result<(), Box<dyn std::error::Error>> {
     let make_svc = make_service_fn(move |_| {

--- a/bottlecap/src/traces/hello_agent.rs
+++ b/bottlecap/src/traces/hello_agent.rs
@@ -7,21 +7,17 @@
 
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{http, Body, Method, Request, Response, Server, StatusCode};
+use serde_json::json;
 use std::convert::Infallible;
 use std::net::SocketAddr;
 use tracing::error;
-use serde_json::json;
 
 const HELLO_PATH: &str = "/lambda/hello";
 const AGENT_PORT: usize = 8126;
 
 pub async fn start_handler() -> Result<(), Box<dyn std::error::Error>> {
     let make_svc = make_service_fn(move |_| {
-        let service = service_fn(move |req| {
-            hello_handler(
-                req,
-            )
-        });
+        let service = service_fn(move |req| hello_handler(req));
 
         async move { Ok::<_, Infallible>(service) }
     });
@@ -39,16 +35,13 @@ pub async fn start_handler() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
-
 }
 
 async fn hello_handler(req: Request<Body>) -> http::Result<Response<Body>> {
     match (req.method(), req.uri().path()) {
-        (&Method::GET, HELLO_PATH) => {
-            Response::builder()
-                .status(200)
-                .body(Body::from(json!({}).to_string()))
-        },
+        (&Method::GET, HELLO_PATH) => Response::builder()
+            .status(200)
+            .body(Body::from(json!({}).to_string())),
         _ => {
             let mut not_found = Response::default();
             *not_found.status_mut() = StatusCode::NOT_FOUND;

--- a/bottlecap/src/traces/hello_agent.rs
+++ b/bottlecap/src/traces/hello_agent.rs
@@ -17,7 +17,7 @@ const AGENT_PORT: usize = 8126;
 
 pub async fn start_handler() -> Result<(), Box<dyn std::error::Error>> {
     let make_svc = make_service_fn(move |_| {
-        let service = service_fn(move |req| hello_handler(req));
+        let service = service_fn(hello_handler);
 
         async move { Ok::<_, Infallible>(service) }
     });
@@ -38,14 +38,13 @@ pub async fn start_handler() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 async fn hello_handler(req: Request<Body>) -> http::Result<Response<Body>> {
-    match (req.method(), req.uri().path()) {
-        (&Method::GET, HELLO_PATH) => Response::builder()
+    if let (&Method::GET, HELLO_PATH) = (req.method(), req.uri().path()) {
+        Response::builder()
             .status(200)
-            .body(Body::from(json!({}).to_string())),
-        _ => {
-            let mut not_found = Response::default();
-            *not_found.status_mut() = StatusCode::NOT_FOUND;
-            Ok(not_found)
-        }
+            .body(Body::from(json!({}).to_string()))
+    } else {
+        let mut not_found = Response::default();
+        *not_found.status_mut() = StatusCode::NOT_FOUND;
+        Ok(not_found)
     }
 }

--- a/bottlecap/src/traces/mod.rs
+++ b/bottlecap/src/traces/mod.rs
@@ -6,3 +6,4 @@ pub mod stats_processor;
 pub mod trace_agent;
 pub mod trace_flusher;
 pub mod trace_processor;
+pub mod hello_agent;

--- a/bottlecap/src/traces/mod.rs
+++ b/bottlecap/src/traces/mod.rs
@@ -1,9 +1,9 @@
 // Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod hello_agent;
 pub mod stats_flusher;
 pub mod stats_processor;
 pub mod trace_agent;
 pub mod trace_flusher;
 pub mod trace_processor;
-pub mod hello_agent;


### PR DESCRIPTION
the `hello` route was a path used to tell the tracers that the agent is ready to receive data. It goes back to the [original PR](https://github.com/DataDog/datadog-agent/pull/6591) for the extension.

It was eventually [removed](https://github.com/DataDog/datadog-agent/pull/9782) but somehow lives on.

We've since removed it in all lambda layers, but a smoke test revealed that a user was still using it as late as layer v85.

We should remove this entirely at some point, but that would effectively be a breaking change for all versions of the clients/tracers.
