### PR TITLE
fix: require `AGENT_VERSION` to tag the build properly

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,9 @@ variables:
   AGENT_BRANCH:
     description: "Branch of the datadog-agent repository to use."
     value: main
+  AGENT_VERSION:
+    description: "Latest release version of the datadog-agent to tag the build with."
+    value: "7.55.1"
   LAYER_SUFFIX:
     description: "Suffix to be appended to the layer name (default empty)."
     value: ""
@@ -91,3 +94,4 @@ lambda-extension:
     VERSION: $VERSION
     AGENT_BRANCH: $AGENT_BRANCH
     LAYER_SUFFIX: $LAYER_SUFFIX
+    AGENT_VERSION: $AGENT_VERSION

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,6 +77,7 @@ go-agent-only:
   variables:
     AGENT_BRANCH: $AGENT_BRANCH
     LAYER_SUFFIX: $LAYER_SUFFIX
+    AGENT_VERSION: $AGENT_VERSION
 
 lambda-extension:
   stage: build

--- a/.gitlab/scripts/build_go_agent.sh
+++ b/.gitlab/scripts/build_go_agent.sh
@@ -15,6 +15,13 @@ if [ -z "$ARCHITECTURE" ]; then
     exit 1
 fi
 
+if [ -z "$AGENT_VERSION" ]; then
+    printf "[ERROR]: AGENT_VERSION not specified\n"
+    exit 1
+else
+    printf "Building agent with version: ${AGENT_VERSION}\n"
+
+fi
 
 if [ -z "$CI_COMMIT_TAG" ]; then
     # Running on dev


### PR DESCRIPTION
# What?

Tags builds with latest agent, setting the default to the current latest.

# Motivation

We were not tagging the build with the proper Agent version, fallbacking to `6.0`, which is incorrect.