### PR TITLE
chore: decouple `hyper` from `trace_processor`

### DIFF
--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -96,7 +96,6 @@ impl TraceProcessor for ServerlessTraceProcessor {
 #[cfg(test)]
 mod tests {
     use datadog_trace_obfuscation::obfuscation_config::ObfuscationConfig;
-    use serde_json::json;
     use std::{
         collections::HashMap,
         sync::Arc,


### PR DESCRIPTION
# What?

Decouples `hyper` from the Trace processor.

# Motivation

The trace processor should be abstracted from any http/https client. As it's job is to process traces, not hyper requests.
This pre processing for the request should be done at the agent level.

# Testing

- Updated unit tests
- Tested manually for JS

# Notes

To be upstream to libdatadog