### PR TITLE
Bump go version used for building extension.

### DIFF
--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -15,8 +15,8 @@ RUN arch="$(uname -m)"; \
     if [ "${arch}" = 'x86_64' ]; then \
     arch='amd64'; \
     fi; \
-    wget -O go1.22.5.linux-${arch}.tar.gz https://go.dev/dl/go1.22.5.linux-${arch}.tar.gz; \
-    tar -C /usr/local -xzf go1.22.5.linux-${arch}.tar.gz
+    wget -O go1.23.1.linux-${arch}.tar.gz https://go.dev/dl/go1.23.1.linux-${arch}.tar.gz; \
+    tar -C /usr/local -xzf go1.23.1.linux-${arch}.tar.gz
 
 # cache dependencies
 COPY ./scripts/.cache/go.mod /tmp/dd/datadog-agent

--- a/scripts_v2/Dockerfile.build
+++ b/scripts_v2/Dockerfile.build
@@ -14,8 +14,8 @@ RUN arch="$(uname -m)"; \
     if [ "${arch}" = 'x86_64' ]; then \
     arch='amd64'; \
     fi; \
-    wget -O go1.22.5.linux-${arch}.tar.gz https://go.dev/dl/go1.22.5.linux-${arch}.tar.gz; \
-    tar -C /usr/local -xzf go1.22.5.linux-${arch}.tar.gz
+    wget -O go1.23.1.linux-${arch}.tar.gz https://go.dev/dl/go1.23.1.linux-${arch}.tar.gz; \
+    tar -C /usr/local -xzf go1.23.1.linux-${arch}.tar.gz
 
 RUN mkdir -p /tmp/dd
 


### PR DESCRIPTION
Nightly vulnerability scan began failing over the weekend. This should fix the failures.

https://github.com/DataDog/datadog-lambda-extension/actions/runs/10755426699/job/29893196072