### PR TITLE
chore(bottlecap): fallback on `datadog.yaml` usage

### DIFF
--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -106,6 +106,7 @@ pub fn get_config(config_directory: &Path) -> Result<Config, ConfigError> {
         _ => ConfigError::ParseError(err.to_string()),
     })?;
 
+    // TODO(duncanista): revert to using datadog.yaml when we have a proper serializer
     if path.exists() {
         log_failover_reason("datadog_yaml");
         debug!("datadog.yaml is not supported, use environment variables instead");


### PR DESCRIPTION
# What?

Failovers to Go binary when `datadog.yaml` is present.

# Motivation

`figment` crate doesn't match properly fields from `YAML` and environment variables. Therefore, if users had some configuration values enabled, we might not be able to honor them properly, due to how they're processed by figment.

# Note

This should be reverted once configuration is done accordingly for environment variables and `YAML`