### PR TITLE
feat(bottlecap): add `runtime` tag

### DIFF
--- a/bottlecap/src/metrics/enhanced/lambda.rs
+++ b/bottlecap/src/metrics/enhanced/lambda.rs
@@ -35,7 +35,7 @@ impl Lambda {
         }
     }
 
-    /// Set the dynamic value tags that are not available at compile time
+    /// Set the init tags in `dynamic_value_tags`
     pub fn set_init_tags(&mut self, proactive_initialization: bool, cold_start: bool) {
         self.dynamic_value_tags.remove("cold_start");
         self.dynamic_value_tags.remove("proactive_initialization");
@@ -50,6 +50,12 @@ impl Lambda {
                 String::from("true"),
             );
         }
+    }
+
+    /// Sets the runtime tag in `dynamic_value_tags`
+    pub fn set_runtime_tag(&mut self, runtime: &str) {
+        self.dynamic_value_tags
+            .insert(String::from("runtime"), runtime.to_string());
     }
 
     fn get_dynamic_value_tags(&self) -> Option<SortedTags> {

--- a/bottlecap/src/proc/constants.rs
+++ b/bottlecap/src/proc/constants.rs
@@ -2,6 +2,7 @@ pub const PROC_NET_DEV_PATH: &str = "/proc/net/dev";
 pub const PROC_STAT_PATH: &str = "/proc/stat";
 pub const PROC_UPTIME_PATH: &str = "/proc/uptime";
 pub const PROC_PATH: &str = "/proc";
+pub const ETC_PATH: &str = "/etc";
 
 pub const LAMDBA_NETWORK_INTERFACE: &str = "vinternal_1";
 pub const LAMBDA_FILE_DESCRIPTORS_DEFAULT_LIMIT: f64 = 1024.0;

--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -145,7 +145,7 @@ fn tags_from_env(
 }
 
 #[allow(dead_code)] // keeping this logic for when async runtime resolution will be supported
-fn resolve_runtime_from_proc(proc_path: &str, fallback_provided_al_path: &str) -> String {
+pub fn resolve_runtime_from_proc(proc_path: &str, fallback_provided_al_path: &str) -> String {
     let start = Instant::now();
     match fs::read_dir(proc_path) {
         Ok(proc_dir) => {

--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -144,7 +144,6 @@ fn tags_from_env(
     tags_map
 }
 
-#[allow(dead_code)] // keeping this logic for when async runtime resolution will be supported
 pub fn resolve_runtime_from_proc(proc_path: &str, fallback_provided_al_path: &str) -> String {
     let start = Instant::now();
     match fs::read_dir(proc_path) {


### PR DESCRIPTION
# What?

Adds the `runtime` tag to the invocation span and metric tags.

<img width="1030" alt="Screenshot 2024-11-21 at 10 24 06 AM" src="https://github.com/user-attachments/assets/746308c3-6df3-4e33-82ad-9b95a8e4b50c">


<img width="1608" alt="Screenshot 2024-11-21 at 10 24 36 AM" src="https://github.com/user-attachments/assets/f7b1e1b1-7968-4249-a722-eebd4d0a5269">
