### PR TITLE
fix(bottlecap): remove `nightly` in favor or `stable`

### DIFF
--- a/.gitlab/Dockerfile
+++ b/.gitlab/Dockerfile
@@ -13,11 +13,11 @@ RUN chmod +x /install-protoc.sh && /install-protoc.sh
 
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-  sh -s -- --profile minimal --default-toolchain nightly -y
+  sh -s -- --profile minimal --default-toolchain stable -y
 
 RUN source $HOME/.cargo/env
 ENV PATH /root/.cargo/bin/:$PATH
 
-RUN rustup component add rust-src --toolchain nightly
+RUN rustup component add rust-src --toolchain stable
 
 

--- a/scripts/Dockerfile.bottlecap.alpine.build
+++ b/scripts/Dockerfile.bottlecap.alpine.build
@@ -2,7 +2,7 @@
 
 FROM alpine:3.16 as bottlecap-builder
 ARG PLATFORM 
-RUN apk add --no-cache curl gcc musl-dev make unzip bash autoconf automake libtool g++
+RUN apk add --no-cache curl libgcc gcc musl-dev make unzip bash autoconf automake libtool g++
 
 SHELL ["/bin/bash", "-c"]
 
@@ -11,9 +11,13 @@ RUN apk add --no-cache protoc
 
 # Install Rust Toolchain
 RUN curl https://sh.rustup.rs -sSf | \
-    sh -s -- --profile minimal --default-toolchain nightly-$PLATFORM-unknown-linux-musl -y
+    sh -s -- --profile minimal --default-toolchain stable-$PLATFORM-unknown-linux-musl -y
 ENV PATH=/root/.cargo/bin:$PATH
-RUN rustup component add rust-src --toolchain nightly-$PLATFORM-unknown-linux-musl
+RUN rustup component add rust-src --toolchain stable-$PLATFORM-unknown-linux-musl
+
+RUN echo "$(cargo --version)" && \
+    echo "$(rustc --version)" && \
+    echo "$(protoc --version)"
 
 # Build Bottlecap
 RUN mkdir -p /tmp/dd
@@ -21,9 +25,9 @@ COPY ./bottlecap/src /tmp/dd/bottlecap/src
 COPY ./bottlecap/Cargo.toml /tmp/dd/bottlecap/Cargo.toml
 COPY ./bottlecap/Cargo.lock /tmp/dd/bottlecap/Cargo.lock
 # Added `-C link-arg=-lgcc` for alpine.
-ENV RUSTFLAGS="-C panic=abort -C link-arg=-lgcc -Z location-detail=none"
+ENV RUSTFLAGS="-C panic=abort -C link-arg=-lgcc"
 WORKDIR /tmp/dd/bottlecap
-RUN --mount=type=cache,target=/root/.cargo/registry cargo +nightly build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --release --target $PLATFORM-unknown-linux-musl
+RUN --mount=type=cache,target=/root/.cargo/registry cargo +stable build --release --target $PLATFORM-unknown-linux-musl
 RUN cp /tmp/dd/bottlecap/target/$PLATFORM-unknown-linux-musl/release/bottlecap /tmp/dd/bottlecap/bottlecap
 
 # Zip Extension

--- a/scripts/Dockerfile.bottlecap.alpine.build
+++ b/scripts/Dockerfile.bottlecap.alpine.build
@@ -15,10 +15,6 @@ RUN curl https://sh.rustup.rs -sSf | \
 ENV PATH=/root/.cargo/bin:$PATH
 RUN rustup component add rust-src --toolchain stable-$PLATFORM-unknown-linux-musl
 
-RUN echo "$(cargo --version)" && \
-    echo "$(rustc --version)" && \
-    echo "$(protoc --version)"
-
 # Build Bottlecap
 RUN mkdir -p /tmp/dd
 COPY ./bottlecap/src /tmp/dd/bottlecap/src

--- a/scripts/Dockerfile.bottlecap.alpine.build
+++ b/scripts/Dockerfile.bottlecap.alpine.build
@@ -2,7 +2,7 @@
 
 FROM alpine:3.16 as bottlecap-builder
 ARG PLATFORM 
-RUN apk add --no-cache curl libgcc gcc musl-dev make unzip bash autoconf automake libtool g++
+RUN apk add --no-cache curl gcc musl-dev make unzip bash autoconf automake libtool g++
 
 SHELL ["/bin/bash", "-c"]
 

--- a/scripts/Dockerfile.bottlecap.build
+++ b/scripts/Dockerfile.bottlecap.build
@@ -10,18 +10,18 @@ RUN chmod +x /install-protoc.sh && /install-protoc.sh
 
 # Install Rust Toolchain
 RUN curl https://sh.rustup.rs -sSf | \
-    sh -s -- --profile minimal --default-toolchain nightly-$PLATFORM-unknown-linux-gnu -y
+    sh -s -- --profile minimal --default-toolchain stable-$PLATFORM-unknown-linux-gnu -y
 ENV PATH=/root/.cargo/bin:$PATH
-RUN rustup component add rust-src --toolchain nightly-$PLATFORM-unknown-linux-gnu
+RUN rustup component add rust-src --toolchain stable-$PLATFORM-unknown-linux-gnu
 
 # Build Bottlecap
 RUN mkdir -p /tmp/dd
 COPY ./bottlecap/src /tmp/dd/bottlecap/src
 COPY ./bottlecap/Cargo.toml /tmp/dd/bottlecap/Cargo.toml
 COPY ./bottlecap/Cargo.lock /tmp/dd/bottlecap/Cargo.lock
-ENV RUSTFLAGS="-C panic=abort -Z location-detail=none"
+ENV RUSTFLAGS="-C panic=abort"
 WORKDIR /tmp/dd/bottlecap
-RUN --mount=type=cache,target=/usr/local/cargo/registry cargo +nightly build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --release --target $PLATFORM-unknown-linux-gnu
+RUN --mount=type=cache,target=/usr/local/cargo/registry cargo +stable build --release --target $PLATFORM-unknown-linux-gnu
 RUN cp /tmp/dd/bottlecap/target/$PLATFORM-unknown-linux-gnu/release/bottlecap /tmp/dd/bottlecap/bottlecap
 
 # Zip Extension


### PR DESCRIPTION
# What?

Move to `stable` toolchain for rust.

# Why?

Arm64 Alpine build is failing due to `rustc` being updated on `nightly` toolchain.


# Notes

Not updating the `.dev` Dockerfile