### PR TITLE
Retry vulnerability scanner on failure.

### DIFF
--- a/.github/workflows/retry-workflow.yml
+++ b/.github/workflows/retry-workflow.yml
@@ -5,6 +5,9 @@
 
 name: Retry workflow
 
+permissions:
+  actions: write
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/retry-workflow.yml
+++ b/.github/workflows/retry-workflow.yml
@@ -1,0 +1,24 @@
+# When triggered with a run_id, this workflow will retry other workflows. This
+# is useful so we can retry the Serverless Vulnerability Scan action. This must
+# be a separate action from the action to retry because you cannot retry an
+# action that is currently running.
+
+name: Retry workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        required: true
+
+jobs:
+  rerun:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Rerun ${{ inputs.run_id }}
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
+          gh run rerun ${{ inputs.run_id }}

--- a/.github/workflows/serverless-vuln-scan.yml
+++ b/.github/workflows/serverless-vuln-scan.yml
@@ -110,9 +110,20 @@ jobs:
           severity-cutoff: low
           output-format: table
 
+  retry:
+    needs: check
+    if: failure() && fromJSON(github.run_attempt) < 2
+    runs-on: ubuntu-latest
+    steps:
+      - name: Retry failed action
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run retry-workflow.yml -F run_id=${{ github.run_id }}
+
   notify:
     needs: check
-    if: failure()
+    if: failure() && fromJSON(github.run_attempt) >= 2
     runs-on: ubuntu-latest
     steps:
       - name: Notify

--- a/.github/workflows/serverless-vuln-scan.yml
+++ b/.github/workflows/serverless-vuln-scan.yml
@@ -114,6 +114,8 @@ jobs:
     needs: check
     if: failure() && fromJSON(github.run_attempt) < 2
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
       - name: Retry failed action
         env:


### PR DESCRIPTION
Our vulnerability scanner seems to fail pretty often for infrastructure related reasons. When retried, they pass just fine. 

This PR aims to add auto-retries to the vuln scan action.

Note that I am unable to test the retry logic end to end. I created a new github action which cannot be triggered until it hits main.

The plan is to merge this PR, then test a forced failure and ensure it is retried.