### PR TITLE
Bump go version in alpine image to 1.23.2

### DIFF
--- a/.github/workflows/serverless-vuln-scan.yml
+++ b/.github/workflows/serverless-vuln-scan.yml
@@ -27,7 +27,7 @@ jobs:
           exit-code: 1
           format: table
 
-      - name: Scan latest-alpoine released image with trivy
+      - name: Scan latest-alpine released image with trivy
         uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
         with:
           image-ref: "public.ecr.aws/datadog/lambda-extension:latest-alpine"

--- a/scripts/Dockerfile.alpine.build
+++ b/scripts/Dockerfile.alpine.build
@@ -7,7 +7,7 @@ ARG CMD_PATH
 ARG BUILD_TAGS
 
 RUN apk add --no-cache git make musl-dev gcc
-COPY --from=golang:1.22-alpine /usr/local/go/ /usr/lib/go
+COPY --from=golang:1.23.2-alpine /usr/local/go/ /usr/lib/go
 
 ENV GOROOT /usr/lib/go
 ENV GOPATH /go


### PR DESCRIPTION
# What does this PR do?

Bumps go version in alpine image to 1.23.2.

# Motivation

Address vulnerabilities CVE-2024-34156 & CVE-2024-34158.

# Additional Notes

Related to https://github.com/DataDog/datadog-lambda-extension/pull/425

# How to test the change?

Build serverless-init locally and run `trivy image <image name>` to confirm vulnerabilities are addressed.