### PR TITLE
feat: Use stable instead of nightly

### DIFF
--- a/scripts/Dockerfile.bottlecap.dev
+++ b/scripts/Dockerfile.bottlecap.dev
@@ -7,9 +7,9 @@ RUN yum install -y curl gcc gcc-c++ make unzip openssl openssl-devel
 COPY ./scripts/install-protoc.sh /
 RUN chmod +x /install-protoc.sh && /install-protoc.sh
 RUN curl https://sh.rustup.rs -sSf | \
-    sh -s -- --profile minimal --default-toolchain nightly-$PLATFORM-unknown-linux-gnu -y
+    sh -s -- --profile minimal --default-toolchain stable-$PLATFORM-unknown-linux-gnu -y
 ENV PATH=/root/.cargo/bin:$PATH
-RUN rustup component add rust-src --toolchain nightly-$PLATFORM-unknown-linux-gnu
+RUN rustup component add rust-src --toolchain stable-$PLATFORM-unknown-linux-gnu
 RUN mkdir -p /tmp/dd
 COPY ./bottlecap/src /tmp/dd/bottlecap/src
 COPY ./bottlecap/Cargo.toml /tmp/dd/bottlecap/Cargo.toml

--- a/scripts/Dockerfile.bottlecap.dev
+++ b/scripts/Dockerfile.bottlecap.dev
@@ -14,9 +14,9 @@ RUN mkdir -p /tmp/dd
 COPY ./bottlecap/src /tmp/dd/bottlecap/src
 COPY ./bottlecap/Cargo.toml /tmp/dd/bottlecap/Cargo.toml
 COPY ./bottlecap/Cargo.lock /tmp/dd/bottlecap/Cargo.lock
-ENV RUSTFLAGS="-C panic=abort -Z location-detail=none"
+ENV RUSTFLAGS="-C panic=abort"
 WORKDIR /tmp/dd/bottlecap
-RUN --mount=type=cache,target=/usr/local/cargo/registry cargo +nightly build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --release --target $PLATFORM-unknown-linux-gnu
+RUN --mount=type=cache,target=/usr/local/cargo/registry cargo +stable build --release --target $PLATFORM-unknown-linux-gnu
 RUN cp /tmp/dd/bottlecap/target/$PLATFORM-unknown-linux-gnu/release/bottlecap /tmp/dd/bottlecap/bottlecap
 
 # zip the extension


### PR DESCRIPTION
We use stable for alpine and the other builds, I think this is a holdover.

As bottlecap leaves beta and approaches stable, we can explore using nightly to remove the crash handler.
