### PR TITLE
chore(bottlecap): add `hyper@0.x` in telemetry api

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -548,8 +548,7 @@ async fn setup_telemetry_client(
     let ct_clone = telemetry_listener_cancel_token.clone();
     tokio::spawn(async move {
         let _telemetry_listener =
-            TelemetryListener::new(&telemetry_listener_config, logs_agent_channel, ct_clone)
-                .await;
+            TelemetryListener::spin(&telemetry_listener_config, logs_agent_channel, ct_clone).await;
     });
 
     let telemetry_client = TelemetryApiClient::new(extension_id.to_string(), TELEMETRY_PORT);

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -547,8 +547,7 @@ async fn setup_telemetry_client(
     let telemetry_listener_cancel_token = tokio_util::sync::CancellationToken::new();
     let ct_clone = telemetry_listener_cancel_token.clone();
     tokio::spawn(async move {
-        let _telemetry_listener =
-            TelemetryListener::spin(&telemetry_listener_config, logs_agent_channel, ct_clone).await;
+        TelemetryListener::spin(&telemetry_listener_config, logs_agent_channel, ct_clone).await;
     });
 
     let telemetry_client = TelemetryApiClient::new(extension_id.to_string(), TELEMETRY_PORT);

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -536,15 +536,24 @@ async fn setup_telemetry_client(
         port: TELEMETRY_PORT,
     };
     let telemetry_listener_cancel_token = tokio_util::sync::CancellationToken::new();
-    let telemetry_listener = TelemetryListener::new(
-        &telemetry_listener_config,
-        logs_agent_channel,
-        telemetry_listener_cancel_token.clone(),
-    )
-    .await
-    .map_err(|e| Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+    // let _telemetry_listener = TelemetryListener::new_hyper(
+    //     &telemetry_listener_config,
+    //     logs_agent_channel,
+    //     telemetry_listener_cancel_token.clone(),
+    // )
+    // .await;
+    // // .map_err(|e| Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+    // // tokio::spawn(async move {
+    // //     telemetry_listener.spin().await;
+    // // });
+    let ct_clone = telemetry_listener_cancel_token.clone();
     tokio::spawn(async move {
-        telemetry_listener.spin().await;
+        let _telemetry_listener = TelemetryListener::new_hyper(
+            &telemetry_listener_config,
+            logs_agent_channel,
+            ct_clone,
+        )
+        .await;
     });
 
     let telemetry_client = TelemetryApiClient::new(extension_id.to_string(), TELEMETRY_PORT);

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -545,20 +545,10 @@ async fn setup_telemetry_client(
         port: TELEMETRY_PORT,
     };
     let telemetry_listener_cancel_token = tokio_util::sync::CancellationToken::new();
-    // let _telemetry_listener = TelemetryListener::new_hyper(
-    //     &telemetry_listener_config,
-    //     logs_agent_channel,
-    //     telemetry_listener_cancel_token.clone(),
-    // )
-    // .await;
-    // // .map_err(|e| Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-    // // tokio::spawn(async move {
-    // //     telemetry_listener.spin().await;
-    // // });
     let ct_clone = telemetry_listener_cancel_token.clone();
     tokio::spawn(async move {
         let _telemetry_listener =
-            TelemetryListener::new_hyper(&telemetry_listener_config, logs_agent_channel, ct_clone)
+            TelemetryListener::new(&telemetry_listener_config, logs_agent_channel, ct_clone)
                 .await;
     });
 

--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -222,11 +222,7 @@ impl LambdaProcessor {
         }
     }
 
-    pub async fn process(
-        &mut self,
-        event: TelemetryEvent,
-        aggregator: &Arc<Mutex<Aggregator>>,
-    ) {
+    pub async fn process(&mut self, event: TelemetryEvent, aggregator: &Arc<Mutex<Aggregator>>) {
         let mut to_send = Vec::<String>::new();
 
         if let Ok(mut log) = self.make_log(event).await {
@@ -709,9 +705,7 @@ mod tests {
             },
         };
 
-        processor
-            .process(start_event.clone(), &aggregator)
-            .await;
+        processor.process(start_event.clone(), &aggregator).await;
         assert_eq!(
             processor.invocation_context.request_id,
             "test-request-id".to_string()

--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -224,33 +224,31 @@ impl LambdaProcessor {
 
     pub async fn process(
         &mut self,
-        events: Vec<TelemetryEvent>,
+        event: TelemetryEvent,
         aggregator: &Arc<Mutex<Aggregator>>,
     ) {
         let mut to_send = Vec::<String>::new();
 
-        for event in events {
-            if let Ok(mut log) = self.make_log(event).await {
-                let should_send_log =
-                    LambdaProcessor::apply_rules(&self.rules, &mut log.message.message);
-                if should_send_log {
-                    if let Ok(serialized_log) = serde_json::to_string(&log) {
-                        // explicitly drop log so we don't accidentally re-use it and push
-                        // duplicate logs to the aggregator
-                        drop(log);
-                        to_send.push(serialized_log);
-                    }
+        if let Ok(mut log) = self.make_log(event).await {
+            let should_send_log =
+                LambdaProcessor::apply_rules(&self.rules, &mut log.message.message);
+            if should_send_log {
+                if let Ok(serialized_log) = serde_json::to_string(&log) {
+                    // explicitly drop log so we don't accidentally re-use it and push
+                    // duplicate logs to the aggregator
+                    drop(log);
+                    to_send.push(serialized_log);
                 }
+            }
 
-                // Process orphan logs, since we have a `request_id` now
-                for mut orphan_log in self.orphan_logs.drain(..) {
-                    orphan_log.message.lambda.request_id =
-                        Some(self.invocation_context.request_id.clone());
-                    if should_send_log {
-                        if let Ok(serialized_log) = serde_json::to_string(&orphan_log) {
-                            drop(orphan_log);
-                            to_send.push(serialized_log);
-                        }
+            // Process orphan logs, since we have a `request_id` now
+            for mut orphan_log in self.orphan_logs.drain(..) {
+                orphan_log.message.lambda.request_id =
+                    Some(self.invocation_context.request_id.clone());
+                if should_send_log {
+                    if let Ok(serialized_log) = serde_json::to_string(&orphan_log) {
+                        drop(orphan_log);
+                        to_send.push(serialized_log);
                     }
                 }
             }
@@ -628,7 +626,7 @@ mod tests {
             },
         };
 
-        processor.process(vec![event.clone()], &aggregator).await;
+        processor.process(event.clone(), &aggregator).await;
 
         let mut aggregator_lock = aggregator.lock().unwrap();
         let batch = aggregator_lock.get_batch();
@@ -675,7 +673,7 @@ mod tests {
             record: TelemetryRecord::Function(Value::String("test-function".to_string())),
         };
 
-        processor.process(vec![event.clone()], &aggregator).await;
+        processor.process(event.clone(), &aggregator).await;
         assert_eq!(processor.orphan_logs.len(), 1);
 
         let mut aggregator_lock = aggregator.lock().unwrap();
@@ -712,7 +710,7 @@ mod tests {
         };
 
         processor
-            .process(vec![start_event.clone()], &aggregator)
+            .process(start_event.clone(), &aggregator)
             .await;
         assert_eq!(
             processor.invocation_context.request_id,
@@ -725,7 +723,7 @@ mod tests {
             record: TelemetryRecord::Function(Value::String("test-function".to_string())),
         };
 
-        processor.process(vec![event.clone()], &aggregator).await;
+        processor.process(event.clone(), &aggregator).await;
 
         // Verify aggregator logs
         let mut aggregator_lock = aggregator.lock().unwrap();

--- a/bottlecap/src/logs/processor.rs
+++ b/bottlecap/src/logs/processor.rs
@@ -29,11 +29,7 @@ impl LogsProcessor {
         }
     }
 
-    pub async fn process(
-        &mut self,
-        event: TelemetryEvent,
-        aggregator: &Arc<Mutex<Aggregator>>,
-    ) {
+    pub async fn process(&mut self, event: TelemetryEvent, aggregator: &Arc<Mutex<Aggregator>>) {
         match self {
             LogsProcessor::Lambda(lambda_processor) => {
                 lambda_processor.process(event, aggregator).await;

--- a/bottlecap/src/logs/processor.rs
+++ b/bottlecap/src/logs/processor.rs
@@ -31,12 +31,12 @@ impl LogsProcessor {
 
     pub async fn process(
         &mut self,
-        events: Vec<TelemetryEvent>,
+        event: TelemetryEvent,
         aggregator: &Arc<Mutex<Aggregator>>,
     ) {
         match self {
             LogsProcessor::Lambda(lambda_processor) => {
-                lambda_processor.process(events, aggregator).await;
+                lambda_processor.process(event, aggregator).await;
             }
         }
     }

--- a/bottlecap/src/telemetry/listener.rs
+++ b/bottlecap/src/telemetry/listener.rs
@@ -247,13 +247,10 @@ impl TelemetryListener {
     }
 
     pub async fn handle(req: Request<Body>, event_bus: Sender<Vec<TelemetryEvent>>) -> Result<Response<Body>, hyper::Error> {
-        debug!("[jordan] Received a Telemetry API connection, starting to wait for body",);
-
         let whole_body = hyper::body::to_bytes(req.into_body()).await?;
 
         let body = whole_body.to_vec();
         let body = std::str::from_utf8(&body).expect("infallible");
-        debug!("[jordan] Body received is : {}", body);
 
         let telemetry_events: Vec<TelemetryEvent> = serde_json::from_str(body).expect("infallible");
         event_bus

--- a/bottlecap/src/telemetry/listener.rs
+++ b/bottlecap/src/telemetry/listener.rs
@@ -37,9 +37,8 @@ impl TelemetryListener {
         tokio::select! {
             biased;
             _ = server => {}
-            _ = cancel_token.cancelled() => {
+            () = cancel_token.cancelled() => {
                 debug!("Telemetry API listener cancelled");
-                return;
             }
         }
     }
@@ -82,6 +81,7 @@ mod tests {
     use crate::telemetry::events::{InitPhase, InitType, TelemetryRecord};
 
     #[tokio::test]
+    #[allow(clippy::unwrap_used)]
     async fn test_handle() {
         let event_body = hyper::Body::from(
             r#"[{"time":"2024-04-25T17:35:59.944Z","type":"platform.initStart","record":{"initializationType":"on-demand","phase":"init","runtimeVersion":"nodejs:20.v22","runtimeVersionArn":"arn:aws:lambda:us-east-1::runtime:da57c20c4b965d5b75540f6865a35fc8030358e33ec44ecfed33e90901a27a72","functionName":"hello-world","functionVersion":"$LATEST"}}]"#,

--- a/bottlecap/src/telemetry/listener.rs
+++ b/bottlecap/src/telemetry/listener.rs
@@ -1,198 +1,15 @@
 use crate::telemetry::events::TelemetryEvent;
-use core::fmt::Display;
 
-use std::collections::HashMap;
 use std::net::SocketAddr;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::mpsc::Sender;
 
 use hyper::service::{make_service_fn, service_fn};
-use hyper::{Body, Request, Response, Server, StatusCode};
+use hyper::{Body, Request, Response, Server};
 use tracing::{debug, error};
 
-pub struct HttpRequestParser {
-    headers: HashMap<String, String>,
-    body: String,
-}
-
-#[derive(Debug, PartialEq)]
-pub enum TcpError {
-    Close(String),
-    Read(String),
-    Write(String),
-    Parse(String),
-}
-
-impl Display for TcpError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            TcpError::Close(close) => write!(f, "{}", close.clone()),
-            TcpError::Read(read) => write!(f, "{}", read.clone()),
-            TcpError::Parse(parse) => write!(f, "{}", parse.clone()),
-            TcpError::Write(write) => write!(f, "{}", write.clone()),
-        }
-    }
-}
-
-const CR: u8 = b'\r';
-const LR: u8 = b'\n';
-/// It is guaranteed that the headers will be less than 256 bytes.
-const HEADERS_BUFFER_SIZE: usize = 256;
-
-impl HttpRequestParser {
-    /// Create a `HttpRequestParser` from passed `TcpStream`
-    ///
-    /// # Errors
-    ///
-    /// Function will error if the stream cannot be read from.
-    ///
-    /// It will also error if the headers cannot be parsed.
-    ///
-    /// Or if the body cannot be parsed.
-    pub async fn from_stream(stream: &mut TcpStream) -> Result<HttpRequestParser, TcpError> {
-        let mut parser = HttpRequestParser {
-            headers: HashMap::new(),
-            body: String::new(),
-        };
-
-        let mut headers_buf = [0u8; HEADERS_BUFFER_SIZE];
-        loop {
-            // select here
-            match stream.read(&mut headers_buf).await {
-                Ok(0) => {
-                    return Err(TcpError::Close("Connection closed by client".to_string()));
-                }
-                Ok(_) => {}
-                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                    continue;
-                }
-                Err(e) => {
-                    error!("Error reading from stream: {}", e);
-                    return Err(TcpError::Read(e.to_string()));
-                }
-            }
-
-            let _ = parser.parse_headers(&headers_buf);
-            if parser.headers.contains_key("content-length") {
-                break;
-            }
-        }
-
-        let body_start_index = parser.parse_headers(&headers_buf)?;
-        let content_length = parser
-            .headers
-            .get("content-length")
-            .expect("infallible")
-            .parse::<usize>()
-            .map_err(|e| TcpError::Parse(e.to_string()))?;
-        let body_bytes_read = headers_buf.len() - body_start_index;
-        let missing_body_length = content_length - body_bytes_read;
-        let mut body_buf = vec![0u8; missing_body_length];
-
-        stream
-            .read_exact(&mut body_buf)
-            .await
-            .map_err(|e| TcpError::Read(e.to_string()))?;
-
-        let total_bytes_read = headers_buf.len() + missing_body_length;
-        let mut buf = vec![0u8; total_bytes_read];
-        buf[..headers_buf.len()].copy_from_slice(&headers_buf);
-        buf[headers_buf.len()..].copy_from_slice(&body_buf);
-
-        parser.parse_body(&buf, body_start_index)?;
-
-        Ok(parser)
-    }
-
-    fn parse_headers(&mut self, buf: &[u8]) -> Result<usize, TcpError> {
-        let mut last_start = 0;
-        let mut i = 0;
-
-        // Ignore method, path, and protocol
-        // i + 1 because we are checking next character always
-        while i + 1 < buf.len() {
-            // '\n\r' indicate the end of every line, the first line
-            // is always method, path, and protocol.
-            if buf[i] == CR && buf[i + 1] == LR {
-                // i + 2 to skip '\n\r' on the next iteration
-                last_start = i + 2;
-                break;
-            }
-            i += 1;
-        }
-
-        // Parse headers
-        i = last_start;
-        while i < buf.len() {
-            // Here we've reached end of one header
-            if buf[i] == CR && buf[i + 1] == LR {
-                // Slice the header from the buffer, not using i+1
-                // because we don't want to include '\r\n' in the value
-                let header = std::str::from_utf8(&buf[last_start..i])
-                    .map_err(|e| TcpError::Parse(e.to_string()))?;
-                let mut header_parts = header.split(": ");
-
-                if let (Some(key), Some(value)) = (header_parts.next(), header_parts.next()) {
-                    self.headers
-                        .insert(key.to_string().to_lowercase(), value.to_string());
-                } else {
-                    error!("Error parsing header, skipping it: {}", header);
-                }
-
-                // Check if we reached the end of the headers
-                // i + 3 because we are checking next 3 characters, '\r\n\r\n'
-                // This indicates the end of the headers, and the start of the body
-                if i + 3 < buf.len() && buf[i + 2] == CR && buf[i + 3] == LR {
-                    // Set our last_start so we can parse the body
-                    last_start = i + 4;
-                    break;
-                }
-
-                // Skip '\r\n' to start parsing the next header
-                last_start = i + 2;
-                i = last_start;
-                continue;
-            }
-            i += 1;
-        }
-
-        Ok(last_start)
-    }
-
-    fn parse_body(&mut self, buf: &[u8], start_index: usize) -> Result<(), TcpError> {
-        let content_length = match self.headers.get("content-length") {
-            Some(length) => length
-                .parse::<usize>()
-                .map_err(|e| TcpError::Parse(e.to_string()))?,
-            None => {
-                return Err(TcpError::Parse(
-                    "content-length header not found".to_string(),
-                ))
-            }
-        };
-
-        let end_index = start_index + content_length;
-
-        if end_index > buf.len() {
-            return Err(TcpError::Parse(
-                "content-length header is greater than the buffer length".to_string(),
-            ));
-        }
-
-        self.body = std::str::from_utf8(&buf[start_index..end_index])
-            .map_err(|e| TcpError::Parse(e.to_string()))?
-            .to_string();
-
-        Ok(())
-    }
-}
-
 #[allow(clippy::module_name_repetitions)]
-pub struct TelemetryListener {
-    event_bus: Sender<Vec<TelemetryEvent>>,
-    cancel_token: tokio_util::sync::CancellationToken,
-}
+#[derive(Debug, Clone, Copy)]
+pub struct TelemetryListener {}
 
 pub struct TelemetryListenerConfig {
     pub host: String,
@@ -200,300 +17,63 @@ pub struct TelemetryListenerConfig {
 }
 
 impl TelemetryListener {
-    /// Run the `TelemetryListener`
-    ///
-    /// # Errors
-    ///
-    /// Function will error if the passed address cannot be bound.
-    // pub async fn new(
-    //     config: &TelemetryListenerConfig,
-    //     event_bus: Sender<Vec<TelemetryEvent>>,
-    //     cancel_token: tokio_util::sync::CancellationToken,
-    // ) -> Result<TelemetryListener, String> {
-    //     let addr = format!("{}:{}", &config.host, &config.port);
-    //     let listener = TcpListener::bind(addr).await.map_err(|e| e.to_string())?;
-
-    //     Ok(TelemetryListener {
-    //         event_bus,
-    //         cancel_token,
-    //         listener,
-    //     })
-    // }
-
     pub async fn new_hyper(
         config: &TelemetryListenerConfig,
-        event_bus: Sender<Vec<TelemetryEvent>>,
-        cancel_token: tokio_util::sync::CancellationToken,
+        event_bus: Sender<TelemetryEvent>,
+        _cancel_token: tokio_util::sync::CancellationToken,
     ) {
         // let addr = format!("{}:{}", &config.host, &config.port);
         let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
 
-        let service =
-            make_service_fn(move |_| {
-                let event_bus = event_bus.clone();
-                async move {
-                    Ok::<_, hyper::Error>(service_fn(move |req| {
-                        Self::handle(req, event_bus.clone())
-                    }))
-                }
-            });
+        let service = make_service_fn(move |_| {
+            let event_bus = event_bus.clone();
+            async move {
+                Ok::<_, hyper::Error>(service_fn(move |req| Self::handle(req, event_bus.clone())))
+            }
+        });
         let listener = Server::bind(&addr);
 
         let server = listener.serve(service);
-        debug!("[jordan] starting Telemetry API listener on {}", addr);
+        debug!("Starting Telemetry API listener on {}", addr);
         if let Err(e) = server.await {
-            error!("[jordan] Telemetry API listener error: {:?}", e);
+            error!("Telemetry API listener error: {:?}", e);
         }
     }
 
-    pub async fn handle(req: Request<Body>, event_bus: Sender<Vec<TelemetryEvent>>) -> Result<Response<Body>, hyper::Error> {
+    pub async fn handle(
+        req: Request<Body>,
+        event_bus: Sender<TelemetryEvent>,
+    ) -> Result<Response<Body>, hyper::Error> {
         let whole_body = hyper::body::to_bytes(req.into_body()).await?;
 
         let body = whole_body.to_vec();
         let body = std::str::from_utf8(&body).expect("infallible");
 
-        let telemetry_events: Vec<TelemetryEvent> = serde_json::from_str(body).expect("infallible");
-        event_bus
-            .send(telemetry_events)
-            .await.expect("infallible"); 
+        let mut telemetry_events: Vec<TelemetryEvent> = serde_json::from_str(body).expect("infallible");
+        for event in telemetry_events.drain(..) {
+            event_bus.send(event).await.expect("infallible");
+        }
 
         let ack = Response::new(Body::from("OK"));
         Ok(ack)
     }
-
-    // pub async fn spin(self) {
-    //     loop {
-    //         tokio::select! {
-    //             biased;
-    //             stream = self.listener.accept() => {
-    //                 match stream {
-    //                     Ok((mut stream, _)) => {
-    //                         debug!("Received a Telemetry API connection");
-    //                         let cloned_event_bus = self.event_bus.clone();
-    //                         tokio::spawn(async move {
-    //                             let _ = Self::handle_stream(&mut stream, cloned_event_bus).await;
-    //                         });
-    //                     }
-    //                     Err(e) => {
-    //                         error!("Error accepting connection: {:?}", e);
-    //                     }
-    //                 }
-    //             }
-    //             () = self.cancel_token.cancelled() => {
-    //                 break;
-    //             }
-    //         }
-    //     }
-    // }
-
-    async fn handle_stream(
-        stream: &mut TcpStream,
-        event_bus: Sender<Vec<TelemetryEvent>>,
-    ) -> Result<(), TcpError> {
-        loop {
-            match HttpRequestParser::from_stream(stream).await {
-                Ok(p) => {
-                    let telemetry_events: Vec<TelemetryEvent> = serde_json::from_str(&p.body)
-                        .map_err(|e| TcpError::Parse(e.to_string()))?;
-                    event_bus
-                        .send(telemetry_events)
-                        .await
-                        .map_err(|e| TcpError::Write(e.to_string()))?; //todo
-                                                                       //AJ this is cheeky but we should have include the SendError in the enum
-                    if let Err(e) = Self::acknowledge_request(stream, Ok(())).await {
-                        error!("Error acknowledging Telemetry request: {:?}", e);
-                        return Err(TcpError::Write(e));
-                    }
-                }
-                Err(e) => match e {
-                    TcpError::Close(_) => return Ok(()),
-                    _ => return Err(e),
-                },
-            }
-        }
-    }
-
-    async fn acknowledge_request(
-        stream: &mut TcpStream,
-        request: Result<(), String>,
-    ) -> Result<(), String> {
-        match request {
-            Ok(()) => {
-                let _ = stream.write(b"HTTP/1.1 200 OK\r\n\r\n").await;
-            }
-            Err(_) => {
-                let _ = stream.write(b"HTTP/1.1 400 Bad Request\r\n\r\n").await;
-            }
-        }
-        Ok(())
-    }
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
-    use chrono::DateTime;
-
-    use crate::telemetry::events::{InitPhase, InitType, TelemetryRecord};
-
-    use super::*;
-
-    #[test]
-    fn test_parse_headers() {
-        let mut parser = HttpRequestParser {
-            headers: HashMap::new(),
-            body: String::new(),
-        };
-        let buf = b"GET /path HTTP/1.1\r\nContent-Length: 10\r\nHeader1: Value1\r\n\r\n";
-        let result = parser.parse_headers(buf);
-        assert!(result.is_ok());
-        assert_eq!(parser.headers.len(), 2);
-        assert_eq!(
-            parser.headers.get("content-length"),
-            Some(&"10".to_string())
-        );
-        assert_eq!(parser.headers.get("header1"), Some(&"Value1".to_string()));
-    }
-
-    #[test]
-    #[should_panic(expected = "content-length header not found")]
-    fn test_parse_headers_no_content_length() {
-        let mut parser = HttpRequestParser {
-            headers: HashMap::new(),
-            body: String::new(),
-        };
-        let buf = b"GET /path HTTP/1.1\r\nHeader1: Value1\r\n\r\n";
-        let body_start_index = parser.parse_headers(buf).expect("invalid buffer");
-        parser.parse_body(buf, body_start_index).unwrap();
-    }
-
-    #[test]
-    #[should_panic(expected = "content-length header is greater than the buffer length")]
-    fn test_parse_headers_wrong_content_length() {
-        let mut parser = HttpRequestParser {
-            headers: HashMap::new(),
-            body: String::new(),
-        };
-        let buf =
-            b"GET /path HTTP/1.1\r\nContent-Length: 56\r\nHeader1: Value1\r\n\r\nHello, World!";
-        let body_start_index = parser.parse_headers(buf).expect("invalid buffer");
-        parser.parse_body(buf, body_start_index).unwrap();
-    }
-
-    #[test]
-    #[should_panic(
-        expected = "called `Result::unwrap()` on an `Err` value: Parse(\"invalid digit found in string\")"
-    )]
-    fn test_parse_headers_invalid_content_length() {
-        let mut parser = HttpRequestParser {
-            headers: HashMap::new(),
-            body: String::new(),
-        };
-        let buf = b"GET /path HTTP/1.1\r\nContent-Length: Bottlecap!\r\nHeader1: Value1\r\n\r\nHello, World!";
-        let body_start_index = parser.parse_headers(buf).expect("invalid buffer");
-        parser.parse_body(buf, body_start_index).unwrap();
-    }
-
-    #[test]
-    fn test_parse_body() {
-        let mut parser = HttpRequestParser {
-            headers: HashMap::new(),
-            body: String::new(),
-        };
-        parser
-            .headers
-            .insert("content-length".to_string(), "13".to_string());
-        let buf = b"Hello, World!";
-        let result = parser.parse_body(buf, 0);
-        assert!(result.is_ok());
-        assert_eq!(parser.body, "Hello, World!".to_string());
-    }
-
-    async fn get_stream(data: Vec<u8>) -> TcpStream {
-        let listener = TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("Failed to bind listener");
-        let addr = listener.local_addr().expect("Failed to get local address");
-
-        let (tx, mut rx) = tokio::sync::mpsc::channel(10000);
-        tokio::spawn(async move {
-            let (mut stream, _) = listener
-                .accept()
-                .await
-                .expect("Failed to accept connection");
-            stream.write_all(&data).await.expect("Failed to write data");
-            tx.send(())
-                .await
-                .expect("Signal that the request has not been sent");
-        });
-
-        let stream = TcpStream::connect(addr)
-            .await
-            .expect("Failed to connect to the listener");
-        rx.recv()
-            .await
-            .expect("Error while waiting for the signal from the spawned thread");
-
-        stream
-    }
-
     #[tokio::test]
-    async fn test_handle_stream() {
-        let mut stream = get_stream(b"POST /path HTTP/1.1\r\nContent-Length: 335\r\nHeader1: Value1\r\n\r\n[{\"time\":\"2024-04-25T17:35:59.944Z\",\"type\":\"platform.initStart\",\"record\":{\"initializationType\":\"on-demand\",\"phase\":\"init\",\"runtimeVersion\":\"nodejs:20.v22\",\"runtimeVersionArn\":\"arn:aws:lambda:us-east-1::runtime:da57c20c4b965d5b75540f6865a35fc8030358e33ec44ecfed33e90901a27a72\",\"functionName\":\"hello-world\",\"functionVersion\":\"$LATEST\"}}]".to_vec()).await;
+    async fn test_handle() {
+        let req = hyper::Request::builder()
+            .method("POST")
+            .uri("http://localhost:8080")
+            .body(hyper::Body::from(r#"{"key": "value"}"#))
+            .unwrap();
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel(3);
-        let result = TelemetryListener::handle_stream(&mut stream, tx).await;
-        let events = rx.recv().await.expect("No events received");
-        let telemetry_event = events.first().expect("failed to get event");
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let _ = super::TelemetryListener::handle(req, tx).await;
 
-        let expected_time =
-            DateTime::parse_from_rfc3339("2024-04-25T17:35:59.944Z").expect("failed to parse time");
-        assert_eq!(telemetry_event.time, expected_time);
-        assert_eq!(telemetry_event.record, TelemetryRecord::PlatformInitStart {
-            initialization_type: InitType::OnDemand,
-            phase: InitPhase::Init,
-            runtime_version: Some("nodejs:20.v22".to_string()),
-            runtime_version_arn: Some("arn:aws:lambda:us-east-1::runtime:da57c20c4b965d5b75540f6865a35fc8030358e33ec44ecfed33e90901a27a72".to_string()),
-        });
-        assert!(result.is_ok());
-    }
-
-    macro_rules! test_handle_stream_invalid_body {
-        ($($name:ident: $value:tt,)*) => {
-            $(
-                #[tokio::test]
-                #[should_panic(expected = "attempt to subtract with overflow")]
-                async fn $name() {
-                    let mut stream = get_stream($value.to_vec()).await;
-                    let (tx, _) = tokio::sync::mpsc::channel(4);
-                    TelemetryListener::handle_stream(&mut stream, tx).await.unwrap()
-                }
-            )*
-        }
-    }
-
-    test_handle_stream_invalid_body! {
-        invalid_json: b"POST /path HTTP/1.1\r\nContent-Length: 13\r\nHeader1: Value1\r\n\r\nHello, World!",
-        empty_json: b"POST /path HTTP/1.1\r\nContent-Length: 2\r\nHeader1: Value1\r\n\r\n{}",
-        json_array_with_empty_json: b"POST /path HTTP/1.1\r\nContent-Length: 4\r\nHeader1: Value1\r\n\r\n[{}]",
-
-    }
-
-    #[tokio::test]
-    async fn test_from_stream() {
-        let mut stream = get_stream(b"POST /path HTTP/1.1\r\nContent-Length: 335\r\nHeader1: Value1\r\n\r\n[{\"time\":\"2024-04-25T17:35:59.944Z\",\"type\":\"platform.initStart\",\"record\":{\"initializationType\":\"on-demand\",\"phase\":\"init\",\"runtimeVersion\":\"nodejs:20.v22\",\"runtimeVersionArn\":\"arn:aws:lambda:us-east-1::runtime:da57c20c4b965d5b75540f6865a35fc8030358e33ec44ecfed33e90901a27a72\",\"functionName\":\"hello-world\",\"functionVersion\":\"$LATEST\"}}]".to_vec()).await;
-
-        let result = HttpRequestParser::from_stream(&mut stream).await;
-
-        assert!(result.is_ok());
-        let parser = result.expect("invalid header parser");
-        assert_eq!(parser.headers.len(), 2);
-        assert_eq!(
-            parser.headers.get("content-length"),
-            Some(&"335".to_string())
-        );
-        assert_eq!(parser.headers.get("header1"), Some(&"Value1".to_string()));
-
-        assert_eq!(parser.body, "[{\"time\":\"2024-04-25T17:35:59.944Z\",\"type\":\"platform.initStart\",\"record\":{\"initializationType\":\"on-demand\",\"phase\":\"init\",\"runtimeVersion\":\"nodejs:20.v22\",\"runtimeVersionArn\":\"arn:aws:lambda:us-east-1::runtime:da57c20c4b965d5b75540f6865a35fc8030358e33ec44ecfed33e90901a27a72\",\"functionName\":\"hello-world\",\"functionVersion\":\"$LATEST\"}}]".to_string());
+        let events = rx.recv().await.unwrap();
+        assert_eq!(events.len(), 1);
+        //assert_eq!(events[0].get("key").unwrap(), "value");
     }
 }

--- a/bottlecap/src/telemetry/listener.rs
+++ b/bottlecap/src/telemetry/listener.rs
@@ -17,7 +17,7 @@ pub struct TelemetryListenerConfig {
 }
 
 impl TelemetryListener {
-    pub async fn new(
+    pub async fn spin(
         config: &TelemetryListenerConfig,
         event_bus: Sender<TelemetryEvent>,
         _cancel_token: tokio_util::sync::CancellationToken,

--- a/bottlecap/src/telemetry/listener.rs
+++ b/bottlecap/src/telemetry/listener.rs
@@ -67,8 +67,7 @@ impl TelemetryListener {
             event_bus.send(event).await.expect("infallible");
         }
 
-        let ack = Response::new(Body::from("OK"));
-        Ok(ack)
+        Ok(Response::new(Body::from("OK")))
     }
 }
 

--- a/bottlecap/src/telemetry/listener.rs
+++ b/bottlecap/src/telemetry/listener.rs
@@ -17,12 +17,11 @@ pub struct TelemetryListenerConfig {
 }
 
 impl TelemetryListener {
-    pub async fn new_hyper(
+    pub async fn new(
         config: &TelemetryListenerConfig,
         event_bus: Sender<TelemetryEvent>,
         _cancel_token: tokio_util::sync::CancellationToken,
     ) {
-        // let addr = format!("{}:{}", &config.host, &config.port);
         let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
 
         let service = make_service_fn(move |_| {


### PR DESCRIPTION
# What?

Use `hyper` crate instead of parsing payload for the telemetry API.

# Motivation

We should have done this since the start, but we weren't using tokio
