### PR TITLE
feat(bottlecap): add `dd_extension_version` to tags

### DIFF
--- a/bottlecap/src/metrics/aggregator.rs
+++ b/bottlecap/src/metrics/aggregator.rs
@@ -429,6 +429,8 @@ mod tests {
     use std::collections::hash_map;
     use std::sync::Arc;
 
+    const SINGLE_METRIC_SIZE: usize = 205;
+
     fn create_tags_provider() -> Arc<provider::Provider> {
         let config = Arc::new(config::Config::default());
         Arc::new(provider::Provider::new(
@@ -604,8 +606,8 @@ mod tests {
 
     #[test]
     fn consume_distributions_batch_bytes() {
-        let single_proto_size = 121;
-        let max_bytes = 250;
+        let single_proto_size = 152;
+        let max_bytes = 310;
         let tot = 5;
         let mut aggregator = Aggregator {
             tags_provider: create_tags_provider(),
@@ -634,7 +636,7 @@ mod tests {
 
     #[test]
     fn consume_distribution_one_element_bigger_than_max_size() {
-        let single_proto_size = 121;
+        let single_proto_size = 152;
         let max_bytes = 1;
         let tot = 5;
         let mut aggregator = Aggregator {
@@ -722,9 +724,8 @@ mod tests {
 
     #[test]
     fn consume_metrics_batch_bytes() {
-        let single_metric_size = 174;
-        let two_metrics_size = 336;
-        let max_bytes = 350;
+        let two_metrics_size = 398;
+        let max_bytes = 413; //use a size that is not multiple or round, just in case
         let tot = 5;
         let mut aggregator = Aggregator {
             tags_provider: create_tags_provider(),
@@ -750,13 +751,12 @@ mod tests {
         );
         assert_eq!(
             serde_json::to_vec(batched.get(2).unwrap()).unwrap().len(),
-            single_metric_size
+            SINGLE_METRIC_SIZE
         );
     }
 
     #[test]
     fn consume_series_one_element_bigger_than_max_size() {
-        let single_metric_size = 174;
         let max_bytes = 1;
         let tot = 5;
         let mut aggregator = Aggregator {
@@ -776,7 +776,7 @@ mod tests {
         for a_batch in batched {
             assert_eq!(
                 serde_json::to_vec(&a_batch).unwrap().len(),
-                single_metric_size
+                SINGLE_METRIC_SIZE
             );
         }
     }

--- a/bottlecap/src/metrics/aggregator.rs
+++ b/bottlecap/src/metrics/aggregator.rs
@@ -430,6 +430,7 @@ mod tests {
     use std::sync::Arc;
 
     const SINGLE_METRIC_SIZE: usize = 205;
+    const SINGLE_DISTRIBUTION_SIZE: u64 = 152;
 
     fn create_tags_provider() -> Arc<provider::Provider> {
         let config = Arc::new(config::Config::default());
@@ -606,37 +607,46 @@ mod tests {
 
     #[test]
     fn consume_distributions_batch_bytes() {
-        let single_proto_size = 152;
-        let max_bytes = 310;
-        let tot = 5;
+        let expected_distribution_per_batch = 2;
+        let total_number_of_distributions = 5;
+        let max_bytes = SINGLE_METRIC_SIZE * expected_distribution_per_batch + 11;
         let mut aggregator = Aggregator {
             tags_provider: create_tags_provider(),
             map: hash_table::HashTable::new(),
             max_batch_entries_single_metric: 1_000,
             max_batch_bytes_single_metric: 1_000,
             max_batch_entries_sketch_metric: 1_000,
-            max_batch_bytes_sketch_metric: max_bytes,
+            max_batch_bytes_sketch_metric: max_bytes as u64,
             max_context: 1_000,
         };
 
-        add_metrics(tot, &mut aggregator, "d".to_string());
+        add_metrics(
+            total_number_of_distributions,
+            &mut aggregator,
+            "d".to_string(),
+        );
         let batched = aggregator.consume_distributions();
 
-        assert_eq!(batched.len(), tot / 2 + 1);
+        assert_eq!(
+            batched.len(),
+            total_number_of_distributions / expected_distribution_per_batch + 1
+        );
         assert_eq!(
             batched.first().unwrap().compute_size(),
-            single_proto_size * 2
+            SINGLE_DISTRIBUTION_SIZE * expected_distribution_per_batch as u64
         );
         assert_eq!(
             batched.get(1).unwrap().compute_size(),
-            single_proto_size * 2
+            SINGLE_DISTRIBUTION_SIZE * expected_distribution_per_batch as u64
         );
-        assert_eq!(batched.get(2).unwrap().compute_size(), single_proto_size);
+        assert_eq!(
+            batched.get(2).unwrap().compute_size(),
+            SINGLE_DISTRIBUTION_SIZE
+        );
     }
 
     #[test]
     fn consume_distribution_one_element_bigger_than_max_size() {
-        let single_proto_size = 152;
         let max_bytes = 1;
         let tot = 5;
         let mut aggregator = Aggregator {
@@ -654,7 +664,7 @@ mod tests {
 
         assert_eq!(batched.len(), tot);
         for a_batch in batched {
-            assert_eq!(a_batch.compute_size(), single_proto_size);
+            assert_eq!(a_batch.compute_size(), SINGLE_DISTRIBUTION_SIZE);
         }
     }
 
@@ -724,23 +734,27 @@ mod tests {
 
     #[test]
     fn consume_metrics_batch_bytes() {
+        let expected_metrics_per_batch = 2;
+        let total_number_of_metrics = 5;
         let two_metrics_size = 398;
-        let max_bytes = 413; //use a size that is not multiple or round, just in case
-        let tot = 5;
+        let max_bytes = SINGLE_METRIC_SIZE * expected_metrics_per_batch + 13;
         let mut aggregator = Aggregator {
             tags_provider: create_tags_provider(),
             map: hash_table::HashTable::new(),
             max_batch_entries_single_metric: 1_000,
-            max_batch_bytes_single_metric: max_bytes,
+            max_batch_bytes_single_metric: max_bytes as u64,
             max_batch_entries_sketch_metric: 1_000,
             max_batch_bytes_sketch_metric: 1_000,
             max_context: 1_000,
         };
 
-        add_metrics(tot, &mut aggregator, "c".to_string());
+        add_metrics(total_number_of_metrics, &mut aggregator, "c".to_string());
         let batched = aggregator.consume_metrics();
 
-        assert_eq!(batched.len(), tot / 2 + 1);
+        assert_eq!(
+            batched.len(),
+            total_number_of_metrics / expected_metrics_per_batch + 1
+        );
         assert_eq!(
             serde_json::to_vec(batched.first().unwrap()).unwrap().len(),
             two_metrics_size

--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -228,7 +228,7 @@ mod tests {
     fn test_new_from_config() {
         let metadata = hash_map::HashMap::new();
         let tags = Lambda::new_from_config(Arc::new(config::Config::default()), &metadata);
-        assert_eq!(tags.tags_map.len(), 3);
+        assert_eq!(tags.tags_map.len(), 4);
         assert_eq!(
             tags.tags_map.get(COMPUTE_STATS_KEY).unwrap(),
             COMPUTE_STATS_VALUE

--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -47,7 +47,7 @@ const COMPUTE_STATS_VALUE: &str = "1";
 // TODO(astuyve) decide what to do with the version
 const EXTENSION_VERSION_KEY: &str = "dd_extension_version";
 // TODO(duncanista) figure out a better way to not hardcode this
-const EXTENSION_VERSION: &str = "v61-next";
+const EXTENSION_VERSION: &str = "61-next";
 
 const REGION_KEY: &str = "region";
 const ACCOUNT_ID_KEY: &str = "account_id";

--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -130,7 +130,10 @@ fn tags_from_env(
     }
 
     tags_map.insert(ARCHITECTURE_KEY.to_string(), arch_to_platform().to_string());
-    tags_map.insert(EXTENSION_VERSION_KEY.to_string(), EXTENSION_VERSION.to_string());
+    tags_map.insert(
+        EXTENSION_VERSION_KEY.to_string(),
+        EXTENSION_VERSION.to_string(),
+    );
 
     if let Some(tags) = &config.tags {
         for tag in tags.split(',') {
@@ -236,6 +239,11 @@ mod tests {
             &arch.to_string()
         );
         assert_eq!(tags.tags_map.get(RUNTIME_KEY).unwrap(), "unknown");
+
+        assert_eq!(
+            tags.tags_map.get(EXTENSION_VERSION_KEY).unwrap(),
+            EXTENSION_VERSION
+        );
     }
 
     #[test]

--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -45,7 +45,9 @@ const COMPUTE_STATS_KEY: &str = "_dd.compute_stats";
 // ComputeStatsValue is the tag value indicating trace stats should be computed
 const COMPUTE_STATS_VALUE: &str = "1";
 // TODO(astuyve) decide what to do with the version
-// const EXTENSION_VERSION_KEY: &str = "dd_extension_version";
+const EXTENSION_VERSION_KEY: &str = "dd_extension_version";
+// TODO(duncanista) figure out a better way to not hardcode this
+const EXTENSION_VERSION: &str = "v61-next";
 
 const REGION_KEY: &str = "region";
 const ACCOUNT_ID_KEY: &str = "account_id";
@@ -128,6 +130,7 @@ fn tags_from_env(
     }
 
     tags_map.insert(ARCHITECTURE_KEY.to_string(), arch_to_platform().to_string());
+    tags_map.insert(EXTENSION_VERSION_KEY.to_string(), EXTENSION_VERSION.to_string());
 
     if let Some(tags) = &config.tags {
         for tag in tags.split(',') {

--- a/bottlecap/tests/logs_integration_test.rs
+++ b/bottlecap/tests/logs_integration_test.rs
@@ -20,6 +20,7 @@ async fn test_logs() {
     let regexp_compute_state = r#"_dd.compute_stats:1"#;
     let regexp_arch = r#"architecture:x86_64"#;
     let regexp_function_arn = r#"function_arn:test-arn"#;
+    let regexp_extension_version = r#"dd_extension_version"#;
 
     let server = MockServer::start();
     let hello_mock = server.mock(|when, then| {
@@ -30,7 +31,8 @@ async fn test_logs() {
             .body_contains(regexp_message)
             .body_contains(regexp_compute_state)
             .body_contains(regexp_arch)
-            .body_contains(regexp_function_arn);
+            .body_contains(regexp_function_arn)
+            .body_contains(regexp_extension_version);
 
         then.status(reqwest::StatusCode::ACCEPTED.as_u16());
     });


### PR DESCRIPTION
# What?

Adds `dd_extension_version` to the tags.

# Motivation

We need it.
Also [SVLS-5154](https://datadoghq.atlassian.net/browse/SVLS-5154)

# Note

Currently, we are setting a hardcoded value `61-next` which should indicate the current version of the package. This needs to be updated to not be hardcoded. Keeping it only for closed beta.



[SVLS-5154]: https://datadoghq.atlassian.net/browse/SVLS-5154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ