### PR TITLE
fix: image builder agent resolution

### DIFF
--- a/.gitlab/scripts/build_bottlecap.sh
+++ b/.gitlab/scripts/build_bottlecap.sh
@@ -14,8 +14,10 @@ fi
 
 if [ -z "$ALPINE" ]; then
     printf "Building bottlecap"
+    BUILD_FILE=Dockerfile.bottlecap.build
 else
     echo "Building bottlecap for alpine"
+    BUILD_FILE=Dockerfile.bottlecap.alpine.build
     BUILD_SUFFIX="-alpine"
 fi
 
@@ -39,6 +41,7 @@ prepare_folders() {
 
 docker_build() {
     local arch=$1
+    local file=$2
     if [ "$arch" == "amd64" ]; then
         PLATFORM="x86_64"
     else
@@ -47,7 +50,7 @@ docker_build() {
 
     docker buildx build --platform linux/${arch} \
         -t datadog/build-bottlecap-${arch} \
-        -f ./scripts/Dockerfile.bottlecap.build \
+        -f ./scripts/${file} \
         --build-arg PLATFORM=$PLATFORM \
         --build-arg GO_AGENT_PATH="datadog_extension-${arch}${BUILD_SUFFIX}" \
         . -o $TARGET_DIR/datadog_bottlecap-${arch}${BUILD_SUFFIX}
@@ -61,4 +64,4 @@ docker_build() {
 }
 
 prepare_folders
-docker_build $ARCHITECTURE
+docker_build $ARCHITECTURE $BUILD_FILE

--- a/.gitlab/scripts/build_go_agent.sh
+++ b/.gitlab/scripts/build_go_agent.sh
@@ -16,15 +16,17 @@ if [ -z "$ARCHITECTURE" ]; then
 fi
 
 
-if [ -z "$CI_COMMIT_TAG" ]; then
-    # Running on dev
-    printf "Running on dev environment\n"
-    VERSION="dev"
-else
-    printf "Found version tag in environment\n"
-    VERSION="${CI_COMMIT_TAG//[!0-9]/}"
-    printf "Version: ${VERSION}\n"
-fi
+# if [ -z "$CI_COMMIT_TAG" ]; then
+#     # Running on dev
+#     printf "Running on dev environment\n"
+#     VERSION="dev"
+# else
+#     printf "Found version tag in environment\n"
+#     VERSION="${CI_COMMIT_TAG//[!0-9]/}"
+#     printf "Version: ${VERSION}\n"
+# fi
+
+printf "Version: ${VERSION}\n"
 
 if [ -z "$SERVERLESS_INIT" ]; then
     printf "Building Datadog Lambda Extension\n"

--- a/.gitlab/scripts/build_go_agent.sh
+++ b/.gitlab/scripts/build_go_agent.sh
@@ -16,17 +16,16 @@ if [ -z "$ARCHITECTURE" ]; then
 fi
 
 
-# if [ -z "$CI_COMMIT_TAG" ]; then
-#     # Running on dev
-#     printf "Running on dev environment\n"
-#     VERSION="dev"
-# else
-#     printf "Found version tag in environment\n"
-#     VERSION="${CI_COMMIT_TAG//[!0-9]/}"
-#     printf "Version: ${VERSION}\n"
-# fi
+if [ -z "$CI_COMMIT_TAG" ]; then
+    # Running on dev
+    printf "Running on dev environment\n"
+    VERSION="dev"
+else
+    printf "Found version tag in environment\n"
+    VERSION="${CI_COMMIT_TAG//[!0-9]/}"
+    printf "Version: ${VERSION}\n"
+fi
 
-printf "Version: ${VERSION}\n"
 
 if [ -z "$SERVERLESS_INIT" ]; then
     printf "Building Datadog Lambda Extension\n"

--- a/.gitlab/scripts/build_image.sh
+++ b/.gitlab/scripts/build_image.sh
@@ -12,17 +12,15 @@ set -e
 DOCKER_TARGET_IMAGE="registry.ddbuild.io/ci/datadog-lambda-extension"
 EXTENSION_DIR=".layers"
 
-# if [ -z "$CI_COMMIT_TAG" ]; then
-#     # Running on dev
-#     printf "Running on dev environment\n"
-#     VERSION="dev"
-# else
-#     printf "Found version tag in environment\n"
-#     VERSION=$(echo "${CI_COMMIT_TAG##*v}" | cut -d. -f2)
-#     echo "Version: $VERSION"
-# fi
-
-printf "Version: $VERSION\n"
+if [ -z "$CI_COMMIT_TAG" ]; then
+    # Running on dev
+    printf "Running on dev environment\n"
+    VERSION="dev"
+else
+    printf "Found version tag in environment\n"
+    VERSION=$(echo "${CI_COMMIT_TAG##*v}" | cut -d. -f2)
+    printf "Version: $VERSION\n"
+fi
 
 
 if [ -z "$ALPINE" ]; then

--- a/.gitlab/scripts/build_image.sh
+++ b/.gitlab/scripts/build_image.sh
@@ -12,15 +12,18 @@ set -e
 DOCKER_TARGET_IMAGE="registry.ddbuild.io/ci/datadog-lambda-extension"
 EXTENSION_DIR=".layers"
 
-if [ -z "$CI_COMMIT_TAG" ]; then
-    # Running on dev
-    printf "Running on dev environment\n"
-    VERSION="dev"
-else
-    printf "Found version tag in environment\n"
-    VERSION=$(echo "${CI_COMMIT_TAG##*v}" | cut -d. -f2)
-    echo "Version: $VERSION"
-fi
+# if [ -z "$CI_COMMIT_TAG" ]; then
+#     # Running on dev
+#     printf "Running on dev environment\n"
+#     VERSION="dev"
+# else
+#     printf "Found version tag in environment\n"
+#     VERSION=$(echo "${CI_COMMIT_TAG##*v}" | cut -d. -f2)
+#     echo "Version: $VERSION"
+# fi
+
+printf "Version: $VERSION\n"
+
 
 if [ -z "$ALPINE" ]; then
     printf "Building image\n"

--- a/.gitlab/templates/lambda-extension.yaml.tpl
+++ b/.gitlab/templates/lambda-extension.yaml.tpl
@@ -13,6 +13,7 @@ default:
 variables:
   DOCKER_TARGET_IMAGE: registry.ddbuild.io/ci/datadog-lambda-extension
   DOCKER_TARGET_VERSION: latest
+  VERSION: 61
 
 {{ range $architecture := (ds "architectures").architectures }}
 
@@ -200,8 +201,8 @@ build images:
   stage: build
   tags: ["arch:amd64"]
   image: registry.ddbuild.io/images/docker:20.10
-  rules:
-    - if: '$CI_COMMIT_TAG =~ /^v.*/'
+  # rules:
+  #   - if: '$CI_COMMIT_TAG =~ /^v.*/'
   needs:
     - build bottlecap (arm64)
     - build bottlecap (amd64)
@@ -215,8 +216,8 @@ build images (alpine):
   stage: build
   tags: ["arch:amd64"]
   image: registry.ddbuild.io/images/docker:20.10
-  rules:
-    - if: '$CI_COMMIT_TAG =~ /^v.*/'
+  # rules:
+  #   - if: '$CI_COMMIT_TAG =~ /^v.*/'
   needs:
     - build bottlecap (arm64, alpine)
     - build bottlecap (amd64, alpine)
@@ -230,8 +231,8 @@ build images (alpine):
 
 publish images:
   stage: publish
-  rules:
-    - if: '$CI_COMMIT_TAG =~ /^v.*/'
+  # rules:
+  #   - if: '$CI_COMMIT_TAG =~ /^v.*/'
   needs:
     - build images
   when: manual
@@ -248,8 +249,8 @@ publish images:
 
 publish images (alpine):
   stage: publish
-  rules:
-    - if: '$CI_COMMIT_TAG =~ /^v.*/'
+  # rules:
+  #   - if: '$CI_COMMIT_TAG =~ /^v.*/'
   needs:
     - build images (alpine)
   when: manual

--- a/.gitlab/templates/lambda-extension.yaml.tpl
+++ b/.gitlab/templates/lambda-extension.yaml.tpl
@@ -11,8 +11,8 @@ default:
       - runner_system_failure
 
 variables:
-  DOCKER_TARGET_IMAGE: registry.ddbuild.io/ci/datadog-lambda-extension
-  DOCKER_TARGET_VERSION: latest
+  CI_DOCKER_TARGET_IMAGE: registry.ddbuild.io/ci/datadog-lambda-extension
+  CI_DOCKER_TARGET_VERSION: latest
   VERSION: 61
 
 {{ range $architecture := (ds "architectures").architectures }}
@@ -103,7 +103,7 @@ check layer size ({{ $architecture.name }}):
 fmt ({{ $architecture.name }}):
   stage: test
   tags: ["arch:{{ $architecture.name }}"]
-  image: ${DOCKER_TARGET_IMAGE}:${DOCKER_TARGET_VERSION}
+  image: ${CI_DOCKER_TARGET_IMAGE}:${CI_DOCKER_TARGET_VERSION}
   needs: []
   script:
     - cd bottlecap && cargo fmt
@@ -111,7 +111,7 @@ fmt ({{ $architecture.name }}):
 check ({{ $architecture.name }}):
   stage: test
   tags: ["arch:{{ $architecture.name }}"]
-  image: ${DOCKER_TARGET_IMAGE}:${DOCKER_TARGET_VERSION}
+  image: ${CI_DOCKER_TARGET_IMAGE}:${CI_DOCKER_TARGET_VERSION}
   needs: []
   script:
     - cd bottlecap && cargo check
@@ -119,7 +119,7 @@ check ({{ $architecture.name }}):
 clippy ({{ $architecture.name }}):
   stage: test
   tags: ["arch:{{ $architecture.name }}"]
-  image: ${DOCKER_TARGET_IMAGE}:${DOCKER_TARGET_VERSION}
+  image: ${CI_DOCKER_TARGET_IMAGE}:${CI_DOCKER_TARGET_VERSION}
   needs: []
   script:
     - cd bottlecap && cargo clippy --all-features
@@ -130,7 +130,7 @@ clippy ({{ $architecture.name }}):
 sign layer ({{ $architecture.name }}):
   stage: sign
   tags: ["arch:amd64"]
-  image: ${DOCKER_TARGET_IMAGE}:${DOCKER_TARGET_VERSION}
+  image: ${CI_DOCKER_TARGET_IMAGE}:${CI_DOCKER_TARGET_VERSION}
   rules:
     - if: '$CI_COMMIT_TAG =~ /^v.*/'
       when: manual
@@ -157,7 +157,7 @@ sign layer ({{ $architecture.name }}):
 publish layer {{ $environment.name }} ({{ $architecture.name }}):
   stage: publish
   tags: ["arch:amd64"]
-  image: ${DOCKER_TARGET_IMAGE}:${DOCKER_TARGET_VERSION}
+  image: ${CI_DOCKER_TARGET_IMAGE}:${CI_DOCKER_TARGET_VERSION}
   rules:
     - if: '"{{ $environment.name }}" =~ /^(sandbox|staging)/'
       when: manual
@@ -240,10 +240,8 @@ publish images:
     project: DataDog/public-images
     branch: main
     strategy: depend
-    forward:
-      yaml_variables: false
   variables:
-    IMG_SOURCES: ${DOCKER_TARGET_IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+    IMG_SOURCES: ${CI_DOCKER_TARGET_IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     IMG_DESTINATIONS: datadog/lambda-extension:${VERSION},datadog/lambda-extension:latest
     IMG_REGISTRIES: dockerhub,ecr-public,gcr-datadoghq
 
@@ -258,9 +256,7 @@ publish images (alpine):
     project: DataDog/public-images
     branch: main
     strategy: depend
-    forward:
-      yaml_variables: false
   variables:
-    IMG_SOURCES: ${DOCKER_TARGET_IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-alpine
+    IMG_SOURCES: ${CI_DOCKER_TARGET_IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-alpine
     IMG_DESTINATIONS: datadog/lambda-extension:${VERSION}-alpine,datadog/lambda-extension:latest-alpine
     IMG_REGISTRIES: dockerhub,ecr-public,gcr-datadoghq

--- a/.gitlab/templates/lambda-extension.yaml.tpl
+++ b/.gitlab/templates/lambda-extension.yaml.tpl
@@ -13,7 +13,6 @@ default:
 variables:
   CI_DOCKER_TARGET_IMAGE: registry.ddbuild.io/ci/datadog-lambda-extension
   CI_DOCKER_TARGET_VERSION: latest
-  VERSION: 61
 
 {{ range $architecture := (ds "architectures").architectures }}
 
@@ -201,8 +200,8 @@ build images:
   stage: build
   tags: ["arch:amd64"]
   image: registry.ddbuild.io/images/docker:20.10
-  # rules:
-  #   - if: '$CI_COMMIT_TAG =~ /^v.*/'
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^v.*/'
   needs:
     - build bottlecap (arm64)
     - build bottlecap (amd64)
@@ -216,8 +215,8 @@ build images (alpine):
   stage: build
   tags: ["arch:amd64"]
   image: registry.ddbuild.io/images/docker:20.10
-  # rules:
-  #   - if: '$CI_COMMIT_TAG =~ /^v.*/'
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^v.*/'
   needs:
     - build bottlecap (arm64, alpine)
     - build bottlecap (amd64, alpine)
@@ -231,8 +230,8 @@ build images (alpine):
 
 publish images:
   stage: publish
-  # rules:
-  #   - if: '$CI_COMMIT_TAG =~ /^v.*/'
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^v.*/'
   needs:
     - build images
   when: manual
@@ -244,11 +243,12 @@ publish images:
     IMG_SOURCES: ${CI_DOCKER_TARGET_IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     IMG_DESTINATIONS: lambda-extension:${VERSION},lambda-extension:latest
     IMG_REGISTRIES: dockerhub,ecr-public,gcr-datadoghq
+    IMG_SIGNING: false
 
 publish images (alpine):
   stage: publish
-  # rules:
-  #   - if: '$CI_COMMIT_TAG =~ /^v.*/'
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^v.*/'
   needs:
     - build images (alpine)
   when: manual
@@ -260,3 +260,4 @@ publish images (alpine):
     IMG_SOURCES: ${CI_DOCKER_TARGET_IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-alpine
     IMG_DESTINATIONS: lambda-extension:${VERSION}-alpine,lambda-extension:latest-alpine
     IMG_REGISTRIES: dockerhub,ecr-public,gcr-datadoghq
+    IMG_SIGNING: false

--- a/.gitlab/templates/lambda-extension.yaml.tpl
+++ b/.gitlab/templates/lambda-extension.yaml.tpl
@@ -239,6 +239,8 @@ publish images:
     project: DataDog/public-images
     branch: main
     strategy: depend
+    forward:
+      yaml_variables: false
   variables:
     IMG_SOURCES: ${DOCKER_TARGET_IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     IMG_DESTINATIONS: datadog/lambda-extension:${VERSION},datadog/lambda-extension:latest
@@ -255,6 +257,8 @@ publish images (alpine):
     project: DataDog/public-images
     branch: main
     strategy: depend
+    forward:
+      yaml_variables: false
   variables:
     IMG_SOURCES: ${DOCKER_TARGET_IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-alpine
     IMG_DESTINATIONS: datadog/lambda-extension:${VERSION}-alpine,datadog/lambda-extension:latest-alpine

--- a/.gitlab/templates/lambda-extension.yaml.tpl
+++ b/.gitlab/templates/lambda-extension.yaml.tpl
@@ -242,7 +242,7 @@ publish images:
     strategy: depend
   variables:
     IMG_SOURCES: ${CI_DOCKER_TARGET_IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
-    IMG_DESTINATIONS: datadog/lambda-extension:${VERSION},datadog/lambda-extension:latest
+    IMG_DESTINATIONS: lambda-extension:${VERSION},lambda-extension:latest
     IMG_REGISTRIES: dockerhub,ecr-public,gcr-datadoghq
 
 publish images (alpine):
@@ -258,5 +258,5 @@ publish images (alpine):
     strategy: depend
   variables:
     IMG_SOURCES: ${CI_DOCKER_TARGET_IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-alpine
-    IMG_DESTINATIONS: datadog/lambda-extension:${VERSION}-alpine,datadog/lambda-extension:latest-alpine
+    IMG_DESTINATIONS: lambda-extension:${VERSION}-alpine,lambda-extension:latest-alpine
     IMG_REGISTRIES: dockerhub,ecr-public,gcr-datadoghq

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,5 +1,5 @@
 FROM scratch
 ARG TARGETARCH
 COPY .layers/datadog_bottlecap-$TARGETARCH/extensions/datadog-agent opt/extensions/datadog-agent
-COPY .layers/datadog_bottlecap-$TARGETARCH/datadog-agent-go opt/extensions/datadog-agent-go
+COPY .layers/datadog_bottlecap-$TARGETARCH/datadog-agent-go opt/datadog-agent-go
 COPY --chmod=0755 scripts/datadog_wrapper opt/datadog_wrapper

--- a/scripts/Dockerfile.alpine
+++ b/scripts/Dockerfile.alpine
@@ -1,5 +1,5 @@
 FROM scratch
 ARG TARGETARCH
 COPY .layers/datadog_bottlecap-$TARGETARCH-alpine/extensions/datadog-agent opt/extensions/datadog-agent
-COPY .layers/datadog_bottlecap-$TARGETARCH-alpine/datadog-agent-go opt/extensions/datadog-agent-go
+COPY .layers/datadog_bottlecap-$TARGETARCH-alpine/datadog-agent-go opt/datadog-agent-go
 COPY --chmod=0755 scripts/datadog_wrapper opt/datadog_wrapper

--- a/scripts/Dockerfile.bottlecap.alpine.build
+++ b/scripts/Dockerfile.bottlecap.alpine.build
@@ -1,0 +1,52 @@
+# syntax = docker/dockerfile:experimental
+
+FROM alpine:3.16 as bottlecap-builder
+ARG PLATFORM 
+RUN apk add --no-cache curl gcc musl-dev make unzip bash autoconf automake libtool g++
+
+SHELL ["/bin/bash", "-c"]
+
+# Install Protocol Buffers, from package instead of manually
+RUN apk add --no-cache protoc
+
+# Install Rust Toolchain
+RUN curl https://sh.rustup.rs -sSf | \
+    sh -s -- --profile minimal --default-toolchain nightly-$PLATFORM-unknown-linux-musl -y
+ENV PATH=/root/.cargo/bin:$PATH
+RUN rustup component add rust-src --toolchain nightly-$PLATFORM-unknown-linux-musl
+
+# Build Bottlecap
+RUN mkdir -p /tmp/dd
+COPY ./bottlecap/src /tmp/dd/bottlecap/src
+COPY ./bottlecap/Cargo.toml /tmp/dd/bottlecap/Cargo.toml
+COPY ./bottlecap/Cargo.lock /tmp/dd/bottlecap/Cargo.lock
+# Added `-C link-arg=-lgcc` for alpine.
+ENV RUSTFLAGS="-C panic=abort -C link-arg=-lgcc -Zlocation-detail=none"
+WORKDIR /tmp/dd/bottlecap
+RUN --mount=type=cache,target=/root/.cargo/registry cargo +nightly build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --release --target $PLATFORM-unknown-linux-musl
+RUN cp /tmp/dd/bottlecap/target/$PLATFORM-unknown-linux-musl/release/bottlecap /tmp/dd/bottlecap/bottlecap
+
+# Zip Extension
+FROM ubuntu:latest as compresser
+ARG DATADOG_WRAPPER=datadog_wrapper
+ARG GO_AGENT_PATH
+
+RUN apt-get update
+RUN apt-get install -y zip binutils
+
+COPY .layers/$GO_AGENT_PATH/extensions/datadog-agent /datadog-agent-go
+RUN strip /datadog-agent-go # just in case
+
+RUN mkdir /extensions
+WORKDIR /extensions
+
+COPY --from=bottlecap-builder /tmp/dd/bottlecap/bottlecap /extensions/datadog-agent
+
+COPY ./scripts/$DATADOG_WRAPPER /$DATADOG_WRAPPER
+RUN chmod +x /$DATADOG_WRAPPER
+RUN  zip -r datadog_extension.zip /extensions /$DATADOG_WRAPPER /datadog-agent-go
+
+# keep the smallest possible docker image
+FROM scratch
+COPY --from=compresser /extensions/datadog_extension.zip /
+ENTRYPOINT ["/datadog_extension.zip"]


### PR DESCRIPTION
# What?

The container images published for `v61` had a mismatch in agent resolution. Our monitors didn't notify us 🤦🏽.
This solved the uncaught typo mismatch and also adds an alpine build for Bottlecap.

# Motivation

#331 and `#incident-29136`

# Test

Manual tested:
- `arm64` and `amd64` image, and
- `arm64` and `amd64` image for alpine.