### PR TITLE
feat: increase to 10k contexts

### DIFF
--- a/bottlecap/src/metrics/constants.rs
+++ b/bottlecap/src/metrics/constants.rs
@@ -1,7 +1,7 @@
 /// The maximum tags that a `Metric` may hold.
 pub const MAX_TAGS: usize = 32;
 
-pub const CONTEXTS: usize = 1024;
+pub const CONTEXTS: usize = 10240;
 
 pub static MAX_CONTEXTS: usize = 65_536; // 2**16, arbitrary
 

--- a/bottlecap/src/traces/trace_agent.rs
+++ b/bottlecap/src/traces/trace_agent.rs
@@ -45,10 +45,6 @@ pub enum ApiVersion {
 impl TraceAgent {
     pub async fn start_trace_agent(&self) -> Result<(), Box<dyn std::error::Error>> {
         let now = Instant::now();
-        debug!(
-            "Time taken to fetch Trace Agent metadata: {} ms",
-            now.elapsed().as_millis()
-        );
 
         // setup a channel to send processed traces to our flusher. tx is passed through each
         // endpoint_handler to the trace processor, which uses it to send de-serialized


### PR DESCRIPTION
I tested this out with 10k contexts along with Python APM tracing enabled and we barely touched 74mb, so I think 10x-ing this is fine and unblocks our customer for now.
<img width="1455" alt="image" src="https://github.com/user-attachments/assets/7c9664f8-01fa-4b1b-92ac-ae733a959e48">

We can replace this with a bump allocator or dynamic flushing as needed, but I think this is the fastest path to resolution
