### PR TITLE
feat(bottlecap): generate tmp enhanced metrics

### DIFF
--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -20,7 +20,7 @@ figment = { version = "0.10", default-features = false, features = ["yaml", "env
 hyper = { version = "0.14", default-features = false, features = ["server"] }
 lazy_static = { version = "1.5", default-features = false }
 log = { version = "0.4", default-features = false }
-nix = { version = "0.26", default-features = false, features = ["feature"] }
+nix = { version = "0.26", default-features = false, features = ["feature", "fs"] }
 protobuf = { version = "3.5", default-features = false }
 regex = { version = "1.10", default-features = false }
 reqwest = { version = "0.12", features = ["json", "http2", "rustls-tls"], default-features = false }

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -62,8 +62,8 @@ use std::{
     sync::{Arc, Mutex},
 };
 use telemetry::listener::TelemetryListenerConfig;
+use tokio::sync::mpsc::Sender;
 use tokio::sync::Mutex as TokioMutex;
-use tokio::sync::{mpsc::Sender, watch};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error};
 use tracing_subscriber::EnvFilter;

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -379,7 +379,7 @@ async fn extension_loop_active(
                 lambda_enhanced_metrics.set_tmp_enhanced_metrics(tmp_chan_rx);
 
                 let mut p = invocation_processor.lock().await;
-                p.on_invoke_event(request_id, Some(tmp_chan_tx));
+                p.on_invoke_event(request_id, tmp_chan_tx);
                 drop(p);
             }
             Ok(NextEventResponse::Shutdown {
@@ -455,13 +455,11 @@ async fn extension_loop_active(
                                     );
 
                                     // set cpu utilization metrics here to avoid accounting for extra idle time
-                                    if let Some(mut data) = enhanced_metric_data {
+                                    if let Some(data) = enhanced_metric_data {
                                         lambda_enhanced_metrics.set_cpu_utilization_enhanced_metrics(data.cpu_offset, data.uptime_offset);
                                         // Send signal to stop monitoring tmp
-                                        if let Some(tmp_chan) = data.tmp_chan.take() {
-                                            _ = tmp_chan.send(());
-                                            drop(tmp_chan);
-                                        }
+                                        _ = data.tmp_chan.send(());
+                                        drop(data.tmp_chan);
                                     }
 
                                     // TODO(astuyve) it'll be easy to

--- a/bottlecap/src/lifecycle/invocation/context.rs
+++ b/bottlecap/src/lifecycle/invocation/context.rs
@@ -172,6 +172,7 @@ impl ContextBuffer {
 mod tests {
     use crate::proc::{CPUData, NetworkData};
     use std::collections::HashMap;
+    use tokio::sync::watch;
 
     use super::*;
 
@@ -318,12 +319,13 @@ mod tests {
         });
 
         let uptime_offset = Some(50.0);
+        let (tmp_chan, _) = watch::channel(());
 
         let enhanced_metric_data = Some(EnhancedMetricData {
             network_offset,
             cpu_offset,
             uptime_offset,
-            tmp_chan: None,
+            tmp_chan,
         });
 
         buffer.add_enhanced_metric_data(&request_id, enhanced_metric_data.clone());

--- a/bottlecap/src/lifecycle/invocation/context.rs
+++ b/bottlecap/src/lifecycle/invocation/context.rs
@@ -319,13 +319,13 @@ mod tests {
         });
 
         let uptime_offset = Some(50.0);
-        let (tmp_chan, _) = watch::channel(());
+        let (tmp_chan_tx, _) = watch::channel(());
 
         let enhanced_metric_data = Some(EnhancedMetricData {
             network_offset,
             cpu_offset,
             uptime_offset,
-            tmp_chan,
+            tmp_chan_tx,
         });
 
         buffer.add_enhanced_metric_data(&request_id, enhanced_metric_data.clone());

--- a/bottlecap/src/lifecycle/invocation/context.rs
+++ b/bottlecap/src/lifecycle/invocation/context.rs
@@ -323,6 +323,7 @@ mod tests {
             network_offset,
             cpu_offset,
             uptime_offset,
+            tmp_chan: None,
         });
 
         buffer.add_enhanced_metric_data(&request_id, enhanced_metric_data.clone());

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    sync::Arc,
+    sync::{mpsc, Arc},
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -81,7 +81,7 @@ impl Processor {
 
     /// Given a `request_id`, creates the context and adds the enhanced metric offsets to the context buffer.
     ///
-    pub fn on_invoke_event(&mut self, request_id: String) {
+    pub fn on_invoke_event(&mut self, request_id: String, tmp_chan: Option<mpsc::Sender<bool>>) {
         self.context_buffer.create_context(request_id.clone());
         if self.collect_enhanced_data {
             let network_offset: Option<NetworkData> = proc::get_network_data().ok();
@@ -91,6 +91,7 @@ impl Processor {
                 network_offset,
                 cpu_offset,
                 uptime_offset,
+                tmp_chan,
             });
             self.context_buffer
                 .add_enhanced_metric_data(&request_id, enhanced_metric_offsets);

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -81,7 +81,7 @@ impl Processor {
 
     /// Given a `request_id`, creates the context and adds the enhanced metric offsets to the context buffer.
     ///
-    pub fn on_invoke_event(&mut self, request_id: String, tmp_chan: Option<watch::Sender<()>>) {
+    pub fn on_invoke_event(&mut self, request_id: String, tmp_chan: watch::Sender<()>) {
         self.context_buffer.create_context(request_id.clone());
         if self.collect_enhanced_data {
             let network_offset: Option<NetworkData> = proc::get_network_data().ok();

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    sync::{mpsc, Arc},
+    sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -8,7 +8,7 @@ use chrono::{DateTime, Utc};
 use datadog_trace_protobuf::pb::Span;
 use datadog_trace_utils::{send_data::SendData, tracer_header_tags};
 use serde_json::{json, Value};
-use tokio::sync::mpsc::Sender;
+use tokio::sync::{mpsc::Sender, watch};
 use tracing::debug;
 
 use crate::{
@@ -81,7 +81,7 @@ impl Processor {
 
     /// Given a `request_id`, creates the context and adds the enhanced metric offsets to the context buffer.
     ///
-    pub fn on_invoke_event(&mut self, request_id: String, tmp_chan: Option<mpsc::Sender<bool>>) {
+    pub fn on_invoke_event(&mut self, request_id: String, tmp_chan: Option<watch::Sender<()>>) {
         self.context_buffer.create_context(request_id.clone());
         if self.collect_enhanced_data {
             let network_offset: Option<NetworkData> = proc::get_network_data().ok();

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -103,7 +103,7 @@ impl Processor {
                 network_offset,
                 cpu_offset,
                 uptime_offset,
-                tmp_chan: tmp_chan_tx,
+                tmp_chan_tx,
             });
             self.context_buffer
                 .add_enhanced_metric_data(&request_id, enhanced_metric_offsets);
@@ -185,7 +185,7 @@ impl Processor {
                     offsets.uptime_offset,
                 );
                 // Send the signal to stop monitoring tmp
-                _ = offsets.tmp_chan.send(());
+                _ = offsets.tmp_chan_tx.send(());
             }
         }
 

--- a/bottlecap/src/metrics/enhanced/constants.rs
+++ b/bottlecap/src/metrics/enhanced/constants.rs
@@ -5,6 +5,9 @@ pub const ARM_LAMBDA_PRICE_PER_GB_SECOND: f64 = 0.000_013_333_4;
 pub const MS_TO_SEC: f64 = 0.001;
 pub const MB_TO_GB: f64 = 1_024.0;
 
+// tmp directory path
+pub const TMP_PATH: &str = "/tmp/";
+
 // Enhanced metrics
 pub const MAX_MEMORY_USED_METRIC: &str = "aws.lambda.enhanced.max_memory_used";
 pub const MEMORY_SIZE_METRIC: &str = "aws.lambda.enhanced.memorysize";
@@ -32,5 +35,8 @@ pub const CPU_TOTAL_UTILIZATION_METRIC: &str = "aws.lambda.enhanced.cpu_total_ut
 pub const NUM_CORES_METRIC: &str = "aws.lambda.enhanced.num_cores";
 pub const CPU_MAX_UTILIZATION_METRIC: &str = "aws.lambda.enhanced.cpu_max_utilization";
 pub const CPU_MIN_UTILIZATION_METRIC: &str = "aws.lambda.enhanced.cpu_min_utilization";
+pub const TMP_MAX_METRIC: &str = "aws.lambda.enhanced.tmp_max";
+pub const TMP_USED_METRIC: &str = "aws.lambda.enhanced.tmp_used";
+pub const TMP_FREE_METRIC: &str = "aws.lambda.enhanced.tmp_free";
 //pub const ASM_INVOCATIONS_METRIC: &str = "aws.lambda.enhanced.asm.invocations";
 pub const ENHANCED_METRICS_ENV_VAR: &str = "DD_ENHANCED_METRICS";

--- a/bottlecap/src/metrics/enhanced/lambda.rs
+++ b/bottlecap/src/metrics/enhanced/lambda.rs
@@ -502,7 +502,7 @@ pub struct EnhancedMetricData {
     pub network_offset: Option<NetworkData>,
     pub cpu_offset: Option<CPUData>,
     pub uptime_offset: Option<f64>,
-    pub tmp_chan: Sender<()>,
+    pub tmp_chan_tx: Sender<()>,
 }
 
 impl PartialEq for EnhancedMetricData {

--- a/bottlecap/src/metrics/enhanced/lambda.rs
+++ b/bottlecap/src/metrics/enhanced/lambda.rs
@@ -502,7 +502,7 @@ pub struct EnhancedMetricData {
     pub network_offset: Option<NetworkData>,
     pub cpu_offset: Option<CPUData>,
     pub uptime_offset: Option<f64>,
-    pub tmp_chan: Option<Sender<()>>,
+    pub tmp_chan: Sender<()>,
 }
 
 impl PartialEq for EnhancedMetricData {

--- a/bottlecap/src/metrics/enhanced/lambda.rs
+++ b/bottlecap/src/metrics/enhanced/lambda.rs
@@ -404,7 +404,7 @@ impl Lambda {
 
             loop {
                 match send_metrics.try_recv() {
-                    Err(mpsc::TryRecvError::Disconnected) => {
+                    Ok(false) | Err(mpsc::TryRecvError::Disconnected) => {
                         let mut aggr: std::sync::MutexGuard<Aggregator> =
                             aggr.lock().expect("lock poisoned");
                         Self::generate_tmp_enhanced_metrics(tmp_max, tmp_used, &mut aggr);
@@ -796,7 +796,11 @@ mod tests {
         let tmp_max = 550461440.0;
         let tmp_used = 12165120.0;
 
-        Lambda::generate_tmp_enhanced_metrics(tmp_max, tmp_used, &mut lambda.aggregator.lock().expect("lock poisoned"));
+        Lambda::generate_tmp_enhanced_metrics(
+            tmp_max,
+            tmp_used,
+            &mut lambda.aggregator.lock().expect("lock poisoned"),
+        );
 
         assert_sketch(&metrics_aggr, constants::TMP_MAX_METRIC, 550461440.0);
         assert_sketch(&metrics_aggr, constants::TMP_USED_METRIC, 12165120.0);

--- a/bottlecap/src/metrics/enhanced/mod.rs
+++ b/bottlecap/src/metrics/enhanced/mod.rs
@@ -1,2 +1,3 @@
 pub mod constants;
 pub mod lambda;
+pub mod statfs;

--- a/bottlecap/src/metrics/enhanced/statfs.rs
+++ b/bottlecap/src/metrics/enhanced/statfs.rs
@@ -5,6 +5,8 @@ use std::io;
 use std::path::Path;
 
 #[cfg(not(target_os = "windows"))]
+/// Returns the block size, total number of blocks, and number of blocks available for the specified directory path.
+///
 pub fn statfs_info(path: &str) -> Result<(f64, f64, f64), io::Error> {
     let stat = statfs(Path::new(path)).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
     Ok((
@@ -16,5 +18,8 @@ pub fn statfs_info(path: &str) -> Result<(f64, f64, f64), io::Error> {
 
 #[cfg(target_os = "windows")]
 fn statfs_info(path: &str) -> Result<(f64, f64, f64), io::Error> {
-    Err(io::Error::new(io::ErrorKind::Other, "Cannot get tmp data on Windows"))
+    Err(io::Error::new(
+        io::ErrorKind::Other,
+        "Cannot get tmp data on Windows",
+    ))
 }

--- a/bottlecap/src/metrics/enhanced/statfs.rs
+++ b/bottlecap/src/metrics/enhanced/statfs.rs
@@ -16,5 +16,5 @@ pub fn statfs_info(path: &str) -> Result<(f64, f64, f64), io::Error> {
 
 #[cfg(target_os = "windows")]
 fn statfs_info(path: &str) -> Result<(f64, f64, f64), io::Error> {
-    Ok((0, 0, 0))
+    Err(io::Error::new(io::ErrorKind::Other, "Cannot get tmp data on Windows"))
 }

--- a/bottlecap/src/metrics/enhanced/statfs.rs
+++ b/bottlecap/src/metrics/enhanced/statfs.rs
@@ -1,0 +1,18 @@
+use nix::sys::statfs::statfs;
+use std::io;
+use std::path::Path;
+
+#[cfg(not(target_os = "windows"))]
+pub fn statfs_info(path: &str) -> Result<(f64, f64, f64), io::Error> {
+    let stat = statfs(Path::new(path)).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    Ok((
+        stat.block_size() as f64,
+        stat.blocks() as f64,
+        stat.blocks_available() as f64,
+    ))
+}
+
+#[cfg(target_os = "windows")]
+fn statfs_info(path: &str) -> Result<(f64, f64, f64), io::Error> {
+    Ok((0, 0, 0))
+}

--- a/bottlecap/src/metrics/enhanced/statfs.rs
+++ b/bottlecap/src/metrics/enhanced/statfs.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::module_name_repetitions)]
+
 use nix::sys::statfs::statfs;
 use std::io;
 use std::path::Path;


### PR DESCRIPTION
### What does this PR do?
This PR introduces three new enhanced lambda metrics. These metrics are emitted once per invocation and represent space used and space available in the `/tmp` directory.

The three new metrics are:
- `aws.lambda.enhanced.tmp_max` - max available bytes in `/tmp`
- `aws.lambda.enhanced.tmp_used` - bytes used or reserved in `/tmp`
- `aws.lambda.enhanced.tmp_free` - bytes available in `/tmp`

### Describe how to test/QA changes
- Build the lambda extension
- Create a lambda function with the extension built in previous step
- Turn on lambda insights / add the [lambda insights extension](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Lambda-Insights-Getting-Started.html) to your function
- Invoke the function
- View the new enhanced metrics in metrics explorer or [this dashboard](https://ddserverless.datadoghq.com/dashboard/ker-x4u-kbr?fromUser=true&refresh_mode=sliding&view=spans&from_ts=1716303324812&to_ts=1716305124812&live=true)
- [Compare with lambda insight metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Lambda-Insights-view-metrics.html) 

### Additional Notes
- `tmp_used` reflects a peak over the course of the request. Suppose 2000 bytes are written to `/tmp`, then deleted, then 3000 bytes are written, then deleted. The metric will report 3000. 