### PR TITLE
feat: add async resolution of runtime

### DIFF
--- a/bottlecap/src/logs/agent.rs
+++ b/bottlecap/src/logs/agent.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use tokio::sync::mpsc::{self, Sender};
 
 use crate::events::Event;
@@ -40,15 +40,19 @@ impl LogsAgent {
         }
     }
 
-    pub async fn spin(&mut self) {
+    pub async fn spin(&mut self, runtime_resolution: Arc<OnceLock<String>>) {
         while let Some(event) = self.rx.recv().await {
-            self.processor.process(event, &self.aggregator).await;
+            self.processor
+                .process(event, runtime_resolution.clone(), &self.aggregator)
+                .await;
         }
     }
 
-    pub async fn sync_consume(&mut self) {
+    pub async fn sync_consume(&mut self, runtime_resolution: Arc<OnceLock<String>>) {
         if let Some(events) = self.rx.recv().await {
-            self.processor.process(events, &self.aggregator).await;
+            self.processor
+                .process(events, runtime_resolution.clone(), &self.aggregator)
+                .await;
         }
     }
 

--- a/bottlecap/src/logs/processor.rs
+++ b/bottlecap/src/logs/processor.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use tokio::sync::mpsc::Sender;
 
 use tracing::debug;
@@ -29,10 +29,10 @@ impl LogsProcessor {
         }
     }
 
-    pub async fn process(&mut self, event: TelemetryEvent, aggregator: &Arc<Mutex<Aggregator>>) {
+    pub async fn process(&mut self, event: TelemetryEvent, runtime_resolution: Arc<OnceLock<String>>, aggregator: &Arc<Mutex<Aggregator>>) {
         match self {
             LogsProcessor::Lambda(lambda_processor) => {
-                lambda_processor.process(event, aggregator).await;
+                lambda_processor.process(event, runtime_resolution, aggregator).await;
             }
         }
     }

--- a/bottlecap/tests/logs_integration_test.rs
+++ b/bottlecap/tests/logs_integration_test.rs
@@ -6,7 +6,7 @@ use bottlecap::telemetry::events::TelemetryEvent;
 use bottlecap::LAMBDA_RUNTIME_SLUG;
 use httpmock::prelude::*;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 mod common;
 
@@ -66,7 +66,7 @@ async fn test_logs() {
             .expect("Failed sending telemetry events");
     }
 
-    logs_agent.sync_consume().await;
+    logs_agent.sync_consume(Arc::new(OnceLock::new())).await;
 
     let _ = logs_flusher.flush().await;
 


### PR DESCRIPTION
I went though multiple implementations and eventually settled for OnceLock:
- using RWLock there are no guarantees that the producer will be done before the consumers are called, risking deadlocks, same for broadcast channels 
- https://doc.rust-lang.org/stable/std/sync/struct.OnceLock.html can be used to initialize the runtime tag value and be passed around behind a ARC. OnceLock won't block on `get` and can be initialize once. If the value is not ready, the tag won't be added for that datapoint. Datadog aggregation should handle and fill that properly
- the runtime resolution logic will contains retry and such, it's the easy part. Not yet added
- tag provider is used as a struct in different ways, adding anything async there will exponentially complicate the logic and force huge refactors. It's probably a wrong mix of data and logic 
- dogstatsd will need changes too, so another PR in libdatadog must be added. This will be a breaking change. To avoid further issue, the OnceLock will have a struct rather than String so more async values can be added later