### PR TITLE
feat(bottlecap): Add Composite Trace Propagator

### DIFF
--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -1,12 +1,15 @@
 pub mod flush_strategy;
 pub mod log_level;
 pub mod processing_rule;
+pub mod trace_propagation_style;
 
 use std::path::Path;
+use std::vec;
 
 use figment::providers::{Format, Yaml};
 use figment::{providers::Env, Figment};
 use serde::Deserialize;
+use trace_propagation_style::{deserialize_trace_propagation_style, TracePropagationStyle};
 
 use crate::config::flush_strategy::FlushStrategy;
 use crate::config::log_level::{deserialize_log_level, LogLevel};
@@ -62,6 +65,13 @@ pub struct Config {
     pub serverless_flush_strategy: FlushStrategy,
     pub enhanced_metrics: bool,
     pub https_proxy: Option<String>,
+    // Trace Propagation
+    #[serde(deserialize_with = "deserialize_trace_propagation_style")]
+    pub trace_propagation_style: Vec<TracePropagationStyle>,
+    #[serde(deserialize_with = "deserialize_trace_propagation_style")]
+    pub trace_propagation_style_extract: Vec<TracePropagationStyle>,
+    pub trace_propagation_extract_first: bool,
+    pub trace_propagation_http_baggage_enabled: bool,
 }
 
 impl Default for Config {
@@ -85,6 +95,14 @@ impl Default for Config {
             enhanced_metrics: true,
             // Failover
             https_proxy: None,
+            // Trace Propagation
+            trace_propagation_style: vec![
+                TracePropagationStyle::Datadog,
+                TracePropagationStyle::TraceContext,
+            ],
+            trace_propagation_style_extract: vec![],
+            trace_propagation_extract_first: false,
+            trace_propagation_http_baggage_enabled: false,
         }
     }
 }
@@ -180,6 +198,15 @@ pub fn get_config(config_directory: &Path) -> Result<Config, ConfigError> {
         }
     }
 
+    // Trace Propagation
+    //
+    // If not set by the user, set defaults
+    if config.trace_propagation_style_extract.is_empty() {
+        config
+            .trace_propagation_style_extract
+            .clone_from(&config.trace_propagation_style);
+    }
+
     Ok(config)
 }
 
@@ -242,13 +269,7 @@ pub mod tests {
             )?;
             jail.set_env("DD_SITE", "datad0g.com");
             let config = get_config(Path::new("")).expect("should parse config");
-            assert_eq!(
-                config,
-                Config {
-                    site: "datad0g.com".to_string(),
-                    ..Config::default()
-                }
-            );
+            assert_eq!(config.site, "datad0g.com");
             Ok(())
         });
     }
@@ -264,13 +285,7 @@ pub mod tests {
             ",
             )?;
             let config = get_config(Path::new("")).expect("should parse config");
-            assert_eq!(
-                config,
-                Config {
-                    site: "datadoghq.com".to_string(),
-                    ..Config::default()
-                }
-            );
+            assert_eq!(config.site, "datadoghq.com");
             Ok(())
         });
     }
@@ -282,13 +297,7 @@ pub mod tests {
             jail.set_env("DD_SITE", "datadoghq.eu");
             jail.set_env("DD_EXTENSION_VERSION", "next");
             let config = get_config(Path::new("")).expect("should parse config");
-            assert_eq!(
-                config,
-                Config {
-                    site: "datadoghq.eu".to_string(),
-                    ..Config::default()
-                }
-            );
+            assert_eq!(config.site, "datadoghq.eu");
             Ok(())
         });
     }
@@ -300,14 +309,7 @@ pub mod tests {
             jail.set_env("DD_LOG_LEVEL", "TRACE");
             jail.set_env("DD_EXTENSION_VERSION", "next");
             let config = get_config(Path::new("")).expect("should parse config");
-            assert_eq!(
-                config,
-                Config {
-                    log_level: LogLevel::Trace,
-                    site: "datadoghq.com".to_string(),
-                    ..Config::default()
-                }
-            );
+            assert_eq!(config.log_level, LogLevel::Trace);
             Ok(())
         });
     }
@@ -322,6 +324,10 @@ pub mod tests {
                 config,
                 Config {
                     site: "datadoghq.com".to_string(),
+                    trace_propagation_style_extract: vec![
+                        TracePropagationStyle::Datadog,
+                        TracePropagationStyle::TraceContext
+                    ],
                     ..Config::default()
                 }
             );
@@ -336,14 +342,7 @@ pub mod tests {
             jail.set_env("DD_SERVERLESS_FLUSH_STRATEGY", "end");
             jail.set_env("DD_EXTENSION_VERSION", "next");
             let config = get_config(Path::new("")).expect("should parse config");
-            assert_eq!(
-                config,
-                Config {
-                    serverless_flush_strategy: FlushStrategy::End,
-                    site: "datadoghq.com".to_string(),
-                    ..Config::default()
-                }
-            );
+            assert_eq!(config.serverless_flush_strategy, FlushStrategy::End);
             Ok(())
         });
     }
@@ -355,16 +354,9 @@ pub mod tests {
             jail.set_env("DD_SERVERLESS_FLUSH_STRATEGY", "periodically,100000");
             jail.set_env("DD_EXTENSION_VERSION", "next");
             let config = get_config(Path::new("")).expect("should parse config");
-            assert_eq!(
-                config,
-                Config {
-                    serverless_flush_strategy: FlushStrategy::Periodically(PeriodicStrategy {
-                        interval: 100_000
-                    }),
-                    site: "datadoghq.com".to_string(),
-                    ..Config::default()
-                }
-            );
+            assert_eq!(config.serverless_flush_strategy, FlushStrategy::Periodically(PeriodicStrategy {
+                interval: 100_000
+            }));
             Ok(())
         });
     }
@@ -376,13 +368,7 @@ pub mod tests {
             jail.set_env("DD_SERVERLESS_FLUSH_STRATEGY", "invalid_strategy");
             jail.set_env("DD_EXTENSION_VERSION", "next");
             let config = get_config(Path::new("")).expect("should parse config");
-            assert_eq!(
-                config,
-                Config {
-                    site: "datadoghq.com".to_string(),
-                    ..Config::default()
-                }
-            );
+            assert_eq!(config.serverless_flush_strategy, FlushStrategy::Default);
             Ok(())
         });
     }
@@ -397,13 +383,7 @@ pub mod tests {
             );
             jail.set_env("DD_EXTENSION_VERSION", "next");
             let config = get_config(Path::new("")).expect("should parse config");
-            assert_eq!(
-                config,
-                Config {
-                    site: "datadoghq.com".to_string(),
-                    ..Config::default()
-                }
-            );
+            assert_eq!(config.serverless_flush_strategy, FlushStrategy::Default);
             Ok(())
         });
     }
@@ -430,17 +410,13 @@ pub mod tests {
             jail.set_env("DD_EXTENSION_VERSION", "next");
             let config = get_config(Path::new("")).expect("should parse config");
             assert_eq!(
-                config,
-                Config {
-                    logs_config_processing_rules: Some(vec![ProcessingRule {
-                        kind: processing_rule::Kind::ExcludeAtMatch,
-                        name: "exclude".to_string(),
-                        pattern: "exclude".to_string(),
-                        replace_placeholder: None
-                    }]),
-                    site: "datadoghq.com".to_string(),
-                    ..Config::default()
-                }
+                config.logs_config_processing_rules,
+                Some(vec![ProcessingRule {
+                    kind: processing_rule::Kind::ExcludeAtMatch,
+                    name: "exclude".to_string(),
+                    pattern: "exclude".to_string(),
+                    replace_placeholder: None
+                }])
             );
             Ok(())
         });
@@ -464,17 +440,13 @@ pub mod tests {
             )?;
             let config = get_config(Path::new("")).expect("should parse config");
             assert_eq!(
-                config,
-                Config {
-                    logs_config_processing_rules: Some(vec![ProcessingRule {
-                        kind: processing_rule::Kind::ExcludeAtMatch,
-                        name: "exclude".to_string(),
-                        pattern: "exclude".to_string(),
-                        replace_placeholder: None
-                    }]),
-                    site: "datadoghq.com".to_string(),
-                    ..Config::default()
-                }
+                config.logs_config_processing_rules,
+                Some(vec![ProcessingRule {
+                    kind: processing_rule::Kind::ExcludeAtMatch,
+                    name: "exclude".to_string(),
+                    pattern: "exclude".to_string(),
+                    replace_placeholder: None
+                }]),
             );
             Ok(())
         });
@@ -489,14 +461,8 @@ pub mod tests {
                 r#"[{"name":"resource.name","pattern":"(.*)/(foo[:%].+)","repl":"$1/{foo}"}]"#,
             );
             jail.set_env("DD_EXTENSION_VERSION", "next");
-            let config = get_config(Path::new("")).expect("should parse config");
-            assert_eq!(
-                config,
-                Config {
-                    site: "datadoghq.com".to_string(),
-                    ..Config::default()
-                }
-            );
+            let config = get_config(Path::new(""));
+            assert!(config.is_ok());
             Ok(())
         });
     }

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -354,9 +354,10 @@ pub mod tests {
             jail.set_env("DD_SERVERLESS_FLUSH_STRATEGY", "periodically,100000");
             jail.set_env("DD_EXTENSION_VERSION", "next");
             let config = get_config(Path::new("")).expect("should parse config");
-            assert_eq!(config.serverless_flush_strategy, FlushStrategy::Periodically(PeriodicStrategy {
-                interval: 100_000
-            }));
+            assert_eq!(
+                config.serverless_flush_strategy,
+                FlushStrategy::Periodically(PeriodicStrategy { interval: 100_000 })
+            );
             Ok(())
         });
     }

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -454,6 +454,52 @@ pub mod tests {
     }
 
     #[test]
+    fn test_parse_trace_propagation_style() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+            jail.set_env(
+                "DD_TRACE_PROPAGATION_STYLE",
+                "datadog,tracecontext,b3,b3multi",
+            );
+            jail.set_env("DD_EXTENSION_VERSION", "next");
+            let config = get_config(Path::new("")).expect("should parse config");
+
+            let expected_styles = vec![
+                TracePropagationStyle::Datadog,
+                TracePropagationStyle::TraceContext,
+                TracePropagationStyle::B3,
+                TracePropagationStyle::B3Multi,
+            ];
+            assert_eq!(config.trace_propagation_style, expected_styles);
+            assert_eq!(config.trace_propagation_style_extract, expected_styles);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_parse_trace_propagation_style_extract() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+            jail.set_env("DD_TRACE_PROPAGATION_STYLE_EXTRACT", "datadog");
+            jail.set_env("DD_EXTENSION_VERSION", "next");
+            let config = get_config(Path::new("")).expect("should parse config");
+
+            assert_eq!(
+                config.trace_propagation_style,
+                vec![
+                    TracePropagationStyle::Datadog,
+                    TracePropagationStyle::TraceContext,
+                ]
+            );
+            assert_eq!(
+                config.trace_propagation_style_extract,
+                vec![TracePropagationStyle::Datadog]
+            );
+            Ok(())
+        });
+    }
+
+    #[test]
     fn test_ignore_apm_replace_tags() {
         figment::Jail::expect_with(|jail| {
             jail.clear_env();

--- a/bottlecap/src/config/trace_propagation_style.rs
+++ b/bottlecap/src/config/trace_propagation_style.rs
@@ -1,0 +1,58 @@
+use std::{fmt::Display, str::FromStr};
+
+use serde::{Deserialize, Deserializer};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TracePropagationStyle {
+    Datadog,
+    B3Multi,
+    B3,
+    TraceContext,
+    None,
+}
+
+impl FromStr for TracePropagationStyle {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "datadog" => Ok(TracePropagationStyle::Datadog),
+            "b3multi" => Ok(TracePropagationStyle::B3Multi),
+            "b3" => Ok(TracePropagationStyle::B3),
+            "tracecontext" => Ok(TracePropagationStyle::TraceContext),
+            "none" => Ok(TracePropagationStyle::None),
+            _ => Err(format!("Unknown trace propagation style: {s}")),
+        }
+    }
+}
+
+impl Display for TracePropagationStyle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let style = match self {
+            TracePropagationStyle::Datadog => "datadog",
+            TracePropagationStyle::B3Multi => "b3multi",
+            TracePropagationStyle::B3 => "b3",
+            TracePropagationStyle::TraceContext => "tracecontext",
+            TracePropagationStyle::None => "none",
+        };
+        write!(f, "{style}")
+    }
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub fn deserialize_trace_propagation_style<'de, D>(
+    deserializer: D,
+) -> Result<Vec<TracePropagationStyle>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: String = String::deserialize(deserializer)?;
+
+    s.split(',')
+        .map(|style| {
+            TracePropagationStyle::from_str(style.trim()).map_err(|e| {
+                serde::de::Error::custom(format!("Failed to deserialize propagation style: {e}"))
+            })
+        })
+        .collect()
+}

--- a/bottlecap/src/traces/context.rs
+++ b/bottlecap/src/traces/context.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use datadog_trace_protobuf::pb::SpanLink;
+
 #[derive(Copy, Clone, Default, Debug)]
 pub struct Sampling {
     pub priority: Option<i8>,
@@ -14,4 +16,5 @@ pub struct SpanContext {
     pub sampling: Option<Sampling>,
     pub origin: Option<String>,
     pub tags: HashMap<String, String>,
+    pub links: Vec<SpanLink>,
 }

--- a/bottlecap/src/traces/context.rs
+++ b/bottlecap/src/traces/context.rs
@@ -2,13 +2,13 @@ use std::collections::HashMap;
 
 use datadog_trace_protobuf::pb::SpanLink;
 
-#[derive(Copy, Clone, Default, Debug)]
+#[derive(Copy, Clone, Default, Debug, PartialEq)]
 pub struct Sampling {
     pub priority: Option<i8>,
     pub mechanism: Option<u8>,
 }
 
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default, Debug, PartialEq)]
 #[allow(clippy::module_name_repetitions)]
 pub struct SpanContext {
     pub trace_id: u64,

--- a/bottlecap/src/traces/propagation/mod.rs
+++ b/bottlecap/src/traces/propagation/mod.rs
@@ -1,3 +1,202 @@
+use std::{collections::HashMap, sync::Arc};
+
+use crate::{
+    config::{self, trace_propagation_style::TracePropagationStyle},
+    traces::context::SpanContext,
+};
+use carrier::{Extractor, Injector};
+use datadog_trace_protobuf::pb::SpanLink;
+use text_map_propagator::{
+    BAGGAGE_PREFIX, DATADOG_HIGHER_ORDER_TRACE_ID_BITS_KEY, DATADOG_LAST_PARENT_ID_KEY,
+    TRACESTATE_KEY,
+};
+
 pub mod carrier;
 pub mod error;
 pub mod text_map_propagator;
+
+pub trait Propagator {
+    fn extract(&self, carrier: &dyn Extractor) -> Option<SpanContext>;
+    fn inject(&self, context: SpanContext, carrier: &mut dyn Injector);
+}
+
+pub struct DatadogCompositePropagator {
+    propagators: Vec<Box<dyn Propagator + 'static>>,
+    config: Arc<config::Config>,
+}
+
+#[allow(clippy::never_loop)]
+impl Propagator for DatadogCompositePropagator {
+    fn extract(&self, carrier: &dyn Extractor) -> Option<SpanContext> {
+        if self.config.trace_propagation_extract_first {
+            for propagator in &self.propagators {
+                let context = propagator.extract(carrier);
+
+                if self.config.trace_propagation_http_baggage_enabled {
+                    if let Some(mut context) = context {
+                        Self::attach_baggage(&mut context, carrier);
+                        return Some(context);
+                    }
+                }
+
+                return context;
+            }
+        }
+
+        let (contexts, styles) = self.extract_available_contexts(carrier);
+        if contexts.is_empty() {
+            return None;
+        }
+
+        let mut context = Self::resolve_contexts(contexts, styles, carrier);
+        if self.config.trace_propagation_http_baggage_enabled {
+            Self::attach_baggage(&mut context, carrier);
+        }
+
+        Some(context)
+    }
+
+    fn inject(&self, _context: SpanContext, _carrier: &mut dyn Injector) {
+        todo!()
+    }
+}
+
+impl DatadogCompositePropagator {
+    #[must_use]
+    pub fn new(config: Arc<config::Config>) -> Self {
+        let propagators: Vec<Box<dyn Propagator + 'static>> = config
+            .trace_propagation_style_extract
+            .iter()
+            .filter_map(|style| match style {
+                TracePropagationStyle::Datadog => {
+                    Some(Box::new(text_map_propagator::DatadogHeaderPropagator)
+                        as Box<dyn Propagator>)
+                }
+                TracePropagationStyle::TraceContext => {
+                    Some(Box::new(text_map_propagator::TraceContextPropagator)
+                        as Box<dyn Propagator>)
+                }
+                _ => None,
+            })
+            .collect();
+
+        Self {
+            propagators,
+            config,
+        }
+    }
+
+    fn extract_available_contexts(
+        &self,
+        carrier: &dyn Extractor,
+    ) -> (Vec<SpanContext>, Vec<TracePropagationStyle>) {
+        let mut contexts = Vec::<SpanContext>::new();
+        let mut styles = Vec::<TracePropagationStyle>::new();
+
+        for (i, propagator) in self.propagators.iter().enumerate() {
+            if let Some(context) = propagator.extract(carrier) {
+                contexts.push(context);
+                styles.push(self.config.trace_propagation_style_extract[i]);
+            }
+        }
+
+        (contexts, styles)
+    }
+
+    fn resolve_contexts(
+        contexts: Vec<SpanContext>,
+        styles: Vec<TracePropagationStyle>,
+        _carrier: &dyn Extractor,
+    ) -> SpanContext {
+        let mut primary_context = contexts[0].clone();
+        let mut links = Vec::<SpanLink>::new();
+
+        let mut i = 1;
+        for context in contexts.iter().skip(1) {
+            let style = styles[i];
+
+            if context.span_id != 0
+                && context.trace_id != 0
+                && context.trace_id != primary_context.trace_id
+            {
+                let sampling = context.sampling.unwrap_or_default().priority.unwrap_or(0);
+                let tracestate: Option<String> = match style {
+                    TracePropagationStyle::TraceContext => {
+                        context.tags.get(TRACESTATE_KEY).cloned()
+                    }
+                    _ => None,
+                };
+                let attributes = HashMap::from([
+                    ("reason".to_string(), "terminated_context".to_string()),
+                    ("context_headers".to_string(), style.to_string()),
+                ]);
+                let trace_id_high_str = context
+                    .tags
+                    .get(DATADOG_HIGHER_ORDER_TRACE_ID_BITS_KEY)
+                    .cloned()
+                    .unwrap_or_default();
+                let trace_ig_high = u64::from_str_radix(&trace_id_high_str, 16).unwrap_or_default();
+
+                links.push(SpanLink {
+                    trace_id: context.trace_id,
+                    trace_id_high: trace_ig_high,
+                    span_id: context.span_id,
+                    flags: u32::from(sampling > 0),
+                    tracestate: tracestate.unwrap_or_default(),
+                    attributes,
+                });
+            } else if style == TracePropagationStyle::TraceContext {
+                if let Some(tracestate) = context.tags.get(TRACESTATE_KEY) {
+                    primary_context
+                        .tags
+                        .insert(TRACESTATE_KEY.to_string(), tracestate.clone());
+                }
+
+                if primary_context.trace_id == context.trace_id
+                    && primary_context.span_id == context.span_id
+                {
+                    let mut dd_context: Option<SpanContext> = None;
+                    if styles.contains(&TracePropagationStyle::Datadog) {
+                        let position = styles
+                            .iter()
+                            .position(|&s| s == TracePropagationStyle::Datadog)
+                            .unwrap_or_default();
+                        dd_context = contexts.get(position).cloned();
+                    }
+
+                    if let Some(parent_id) = context.tags.get(DATADOG_LAST_PARENT_ID_KEY) {
+                        primary_context
+                            .tags
+                            .insert(DATADOG_LAST_PARENT_ID_KEY.to_string(), parent_id.clone());
+                    } else if let Some(sc) = dd_context {
+                        primary_context.tags.insert(
+                            DATADOG_LAST_PARENT_ID_KEY.to_string(),
+                            format!("{:016x}", sc.span_id),
+                        );
+                    }
+
+                    primary_context.span_id = context.span_id;
+                }
+            }
+
+            i += 1;
+        }
+
+        primary_context.links = links;
+
+        primary_context
+    }
+
+    fn attach_baggage(context: &mut SpanContext, carrier: &dyn Extractor) {
+        let keys = carrier.keys();
+
+        for key in keys {
+            if let Some(stripped) = key.strip_prefix(BAGGAGE_PREFIX) {
+                context.tags.insert(
+                    stripped.to_string(),
+                    carrier.get(key).unwrap_or_default().to_string(),
+                );
+            }
+        }
+    }
+}

--- a/bottlecap/src/traces/propagation/mod.rs
+++ b/bottlecap/src/traces/propagation/mod.rs
@@ -153,7 +153,7 @@ impl DatadogCompositePropagator {
                 }
 
                 if primary_context.trace_id == context.trace_id
-                    && primary_context.span_id == context.span_id
+                    && primary_context.span_id != context.span_id
                 {
                     let mut dd_context: Option<SpanContext> = None;
                     if styles.contains(&TracePropagationStyle::Datadog) {
@@ -198,5 +198,676 @@ impl DatadogCompositePropagator {
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use std::vec;
+
+    use lazy_static::lazy_static;
+
+    use crate::traces::context::Sampling;
+
+    use super::*;
+
+    lazy_static! {
+        static ref TRACE_ID: u128 = 171395628812617415352188477958425669623;
+        static ref TRACE_ID_LOWER_ORDER_BITS: u64 = *TRACE_ID as u64;
+        static ref TRACE_ID_HEX: String = String::from("80f198ee56343ba864fe8b2a57d3eff7");
+
+        // TraceContext Headers
+        static ref VALID_TRACECONTEXT_HEADERS_BASIC: HashMap<String, String> = HashMap::from([
+            (
+                "traceparent".to_string(),
+                format!("00-{}-00f067aa0ba902b7-01", *TRACE_ID_HEX)
+            ),
+            (
+                "tracestate".to_string(),
+                "dd=p:00f067aa0ba902b7;s:2;o:rum".to_string()
+            ),
+        ]);
+        static ref VALID_TRACECONTEXT_HEADERS_RUM_NO_SAMPLING_DECISION: HashMap<String, String> =
+            HashMap::from([
+                (
+                    "traceparent".to_string(),
+                    format!("00-{}-00f067aa0ba902b7-00", *TRACE_ID_HEX)
+                ),
+                (
+                    "tracestate".to_string(),
+                    "dd=o:rum".to_string()
+                ),
+            ]);
+        static ref VALID_TRACECONTEXT_HEADERS: HashMap<String, String> = HashMap::from([
+            (
+                "traceparent".to_string(),
+                format!("00-{}-00f067aa0ba902b7-01", *TRACE_ID_HEX)
+            ),
+            (
+                "tracestate".to_string(),
+                "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMz".to_string()
+            ),
+        ]);
+        static ref VALID_TRACECONTEXT_HEADERS_VALID_64_BIT_TRACE_ID: HashMap<String, String> =
+            HashMap::from([
+                (
+                    "traceparent".to_string(),
+                    "00-000000000000000064fe8b2a57d3eff7-00f067aa0ba902b7-01".to_string()
+                ),
+                (
+                    "tracestate".to_string(),
+                    "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMzE".to_string()
+                ),
+            ]);
+
+        // Datadog Headers
+        static ref VALID_DATADOG_HEADERS: HashMap<String, String> = HashMap::from([
+            (
+                "x-datadog-trace-id".to_string(),
+                "13088165645273925489".to_string(),
+            ),
+            ("x-datadog-parent-id".to_string(), "5678".to_string(),),
+            ("x-datadog-sampling-priority".to_string(), "1".to_string()),
+            ("x-datadog-origin".to_string(), "synthetics".to_string()),
+        ]);
+        static ref VALID_DATADOG_HEADERS_NO_PRIORITY: HashMap<String, String> = HashMap::from([
+            (
+                "x-datadog-trace-id".to_string(),
+                "13088165645273925489".to_string(),
+            ),
+            ("x-datadog-parent-id".to_string(), "5678".to_string(),),
+            ("x-datadog-origin".to_string(), "synthetics".to_string()),
+        ]);
+        static ref VALID_DATADOG_HEADERS_MATCHING_TRACE_CONTEXT_VALID_TRACE_ID: HashMap<String, String> =
+            HashMap::from([
+                (
+                    "x-datadog-trace-id".to_string(),
+                    TRACE_ID_LOWER_ORDER_BITS.to_string()
+                ),
+                ("x-datadog-parent-id".to_string(), "5678".to_string()),
+                ("x-datadog-origin".to_string(), "synthetics".to_string()),
+                ("x-datadog-sampling-priority".to_string(), "1".to_string()),
+            ]);
+        static ref INVALID_DATADOG_HEADERS: HashMap<String, String> = HashMap::from([
+            (
+                "x-datadog-trace-id".to_string(),
+                "13088165645273925489".to_string(),
+            ),
+            ("x-datadog-parent-id".to_string(), "parent_id".to_string(),),
+            ("x-datadog-sampling-priority".to_string(), "sample".to_string()),
+        ]);
+
+        // Fixtures
+        //
+        static ref ALL_VALID_HEADERS: HashMap<String, String> = {
+            let mut h = HashMap::new();
+            h.extend(VALID_DATADOG_HEADERS.clone());
+            h.extend(VALID_TRACECONTEXT_HEADERS.clone());
+            // todo: add b3
+            h
+        };
+        static ref DATADOG_TRACECONTEXT_MATCHING_TRACE_ID_HEADERS: HashMap<String, String> = {
+            let mut h = HashMap::new();
+            h.extend(VALID_DATADOG_HEADERS_MATCHING_TRACE_CONTEXT_VALID_TRACE_ID.clone());
+            // We use 64-bit traceparent trace id value here so it can match for
+            // both 128-bit enabled and disabled
+            h.extend(VALID_TRACECONTEXT_HEADERS_VALID_64_BIT_TRACE_ID.clone());
+            h
+        };
+        // Edge cases
+        static ref ALL_HEADERS_CHAOTIC_1: HashMap<String, String> = {
+            let mut h = HashMap::new();
+            h.extend(VALID_DATADOG_HEADERS_MATCHING_TRACE_CONTEXT_VALID_TRACE_ID.clone());
+            h.extend(VALID_TRACECONTEXT_HEADERS_VALID_64_BIT_TRACE_ID.clone());
+            // todo: add b3
+            h
+        };
+        static ref ALL_HEADERS_CHAOTIC_2: HashMap<String, String> = {
+            let mut h = HashMap::new();
+            h.extend(VALID_DATADOG_HEADERS.clone());
+            h.extend(VALID_TRACECONTEXT_HEADERS_VALID_64_BIT_TRACE_ID.clone());
+            // todo: add b3
+            h
+        };
+        static ref NO_TRACESTATE_SUPPORT_NOT_MATCHING_TRACE_ID: HashMap<String, String> = {
+            let mut h = HashMap::new();
+            h.extend(VALID_DATADOG_HEADERS.clone());
+            h.extend(VALID_TRACECONTEXT_HEADERS_RUM_NO_SAMPLING_DECISION.clone());
+            h
+        };
+    }
+
+    macro_rules! test_propagation_extract {
+        ($($name:ident: $value:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let (styles, carrier, expected) = $value;
+                    let mut config = config::Config::default();
+                    config.trace_propagation_style_extract = vec![TracePropagationStyle::Datadog, TracePropagationStyle::TraceContext];
+                    if let Some(s) = styles {
+                        config.trace_propagation_style_extract.clone_from(&s);
+                    }
+
+                    let propagator = DatadogCompositePropagator::new(Arc::new(config));
+
+                    let context = propagator.extract(&carrier).unwrap_or_default();
+
+                    assert_eq!(context, expected);
+                }
+            )*
+        }
+    }
+
+    test_propagation_extract! {
+        // Datadog Headers
+        valid_datadog_default: (
+            None,
+            VALID_DATADOG_HEADERS.clone(),
+            SpanContext {
+                trace_id: 13088165645273925489,
+                span_id: 5678,
+                sampling: Some(Sampling {
+                    priority: Some(1),
+                    mechanism: None,
+                }),
+                origin: Some("synthetics".to_string()),
+                tags: HashMap::from([
+                    ("_dd.p.dm".to_string(), "-3".to_string())
+                ]),
+                links: vec![],
+            }
+        ),
+        valid_datadog_no_priority: (
+            None,
+            VALID_DATADOG_HEADERS_NO_PRIORITY.clone(),
+            SpanContext {
+                trace_id: 13088165645273925489,
+                span_id: 5678,
+                sampling: Some(Sampling {
+                    priority: Some(2),
+                    mechanism: None,
+                }),
+                origin: Some("synthetics".to_string()),
+                tags: HashMap::from([
+                    ("_dd.p.dm".to_string(), "-3".to_string())
+                ]),
+                links: vec![],
+            },
+        ),
+        invalid_datadog: (
+            Some(vec![TracePropagationStyle::Datadog]),
+            INVALID_DATADOG_HEADERS.clone(),
+            SpanContext::default(),
+        ),
+        valid_datadog_explicit_style: (
+            Some(vec![TracePropagationStyle::Datadog]),
+            VALID_DATADOG_HEADERS.clone(),
+            SpanContext {
+                trace_id: 13088165645273925489,
+                span_id: 5678,
+                sampling: Some(Sampling {
+                    priority: Some(1),
+                    mechanism: None,
+                }),
+                origin: Some("synthetics".to_string()),
+                tags: HashMap::from([
+                    ("_dd.p.dm".to_string(), "-3".to_string())
+                ]),
+                links: vec![],
+            },
+        ),
+        invalid_datadog_negative_trace_id: (
+            Some(vec![TracePropagationStyle::Datadog]),
+            HashMap::from([
+                (
+                    "x-datadog-trace-id".to_string(),
+                    "-1".to_string(),
+                ),
+                ("x-datadog-parent-id".to_string(), "5678".to_string(),),
+                ("x-datadog-sampling-priority".to_string(), "1".to_string()),
+                ("x-datadog-origin".to_string(), "synthetics".to_string()),
+            ]),
+            SpanContext::default(),
+        ),
+        valid_datadog_no_datadog_style: (
+            Some(vec![TracePropagationStyle::TraceContext]),
+            VALID_DATADOG_HEADERS.clone(),
+            SpanContext::default(),
+        ),
+        // TraceContext Headers
+        valid_tracecontext_simple: (
+            Some(vec![TracePropagationStyle::TraceContext]),
+            VALID_TRACECONTEXT_HEADERS_BASIC.clone(),
+            SpanContext {
+                trace_id: 7277407061855694839,
+                span_id: 67667974448284343,
+                sampling: Some(Sampling {
+                    priority: Some(2),
+                    mechanism: None,
+                }),
+                origin: Some("rum".to_string()),
+                tags: HashMap::from([
+                    ("tracestate".to_string(), "dd=p:00f067aa0ba902b7;s:2;o:rum".to_string()),
+                    ("_dd.p.tid".to_string(), "9291375655657946024".to_string()),
+                    ("traceparent".to_string(), "00-80f198ee56343ba864fe8b2a57d3eff7-00f067aa0ba902b7-01".to_string()),
+                    ("_dd.parent_id".to_string(), "00f067aa0ba902b7".to_string()),
+                ]),
+                links: vec![],
+            }
+        ),
+        valid_tracecontext_rum_no_sampling_decision: (
+            Some(vec![TracePropagationStyle::TraceContext]),
+            VALID_TRACECONTEXT_HEADERS_RUM_NO_SAMPLING_DECISION.clone(),
+            SpanContext {
+                trace_id: 7277407061855694839,
+                span_id: 67667974448284343,
+                sampling: Some(Sampling {
+                    priority: Some(0),
+                    mechanism: None,
+                }),
+                origin: Some("rum".to_string()),
+                tags: HashMap::from([
+                    ("_dd.p.tid".to_string(), "9291375655657946024".to_string()),
+                    ("tracestate".to_string(), "dd=o:rum".to_string()),
+                    ("traceparent".to_string(), "00-80f198ee56343ba864fe8b2a57d3eff7-00f067aa0ba902b7-00".to_string()),
+                ]),
+                links: vec![],
+            }
+        ),
+        // B3 Headers
+        // todo: all of them
+        // B3 single Headers
+        // todo: all of them
+        // All Headers
+        valid_all_headers: (
+            None,
+            ALL_VALID_HEADERS.clone(),
+            SpanContext {
+                trace_id: 13088165645273925489,
+                span_id: 5678,
+                sampling: Some(Sampling {
+                    priority: Some(1),
+                    mechanism: None,
+                }),
+                origin: Some("synthetics".to_string()),
+                tags: HashMap::from([
+                    ("_dd.p.dm".to_string(), "-3".to_string())
+                ]),
+                links: vec![
+                    SpanLink {
+                        trace_id: 7277407061855694839,
+                        trace_id_high: 0,
+                        span_id: 67667974448284343,
+                        flags: 1,
+                        tracestate: "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMz".to_string(),
+                        attributes: HashMap::from([
+                            ("reason".to_string(), "terminated_context".to_string()),
+                            ("context_headers".to_string(), "tracecontext".to_string()),
+                        ]),
+                    }
+                ],
+            },
+        ),
+        valid_all_headers_all_styles: (
+            Some(vec![TracePropagationStyle::Datadog, TracePropagationStyle::TraceContext]),
+            ALL_VALID_HEADERS.clone(),
+            SpanContext {
+                trace_id: 13088165645273925489,
+                span_id: 5678,
+                sampling: Some(Sampling {
+                    priority: Some(1),
+                    mechanism: None,
+                }),
+                origin: Some("synthetics".to_string()),
+                tags: HashMap::from([
+                    ("_dd.p.dm".to_string(), "-3".to_string())
+                ]),
+                links: vec![
+                    SpanLink {
+                        trace_id: 7277407061855694839,
+                        trace_id_high: 0,
+                        span_id: 67667974448284343,
+                        flags: 1,
+                        tracestate: "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMz".to_string(),
+                        attributes: HashMap::from([
+                            ("reason".to_string(), "terminated_context".to_string()),
+                            ("context_headers".to_string(), "tracecontext".to_string()),
+                        ]),
+                    }
+                    // todo: b3 span links
+                ],
+            },
+        ),
+        valid_all_headers_datadog_style: (
+            Some(vec![TracePropagationStyle::Datadog]),
+            ALL_VALID_HEADERS.clone(),
+            SpanContext {
+                trace_id: 13088165645273925489,
+                span_id: 5678,
+                sampling: Some(Sampling {
+                    priority: Some(1),
+                    mechanism: None,
+                }),
+                origin: Some("synthetics".to_string()),
+                tags: HashMap::from([
+                    ("_dd.p.dm".to_string(), "-3".to_string())
+                ]),
+                links: vec![]
+            },
+        ),
+        // todo: valid_all_headers_b3_style
+        // todo: valid_all_headers_both_b3_styles
+        // todo: valid_all_headers_b3_single_style
+        none_style: (
+            Some(vec![TracePropagationStyle::None]),
+            ALL_VALID_HEADERS.clone(),
+            SpanContext::default(),
+        ),
+        valid_style_and_none_still_extracts: (
+            Some(vec![TracePropagationStyle::Datadog, TracePropagationStyle::None]),
+            ALL_VALID_HEADERS.clone(),
+            SpanContext {
+                trace_id: 13088165645273925489,
+                span_id: 5678,
+                sampling: Some(Sampling {
+                    priority: Some(1),
+                    mechanism: None,
+                }),
+                origin: Some("synthetics".to_string()),
+                tags: HashMap::from([
+                    ("_dd.p.dm".to_string(), "-3".to_string())
+                ]),
+                links: vec![],
+            }
+        ),
+        // Order matters
+        // todo: order_matters_b3_single_header_first
+        // todo: order_matters_b3_first
+        // todo: order_matters_b3_second_no_datadog_headers
+        // Tracestate is still added when TraceContext style comes later and matches
+        // first style's `trace_id`
+        additional_tracestate_support_when_present_and_matches_first_style_trace_id: (
+            Some(vec![TracePropagationStyle::Datadog, TracePropagationStyle::TraceContext]),
+            DATADOG_TRACECONTEXT_MATCHING_TRACE_ID_HEADERS.clone(),
+            SpanContext {
+                trace_id: 7277407061855694839,
+                span_id: 67667974448284343,
+                sampling: Some(Sampling {
+                    priority: Some(1),
+                    mechanism: None,
+                }),
+                origin: Some("synthetics".to_string()),
+                tags: HashMap::from([
+                    ("_dd.p.dm".to_string(), "-3".to_string()),
+                    ("_dd.parent_id".to_string(), "000000000000162e".to_string()),
+                    (TRACESTATE_KEY.to_string(), "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMzE".to_string())
+                ]),
+                links: vec![],
+            }
+        ),
+        // Tracestate is not added when TraceContext style comes later and does not
+        // match first style's `trace_id`
+        no_additional_tracestate_support_when_present_and_trace_id_does_not_match: (
+            Some(vec![TracePropagationStyle::Datadog, TracePropagationStyle::TraceContext]),
+            NO_TRACESTATE_SUPPORT_NOT_MATCHING_TRACE_ID.clone(),
+            SpanContext {
+                trace_id: 13088165645273925489,
+                span_id: 5678,
+                sampling: Some(Sampling {
+                    priority: Some(1),
+                    mechanism: None,
+                }),
+                origin: Some("synthetics".to_string()),
+                tags: HashMap::from([
+                    ("_dd.p.dm".to_string(), "-3".to_string())
+                ]),
+                links: vec![
+                    SpanLink {
+                        trace_id: 7277407061855694839,
+                        trace_id_high: 0,
+                        span_id: 67667974448284343,
+                        flags: 0,
+                        tracestate: "dd=o:rum".to_string(),
+                        attributes: HashMap::from([
+                            ("reason".to_string(), "terminated_context".to_string()),
+                            ("context_headers".to_string(), "tracecontext".to_string()),
+                        ]),
+                    }
+                ],
+            }
+        ),
+        valid_all_headers_no_style: (
+            Some(vec![]),
+            ALL_VALID_HEADERS.clone(),
+            SpanContext::default(),
+        ),
+        datadog_tracecontext_conflicting_span_ids: (
+            Some(vec![TracePropagationStyle::Datadog, TracePropagationStyle::TraceContext]),
+            HashMap::from([
+                (
+                    "x-datadog-trace-id".to_string(),
+                    "9291375655657946024".to_string(),
+                ),
+                ("x-datadog-parent-id".to_string(), "15".to_string(),),
+                ("traceparent".to_string(), "00-000000000000000080f198ee56343ba8-000000000000000a-01".to_string()),
+            ]),
+            SpanContext {
+                trace_id: 9291375655657946024,
+                span_id: 10,
+                sampling: Some(Sampling {
+                    priority: Some(2),
+                    mechanism: None,
+                }),
+                origin: None,
+                tags: HashMap::from([
+                    ("_dd.parent_id".to_string(), "000000000000000f".to_string()),
+                    ("_dd.p.dm".to_string(), "-3".to_string()),
+                ]),
+                links: vec![],
+            }
+        ),
+        // todo: all_headers_all_styles_tracecontext_t_id_match_no_span_link
+        all_headers_all_styles_do_not_create_span_link_for_context_w_out_span_id: (
+            Some(vec![TracePropagationStyle::TraceContext, TracePropagationStyle::Datadog]),
+            ALL_HEADERS_CHAOTIC_2.clone(),
+            SpanContext {
+                trace_id: 7277407061855694839,
+                span_id: 67667974448284343,
+                sampling: Some(Sampling {
+                    priority: Some(2),
+                    mechanism: None,
+                }),
+                origin: Some("rum".to_string()),
+                tags: HashMap::from([
+                    ("_dd.p.dm".to_string(), "-4".to_string()),
+                    ("_dd.p.tid".to_string(), "0".to_string()),
+                    ("_dd.p.usr.id".to_string(), "baz64".to_string()),
+                    ("traceparent".to_string(), "00-000000000000000064fe8b2a57d3eff7-00f067aa0ba902b7-01".to_string()),
+                    ("tracestate".to_string(), "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMzE".to_string()),
+                ]),
+                links: vec![
+                    SpanLink {
+                        trace_id: 13088165645273925489,
+                        trace_id_high: 0,
+                        span_id: 5678,
+                        flags: 1,
+                        tracestate: "".to_string(),
+                        attributes: HashMap::from([
+                            ("reason".to_string(), "terminated_context".to_string()),
+                            ("context_headers".to_string(), "datadog".to_string()),
+                        ]),
+                    }
+                ],
+            }
+        ),
+        all_headers_all_styles_tracecontext_primary_only_datadog_t_id_diff: (
+            Some(vec![TracePropagationStyle::TraceContext, TracePropagationStyle::Datadog]),
+            ALL_VALID_HEADERS.clone(),
+            SpanContext {
+                trace_id: 7277407061855694839,
+                span_id: 67667974448284343,
+                sampling: Some(Sampling {
+                    priority: Some(2),
+                    mechanism: None,
+                }),
+                origin: Some("rum".to_string()),
+                tags: HashMap::from([
+                    ("_dd.p.dm".to_string(), "-4".to_string()),
+                    ("_dd.p.tid".to_string(), "9291375655657946024".to_string()),
+                    ("_dd.p.usr.id".to_string(), "baz64".to_string()),
+                    ("traceparent".to_string(), "00-80f198ee56343ba864fe8b2a57d3eff7-00f067aa0ba902b7-01".to_string()),
+                    ("tracestate".to_string(), "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMz".to_string()),
+                ]),
+                links: vec![
+                    SpanLink {
+                        trace_id: 13088165645273925489,
+                        trace_id_high: 0,
+                        span_id: 5678,
+                        flags: 1,
+                        tracestate: "".to_string(),
+                        attributes: HashMap::from([
+                            ("reason".to_string(), "terminated_context".to_string()),
+                            ("context_headers".to_string(), "datadog".to_string()),
+                        ]),
+                    }
+                ],
+            }
+        ),
+        // todo: fix this test
+        all_headers_all_styles_datadog_primary_only_datadog_t_id_diff: (
+            Some(vec![TracePropagationStyle::Datadog, TracePropagationStyle::TraceContext]),
+            ALL_VALID_HEADERS.clone(),
+            SpanContext {
+                trace_id: 13088165645273925489,
+                span_id: 5678,
+                sampling: Some(Sampling {
+                    priority: Some(1),
+                    mechanism: None,
+                }),
+                origin: Some("synthetics".to_string()),
+                tags: HashMap::from([
+                    ("_dd.p.dm".to_string(), "-3".to_string())
+                ]),
+                links: vec![
+                    SpanLink {
+                        trace_id: 7277407061855694839,
+                        // this should be `9291375655657946024` not `0`, but we don't have this data
+                        // with the current definition of `SpanContext`
+                        trace_id_high: 0,
+                        span_id: 67667974448284343,
+                        flags: 1,
+                        tracestate: "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMz".to_string(),
+                        attributes: HashMap::from([
+                            ("reason".to_string(), "terminated_context".to_string()),
+                            ("context_headers".to_string(), "tracecontext".to_string()),
+                        ]),
+                    }
+                ],
+            }
+        ),
+        // todo: datadog_primary_match_tracecontext_dif_from_b3_b3multi_invalid
+    }
+
+    #[test]
+    fn test_new_filter_propagators() {
+        let mut config = config::Config::default();
+        config.trace_propagation_style_extract = vec![
+            TracePropagationStyle::Datadog,
+            TracePropagationStyle::TraceContext,
+            TracePropagationStyle::B3,
+            TracePropagationStyle::B3Multi,
+        ];
+
+        let propagator = DatadogCompositePropagator::new(Arc::new(config));
+
+        assert_eq!(propagator.propagators.len(), 2);
+    }
+
+    #[test]
+    fn test_new_no_propagators() {
+        let mut config = config::Config::default();
+        config.trace_propagation_style_extract = vec![TracePropagationStyle::None];
+        let propagator = DatadogCompositePropagator::new(Arc::new(config));
+
+        assert_eq!(propagator.propagators.len(), 0);
+    }
+
+    #[test]
+    fn test_extract_available_contexts() {
+        let mut config = config::Config::default();
+        config.trace_propagation_style_extract = vec![
+            TracePropagationStyle::Datadog,
+            TracePropagationStyle::TraceContext,
+        ];
+
+        let propagator = DatadogCompositePropagator::new(Arc::new(config));
+
+        let carrier = HashMap::from([
+            (
+                "traceparent".to_string(),
+                "00-80f198ee56343ba864fe8b2a57d3eff7-00f067aa0ba902b7-01".to_string(),
+            ),
+            (
+                "tracestate".to_string(),
+                "dd=p:00f067aa0ba902b7;s:2;o:rum".to_string(),
+            ),
+            (
+                "x-datadog-trace-id".to_string(),
+                "7277407061855694839".to_string(),
+            ),
+            (
+                "x-datadog-parent-id".to_string(),
+                "67667974448284343".to_string(),
+            ),
+            ("x-datadog-sampling-priority".to_string(), "2".to_string()),
+            ("x-datadog-origin".to_string(), "rum".to_string()),
+            (
+                "x-datadog-tags".to_string(),
+                "_dd.p.test=value,_dd.p.tid=9291375655657946024,any=tag".to_string(),
+            ),
+        ]);
+        let (contexts, styles) = propagator.extract_available_contexts(&carrier);
+
+        assert_eq!(contexts.len(), 2);
+        assert_eq!(styles.len(), 2);
+    }
+
+    #[test]
+    fn test_extract_available_contexts_no_contexts() {
+        let mut config = config::Config::default();
+        config.trace_propagation_style_extract = vec![TracePropagationStyle::Datadog];
+
+        let propagator = DatadogCompositePropagator::new(Arc::new(config));
+
+        let carrier = HashMap::from([
+            (
+                "traceparent".to_string(),
+                "00-80f198ee56343ba864fe8b2a57d3eff7-00f067aa0ba902b7-01".to_string(),
+            ),
+            (
+                "tracestate".to_string(),
+                "dd=p:00f067aa0ba902b7;s:2;o:rum".to_string(),
+            ),
+        ]);
+        let (contexts, styles) = propagator.extract_available_contexts(&carrier);
+
+        assert_eq!(contexts.len(), 0);
+        assert_eq!(styles.len(), 0);
+    }
+
+    #[test]
+    fn test_attach_baggage() {
+        let mut context = SpanContext::default();
+        let carrier = HashMap::from([
+            ("x-datadog-trace-id".to_string(), "123".to_string()),
+            ("x-datadog-parent-id".to_string(), "5678".to_string()),
+            ("ot-baggage-key1".to_string(), "value1".to_string()),
+        ]);
+
+        DatadogCompositePropagator::attach_baggage(&mut context, &carrier);
+
+        assert_eq!(context.tags.len(), 1);
+        assert_eq!(context.tags.get("key1").unwrap(), "value1");
     }
 }


### PR DESCRIPTION
# What?

Creates a composite propagator to extract trace context.

This is because we have specific logic on how we handle/resolve trace context in the tracers.

# How?

- New struct `DatadogCompositePropagator` using `DatadogHeaderPropagator` and `TraceContextPropagator`.
- Added configuration options so the propagator can decide how to act.

# Motivation

[SVLS-5769](https://datadoghq.atlassian.net/browse/SVLS-5769) and...

- Maintain feature parity with the tracers.

# Notes
- Unit tests were copied from Python tracer, seen as the source of "true".



[SVLS-5769]: https://datadoghq.atlassian.net/browse/SVLS-5769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ