### PR TITLE
feat: Remove unused deps, drop minor version pins and update

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -441,7 +441,6 @@ dependencies = [
 name = "bottlecap"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "base64 0.22.1",
  "chrono",
@@ -455,8 +454,6 @@ dependencies = [
  "ddsketch-agent 0.1.0 (git+https://github.com/DataDog/saluki/)",
  "dogstatsd",
  "figment",
- "fnv",
- "hashbrown",
  "hex",
  "hmac",
  "httpmock",
@@ -466,21 +463,16 @@ dependencies = [
  "protobuf",
  "regex",
  "reqwest",
- "rmp",
- "rmp-serde",
- "rmpv",
  "rustls",
  "serde",
  "serde_json",
  "serial_test",
  "sha2",
- "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
- "ustr",
 ]
 
 [[package]]

--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -463,6 +463,7 @@ dependencies = [
  "protobuf",
  "regex",
  "reqwest",
+ "rmp-serde",
  "rustls",
  "serde",
  "serde_json",

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -5,9 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-async-trait = { version = "0.1.64", default-features = false }
-anyhow = { version = "1.0", default-features = false }
-chrono = { version = "0.4.38", features = ["serde", "std", "now"], default-features = false }
+async-trait = { version = "0.1", default-features = false }
+chrono = { version = "0.4", features = ["serde", "std", "now"], default-features = false }
 datadog-protos = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/" }
 ddsketch-agent = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/" }
 ddcommon = { version = "12.0.0", git = "https://github.com/DataDog/libdatadog" }
@@ -17,37 +16,30 @@ datadog-trace-mini-agent = { version = "12.0.0", git = "https://github.com/DataD
 datadog-trace-normalization = { version = "12.0.0", git = "https://github.com/DataDog/libdatadog" }
 datadog-trace-obfuscation = { version = "12.0.0", git = "https://github.com/DataDog/libdatadog" }
 dogstatsd = { git = "https://github.com/DataDog/libdatadog", branch = "main" }
-figment = { version = "0.10.15", default-features = false, features = ["yaml", "env"] }
-fnv = { version = "1.0.7", default-features = false }
-hashbrown = { version = "0.14.3", default-features = false, features = ["inline-more"] }
+figment = { version = "0.10", default-features = false, features = ["yaml", "env"] }
 hyper = { version = "0.14", default-features = false, features = ["server"] }
-log = { version = "0.4.21", default-features = false }
-protobuf = { version = "3.5.0", default-features = false }
-regex = { version = "1.10.4", default-features = false }
-reqwest = { version = "0.12.4", features = ["json", "http2", "rustls-tls"], default-features = false }
-serde = { version = "1.0.197", default-features = false, features = ["derive"] }
-serde_json = { version = "1.0.116", default-features = false, features = ["alloc"] }
-thiserror = { version = "1.0.58", default-features = false }
-tokio = { version = "1.37.0", default-features = false, features = ["macros", "rt-multi-thread"] }
-tokio-util = { version = "0.7.11", default-features = false }
-tracing = { version = "0.1.40", default-features = false }
-tracing-core = { version = "0.1.32", default-features = false }
-tracing-subscriber = { version = "0.3.18", default-features = false, features = ["std", "registry", "fmt", "env-filter", "tracing-log"] }
-ustr = { version = "1.0.0", default-features = false }
-hmac = { version = "0.12.1", default-features = false }
-sha2 = { version = "0.10.8", default-features = false }
-hex = { version = "0.4.3", default-features = false, features = ["std"] }
-base64 = { version = "0.22.0", default-features = false }
-rmp-serde = { version = "1.3.0", default-features = false }
-rmpv = { version = "1.3.0", default-features = false }
-rmp = { version = "0.8.14", default-features = false }
+log = { version = "0.4", default-features = false }
+protobuf = { version = "3.5", default-features = false }
+regex = { version = "1.10", default-features = false }
+reqwest = { version = "0.12", features = ["json", "http2", "rustls-tls"], default-features = false }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+tokio = { version = "1.37", default-features = false, features = ["macros", "rt-multi-thread"] }
+tokio-util = { version = "0.7", default-features = false }
+tracing = { version = "0.1", default-features = false }
+tracing-core = { version = "0.1", default-features = false }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["std", "registry", "fmt", "env-filter", "tracing-log"] }
+hmac = { version = "0.12", default-features = false }
+sha2 = { version = "0.10", default-features = false }
+hex = { version = "0.4", default-features = false, features = ["std"] }
+base64 = { version = "0.22", default-features = false }
 rustls = { version = "0.23.12", default-features = false, features = ["aws-lc-rs"] }
 
 [dev-dependencies]
-figment = { version = "0.10.15", default-features = false, features = ["yaml", "env", "test"] }
-proptest = "1.4.0"
-httpmock = "0.7.0"
-serial_test = "3.1.1"
+figment = { version = "0.10", default-features = false, features = ["yaml", "env", "test"] }
+proptest = "1.4"
+httpmock = "0.7"
+serial_test = "3.1"
 
 [[bin]]
 name = "bottlecap"

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -33,6 +33,7 @@ hmac = { version = "0.12", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["std"] }
 base64 = { version = "0.22", default-features = false }
+rmp-serde = { version = "1.3.0", default-features = false }
 rustls = { version = "0.23.12", default-features = false, features = ["aws-lc-rs"] }
 
 [dev-dependencies]


### PR DESCRIPTION
1. We merged dogstatsd upstream to libdatadog, but we left all the dependencies in main. This removes those dependencies
2. By default cargo will use the patch version of whatever we install, and now we're a few fixes behind. I'm switching everything to grab the latest patch release for every minor version and will give a second pass for things we can open up to any major.
3. Updates licenses
