### PR TITLE
Adding static flag to build parameters for alpine images

### DIFF
--- a/scripts/Dockerfile.alpine.build
+++ b/scripts/Dockerfile.alpine.build
@@ -31,11 +31,11 @@ WORKDIR /tmp/dd/datadog-agent/"${CMD_PATH}"
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     if [ -z "$AGENT_VERSION" ]; then \
-        /usr/lib/go/bin/go build -ldflags="-w \
+        /usr/lib/go/bin/go build -ldflags="-w -extldflags '-static' \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
         -tags "${BUILD_TAGS}" -o datadog-agent; \
     else \
-        /usr/lib/go/bin/go build -ldflags="-w \
+        /usr/lib/go/bin/go build -ldflags="-w  -extldflags '-static' \
         -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION \
         -X github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault=$AGENT_VERSION" \
         -tags "${BUILD_TAGS}" -o datadog-agent; \


### PR DESCRIPTION
**What this does:**
This change builds the go-agent as a statically linked library when building for alpine. 

**Why make this change:**
A customer experience an issue using the extension in a container image that was using a really outdated version of GLIBc (2.17) for their go application. Where as our typical binary is compiled against GLIBc version (2.18). This was a current aws provided image so we could not advise the customer to update their base image. An easier solution would offer a statically linked library using a lightweight c library such as the one from alpine (musc). This will ensure compatibility across multiple linux environments. 

**Testing**  
I tested the new build with a container image that matched the environment the customer had. Previously the customer would receive errors regarding the glibc version being incompatible. My test I was able to run the extension and receive logs from the lambda. 

One concern I had about this change was file size, when statically linking an application any dependencies will be copied into the binary directly. 
To test this I built the application as a statically linked application and dynamically linked application and I compared the the final sizes:

 _ | Statically Linked | Dynamically Linked |
|--------|--------|--------|
| datadog-agent | 42438.376 kb | 42389.6 kb |

With this information you can see we're only adding less than a few hundred kilobytes to the binary. I think this is a small traded off to ensure the agent can be ran on any linux platform. 

