### PR TITLE
Instruct trivy to use fallback for downloading db.

### DIFF
--- a/.github/workflows/serverless-vuln-scan.yml
+++ b/.github/workflows/serverless-vuln-scan.yml
@@ -8,6 +8,9 @@ on:
 
 env:
   VERSION: 1  # env var required when building extension
+  # adds public.ecr.aws as fallback incase rate limit on ghcr.io is hit
+  TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+  TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
 
 jobs:
   check:


### PR DESCRIPTION
Seeing error when running nightly [vulnerability scan](https://github.com/DataDog/datadog-lambda-extension/actions/runs/11421773466/job/31779610353)

```
Running Trivy with options: trivy image public.ecr.aws/datadog/lambda-extension:latest
2024-10-20T01:32:03Z	INFO	[vulndb] Need to update DB
2024-10-20T01:32:03Z	INFO	[vulndb] Downloading vulnerability DB...
2024-10-20T01:32:03Z	INFO	[vulndb] Downloading artifact...	repo="ghcr.io/aquasecurity/trivy-db:2"
2024-10-20T01:32:04Z	ERROR	[vulndb] Failed to download artifact	repo="ghcr.io/aquasecurity/trivy-db:2" err="OCI repository error: 1 error occurred:\n\t* GET https://ghcr.io/v2/aquasecurity/trivy-db/manifests/2: TOOMANYREQUESTS: retry-after: 1.084625ms, allowed: 44000/minute\n\n"
2024-10-20T01:32:04Z	FATAL	Fatal error	init error: DB error: failed to download vulnerability DB: OCI artifact error: failed to download vulnerability DB: failed to download artifact from any source
```

Using solution from this [github issue](https://github.com/aquasecurity/trivy/discussions/7668#discussioncomment-10884984), adds fallback db when rate limit is hit.