### PR TITLE
feat: Specify aws_lc_rs as our default crypto provider

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -469,6 +469,7 @@ dependencies = [
  "rmp",
  "rmp-serde",
  "rmpv",
+ "rustls",
  "serde",
  "serde_json",
  "serial_test",

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -41,6 +41,7 @@ base64 = { version = "0.22.0", default-features = false }
 rmp-serde = { version = "1.3.0", default-features = false }
 rmpv = { version = "1.3.0", default-features = false }
 rmp = { version = "0.8.14", default-features = false }
+rustls = { version = "0.23.12", default-features = false, features = ["aws-lc-rs"] }
 
 [dev-dependencies]
 figment = { version = "0.10.15", default-features = false, features = ["yaml", "env", "test"] }

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -159,6 +159,7 @@ fn build_function_arn(account_id: &str, region: &str, function_name: &str) -> St
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     let (aws_config, config) = load_configs();
 
     enable_logging_subsystem(&config);


### PR DESCRIPTION
Required now for as rustls will be upset if both `ring` and `aws-lc-rs` are present.