### PR TITLE
fix(bottlecap): remove log that might confuse customers

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -201,9 +201,7 @@ fn load_configs() -> (AwsConfig, Arc<Config>) {
     let lambda_directory = env::var("LAMBDA_TASK_ROOT").unwrap_or_else(|_| "/var/task".to_string());
     let config = match config::get_config(Path::new(&lambda_directory)) {
         Ok(config) => Arc::new(config),
-        Err(e) => {
-            // NOTE we must print here as the logging subsystem is not enabled yet.
-            println!("Error loading configuration: {e:?}");
+        Err(_e) => {
             let err = Command::new("/opt/datadog-agent-go").exec();
             panic!("Error starting the extension: {err:?}");
         }

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -6,7 +6,6 @@ use std::path::Path;
 
 use figment::{providers::Env, Figment};
 use serde::Deserialize;
-use tracing::debug;
 
 use crate::config::flush_strategy::FlushStrategy;
 use crate::config::log_level::LogLevel;
@@ -109,7 +108,6 @@ pub fn get_config(config_directory: &Path) -> Result<Config, ConfigError> {
     // TODO(duncanista): revert to using datadog.yaml when we have a proper serializer
     if path.exists() {
         log_failover_reason("datadog_yaml");
-        debug!("datadog.yaml is not supported, use environment variables instead");
         return Err(ConfigError::UnsupportedField("datadog_yaml".to_string()));
     }
 


### PR DESCRIPTION
# What?

When loading Rust, a `println` explicitly marked an `Error` which would end up in customers Lambdas, this might appear as confusing, since we end up going into failover with Go

# Motivation

We should have removed this, but we forgot that this could appear on every customer 🤦🏽.
Also `#incident-29136`