### PR TITLE
[serverless-init] Use branches or tags when releasing serverless-init

### DIFF
--- a/.github/workflows/release-serverless-init.yml
+++ b/.github/workflows/release-serverless-init.yml
@@ -25,7 +25,7 @@ on:
         description: Datadog agent version
       agentBranch:
         type: string
-        description: Datadog agent branch name (default main)
+        description: Datadog agent branch or tag name (default main)
         default: "main"
 
 env:
@@ -74,33 +74,3 @@ jobs:
       - name: Set up tracer installation script
         run: |
           cp ./scripts/serverless_init_dotnet.sh ./scripts/bin/
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v6
-        with:
-          context: ./scripts
-          file: ./scripts/${{ matrix.arrays.dockerFile }}
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.tag }}${{ matrix.arrays.tagSuffix }}
-          provenance: false
-          platforms: linux/amd64,linux/arm64
-
-      - name: Build and push latest
-        id: docker_build_latest
-        uses: docker/build-push-action@v6
-        if: ${{ github.event.inputs.latestTag == 'yes' }}
-        with:
-          context: ./scripts
-          file: ./scripts/${{ matrix.arrays.dockerFile }}
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest${{ matrix.arrays.tagSuffix }}
-          provenance: false
-          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release-serverless-init.yml
+++ b/.github/workflows/release-serverless-init.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: DataDog/datadog-agent
-          ref: refs/heads/${{ github.event.inputs.agentBranch }}
+          ref: ${{ github.event.inputs.agentBranch }}
           path: datadog-agent
 
       - name: Set up QEMU

--- a/.github/workflows/release-serverless-init.yml
+++ b/.github/workflows/release-serverless-init.yml
@@ -25,7 +25,7 @@ on:
         description: Datadog agent version
       agentBranch:
         type: string
-        description: Datadog agent branch or tag name (default main)
+        description: Datadog agent branch name (default main)
         default: "main"
 
 env:
@@ -74,3 +74,33 @@ jobs:
       - name: Set up tracer installation script
         run: |
           cp ./scripts/serverless_init_dotnet.sh ./scripts/bin/
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./scripts
+          file: ./scripts/${{ matrix.arrays.dockerFile }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.tag }}${{ matrix.arrays.tagSuffix }}
+          provenance: false
+          platforms: linux/amd64,linux/arm64
+
+      - name: Build and push latest
+        id: docker_build_latest
+        uses: docker/build-push-action@v6
+        if: ${{ github.event.inputs.latestTag == 'yes' }}
+        with:
+          context: ./scripts
+          file: ./scripts/${{ matrix.arrays.dockerFile }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest${{ matrix.arrays.tagSuffix }}
+          provenance: false
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release-serverless-init.yml
+++ b/.github/workflows/release-serverless-init.yml
@@ -25,7 +25,7 @@ on:
         description: Datadog agent version
       agentBranch:
         type: string
-        description: Datadog agent branch name (default main)
+        description: Datadog agent branch or tag name (default main)
         default: "main"
 
 env:


### PR DESCRIPTION
We should be tagging each release in the datadog-agent repo. This way, when we do a release we can pin the release to a specific datadog-agent tag instead of going off of main.