### PR TITLE
feat: Bump unzipped size too

### DIFF
--- a/.gitlab/scripts/check_layer_size.sh
+++ b/.gitlab/scripts/check_layer_size.sh
@@ -15,7 +15,7 @@ if [ -z "$LAYER_FILE" ]; then
 fi
 
 MAX_LAYER_COMPRESSED_SIZE_KB=$(expr 18 \* 1024) # 17 MB, amd64 is 17, while arm64 is 15
-MAX_LAYER_UNCOMPRESSED_SIZE_KB=$(expr 46 \* 1024) # 46 MB, amd is 46, while arm64 is 45
+MAX_LAYER_UNCOMPRESSED_SIZE_KB=$(expr 47 \* 1024) # 46 MB, amd is 46, while arm64 is 45
 
 LAYERS_DIR=".layers"
 


### PR DESCRIPTION
I missed this in the last PR, should have bumped both
<img width="633" alt="image" src="https://github.com/user-attachments/assets/9406e10b-f9cb-4781-8c45-cc5e1b0f491c">

