### PR TITLE
feat: Allow trace disabled plugins

### DIFF
--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -47,6 +47,7 @@ pub struct Config {
     pub cold_start_trace_skip_lib: String,
     pub service_mapping: Option<String>,
     pub data_streams_enabled: bool,
+    pub trace_disabled_plugins: Option<String>,
 }
 
 impl Default for Config {
@@ -71,6 +72,7 @@ impl Default for Config {
             // APM
             apm_enabled: false,
             apm_replace_tags: None,
+            trace_disabled_plugins: None,
             lambda_handler: String::default(),
             serverless_trace_enabled: true,
             trace_enabled: true,

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -48,6 +48,7 @@ pub struct Config {
     pub service_mapping: Option<String>,
     pub data_streams_enabled: bool,
     pub trace_disabled_plugins: Option<String>,
+    pub trace_debug: bool,
 }
 
 impl Default for Config {
@@ -90,6 +91,7 @@ impl Default for Config {
             enhanced_metrics: true,
             service_mapping: None,
             data_streams_enabled: false,
+            trace_debug: false,
         }
     }
 }


### PR DESCRIPTION
Allows `DD_TRACE_DISABLED_PLUGINS` for people who want to optionally disable some plugins in the tracer.
