### PR TITLE
Fix dead link for contributing.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can also open an issue for a feature request.
 
 ## Contributing
 
-If you find an issue with this package and have a fix, please feel free to open a pull request following the [procedures](https://github.com/DataDog/datadog-agent/blob/master/docs/dev/contributing.md).
+If you find an issue with this package and have a fix, please feel free to open a pull request following the [procedures](https://github.com/DataDog/datadog-agent/blob/main/docs/public/guidelines/contributing.md).
 
 ## Testing
 


### PR DESCRIPTION
# What does this PR do?
Fix the broken link for contributing procedures.