### PR TITLE
Add testing of serverless-init latest to vuln scanner.

### DIFF
--- a/.github/workflows/serverless-vuln-scan.yml
+++ b/.github/workflows/serverless-vuln-scan.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Scan latest serverless-init image with trivy
         uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
         with:
-          image-ref: datadog/serverless-init:latest
+          image-ref: "datadog/serverless-init:latest"
           ignore-unfixed: true
           exit-code: 1
           format: table
@@ -46,7 +46,7 @@ jobs:
       - name: Scan latest-alpine serverless-init image with trivy
         uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
         with:
-          image-ref: datadog/serverless-init:latest-alpine
+          image-ref: "datadog/serverless-init:latest-alpine"
           ignore-unfixed: true
           exit-code: 1
           format: table

--- a/.github/workflows/serverless-vuln-scan.yml
+++ b/.github/workflows/serverless-vuln-scan.yml
@@ -68,6 +68,22 @@ jobs:
           exit-code: 1
           format: table
 
+      - name: Scan latest serverless-init image with trivy
+        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
+        with:
+          image-ref: datadog/serverless-init:latest
+          ignore-unfixed: true
+          exit-code: 1
+          format: table
+
+      - name: Scan latest-alpine serverless-init image with trivy
+        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
+        with:
+          image-ref: datadog/serverless-init:latest-alpine
+          ignore-unfixed: true
+          exit-code: 1
+          format: table
+
       - name: Scan amd64 image with grype
         uses: anchore/scan-action@ef0b0b023552a0c077534074723a9915280284bb # v5.1.0
         with:

--- a/.github/workflows/serverless-vuln-scan.yml
+++ b/.github/workflows/serverless-vuln-scan.yml
@@ -69,6 +69,24 @@ jobs:
           severity-cutoff: low
           output-format: table
 
+      - name: Scan latest serverless-init image with grype
+        uses: anchore/scan-action@ef0b0b023552a0c077534074723a9915280284bb # v5.1.0
+        with:
+          image: "datadog/serverless-init:latest"
+          only-fixed: true
+          fail-build: true
+          severity-cutoff: low
+          output-format: table
+
+      - name: Scan latest-alpine serverless-init image with grype
+        uses: anchore/scan-action@ef0b0b023552a0c077534074723a9915280284bb # v5.1.0
+        with:
+          image: "datadog/serverless-init:latest-alpine"
+          only-fixed: true
+          fail-build: true
+          severity-cutoff: low
+          output-format: table
+
       # scan unreleased from main
 
       - name: Checkout datadog-agent repository

--- a/.github/workflows/serverless-vuln-scan.yml
+++ b/.github/workflows/serverless-vuln-scan.yml
@@ -16,6 +16,61 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
+
+      # scan latest released images
+
+      - name: Scan latest released image with trivy
+        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
+        with:
+          image-ref: "public.ecr.aws/datadog/lambda-extension:latest"
+          ignore-unfixed: true
+          exit-code: 1
+          format: table
+
+      - name: Scan latest-alpoine released image with trivy
+        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
+        with:
+          image-ref: "public.ecr.aws/datadog/lambda-extension:latest-alpine"
+          ignore-unfixed: true
+          exit-code: 1
+          format: table
+
+      - name: Scan latest serverless-init image with trivy
+        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
+        with:
+          image-ref: datadog/serverless-init:latest
+          ignore-unfixed: true
+          exit-code: 1
+          format: table
+
+      - name: Scan latest-alpine serverless-init image with trivy
+        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
+        with:
+          image-ref: datadog/serverless-init:latest-alpine
+          ignore-unfixed: true
+          exit-code: 1
+          format: table
+
+      - name: Scan latest release image with grype
+        uses: anchore/scan-action@ef0b0b023552a0c077534074723a9915280284bb # v5.1.0
+        with:
+          image: "public.ecr.aws/datadog/lambda-extension:latest"
+          only-fixed: true
+          fail-build: true
+          severity-cutoff: low
+          output-format: table
+
+      - name: Scan latest-alpine release image with grype
+        uses: anchore/scan-action@ef0b0b023552a0c077534074723a9915280284bb # v5.1.0
+        with:
+          image: "public.ecr.aws/datadog/lambda-extension:latest-alpine"
+          only-fixed: true
+          fail-build: true
+          severity-cutoff: low
+          output-format: table
+
+      # scan unreleased from main
+
       - name: Checkout datadog-agent repository
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
@@ -52,38 +107,6 @@ jobs:
           exit-code: 1
           format: table
 
-      - name: Scan latest released image with trivy
-        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
-        with:
-          image-ref: "public.ecr.aws/datadog/lambda-extension:latest"
-          ignore-unfixed: true
-          exit-code: 1
-          format: table
-
-      - name: Scan latest-alpoine released image with trivy
-        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
-        with:
-          image-ref: "public.ecr.aws/datadog/lambda-extension:latest-alpine"
-          ignore-unfixed: true
-          exit-code: 1
-          format: table
-
-      - name: Scan latest serverless-init image with trivy
-        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
-        with:
-          image-ref: datadog/serverless-init:latest
-          ignore-unfixed: true
-          exit-code: 1
-          format: table
-
-      - name: Scan latest-alpine serverless-init image with trivy
-        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
-        with:
-          image-ref: datadog/serverless-init:latest-alpine
-          ignore-unfixed: true
-          exit-code: 1
-          format: table
-
       - name: Scan amd64 image with grype
         uses: anchore/scan-action@ef0b0b023552a0c077534074723a9915280284bb # v5.1.0
         with:
@@ -97,24 +120,6 @@ jobs:
         uses: anchore/scan-action@ef0b0b023552a0c077534074723a9915280284bb # v5.1.0
         with:
           image: "datadog/build-lambda-extension-arm64:${{ env.VERSION }}"
-          only-fixed: true
-          fail-build: true
-          severity-cutoff: low
-          output-format: table
-
-      - name: Scan latest release image with grype
-        uses: anchore/scan-action@ef0b0b023552a0c077534074723a9915280284bb # v5.1.0
-        with:
-          image: "public.ecr.aws/datadog/lambda-extension:latest"
-          only-fixed: true
-          fail-build: true
-          severity-cutoff: low
-          output-format: table
-
-      - name: Scan latest-alpine release image with grype
-        uses: anchore/scan-action@ef0b0b023552a0c077534074723a9915280284bb # v5.1.0
-        with:
-          image: "public.ecr.aws/datadog/lambda-extension:latest-alpine"
           only-fixed: true
           fail-build: true
           severity-cutoff: low


### PR DESCRIPTION
Customer reported vulnerabillites discovered in latest released version of serverless-init.

Adds vulnerability scanning of serverless-init with both trivy and grype to the nightly vulnerability scan action.

I also rearranged the action steps. Building the serverless binary is very slow, so it is now done last.

If you're struggling to review, go commit by commit.