### PR TITLE
feat: break if we shouldn't wait for the end

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -465,6 +465,9 @@ async fn extension_loop_active(
                         trace_flusher.manual_flush(),
                         stats_flusher.manual_flush()
                     );
+                    if !flush_control.should_flush_end() {
+                        break;
+                    }
                 }
             }
         }

--- a/bottlecap/src/lifecycle/flush_control.rs
+++ b/bottlecap/src/lifecycle/flush_control.rs
@@ -8,16 +8,10 @@ pub struct FlushControl {
     flush_strategy: FlushStrategy,
 }
 
-// FlushControl is called at the end of every invocation and decides whether or not we should flush
-// The flushing logic is complex and depends on the flush strategy
 // 1. Default Strategy
-//   - Flush at the end of the first 20 invocations
-//   - We keep track of the last 20 invocations and calculate the frequency.
-//     - If the duration from the last invocation to the 20th is less than 2 minutes, switch to
-//     periodic flush every 20s
-//     - else, flush at the end of the invocation
+//   - Flush every 1s and at the end of the invocation
 //  2. Periodic Strategy
-//      - User specifies the interval in milliseconds
+//      - User specifies the interval in milliseconds, will not block on the runtimeDone event
 //  3. End strategy
 //      - Always flush at the end of the invocation
 impl FlushControl {


### PR DESCRIPTION
Technically our `periodic` strategy has always been `periodic` + end flushing.
Because we no longer attempt the smart/adaptive flush strategy and instead default by flushing every 1s + at the end of every invocation, we can now diverge from the main agent and allow the `periodic` strategy to skip flushing at the `end`, and thus not block on the `platform.runtimeDone` event.

This also unblocks people who are using local lambda emulation to set `DD_SERVERLESS_FLUSH_STRATEGY=periodically,1`. This prevents the extension from waiting for an event which will never come from the runtime-interface-emulator.