### PR TITLE
aj/allow apm replace tags array

### DIFF
--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -1,5 +1,6 @@
 pub mod flush_strategy;
 pub mod log_level;
+pub mod object_ignore;
 pub mod processing_rule;
 
 use std::path::Path;
@@ -9,6 +10,7 @@ use serde::Deserialize;
 
 use crate::config::flush_strategy::FlushStrategy;
 use crate::config::log_level::LogLevel;
+use crate::config::object_ignore::ObjectIgnore;
 use crate::config::processing_rule::{deserialize_processing_rules, ProcessingRule};
 
 #[derive(Debug, PartialEq, Deserialize, Clone)]
@@ -29,7 +31,7 @@ pub struct Config {
     #[serde(deserialize_with = "deserialize_processing_rules")]
     pub logs_config_processing_rules: Option<Vec<ProcessingRule>>,
     pub apm_enabled: bool,
-    pub apm_replace_tags: Option<String>,
+    pub apm_replace_tags: Option<ObjectIgnore>,
     pub lambda_handler: String,
     pub serverless_flush_strategy: FlushStrategy,
     pub trace_enabled: bool,

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -395,4 +395,26 @@ pub mod tests {
             Ok(())
         });
     }
+
+    #[test]
+    fn test_ignore_apm_replace_tags() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+            jail.set_env(
+                "DD_APM_REPLACE_TAGS",
+                r#"[{"name":"resource.name","pattern":"(.*)/(foo[:%].+)","repl":"$1/{foo}"}]"#,
+            );
+            jail.set_env("DD_EXTENSION_VERSION", "next");
+            let config = get_config(Path::new("")).expect("should parse config");
+            assert_eq!(
+                config,
+                Config {
+                    apm_replace_tags: Some(ObjectIgnore::Ignore),
+                    extension_version: Some("next".to_string()),
+                    ..Config::default()
+                }
+            );
+            Ok(())
+        });
+    }
 }

--- a/bottlecap/src/config/object_ignore.rs
+++ b/bottlecap/src/config/object_ignore.rs
@@ -1,0 +1,15 @@
+use serde::{Deserialize, Deserializer};
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ObjectIgnore {
+    Ignore,
+}
+
+impl<'de> Deserialize<'de> for ObjectIgnore {
+    fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(ObjectIgnore::Ignore)
+    }
+}


### PR DESCRIPTION
APM replace tags can be both a string and a JSON object. But we don't care about its value - that's for the tracers.

This change introduces a new `ObjectIgnore::Ignore` enum to save us the string alloc on the heap and to avoid failing over when customers have more complicated replace rules.
