### PR TITLE
fix: add `ap-southeast-5` region

### DIFF
--- a/.gitlab/datasources/regions.yaml
+++ b/.gitlab/datasources/regions.yaml
@@ -11,6 +11,7 @@ regions:
   - code: "ap-southeast-2"
   - code: "ap-southeast-3"
   - code: "ap-southeast-4"
+  - code: "ap-southeast-5"
   - code: "ap-northeast-1"
   - code: "ap-northeast-2"
   - code: "ap-northeast-3"


### PR DESCRIPTION
# What?

Adds `ap-southeast-5` region to our datasources

# How?

Updated `datasources/regions.yaml`

<img width="782" alt="Screenshot 2024-10-11 at 1 42 20 PM" src="https://github.com/user-attachments/assets/0ada0da5-0179-4a94-83bf-03b9571dda1c">
