### PR TITLE
feat(bottlecap): handle OOM exceptions

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -452,6 +452,8 @@ async fn extension_loop_active(
                                     // pass the invocation deadline to
                                     // flush tasks here, so they can
                                     // retry if we have more time
+                                    //
+                                    // We always want to flush on a timeout
                                     if flush_control.should_flush_end() || status == Status::Timeout {
                                         tokio::join!(
                                             logs_flusher.flush(),

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -400,7 +400,12 @@ async fn extension_loop_active(
                     match event {
                         Event::Metric(event) => {
                             debug!("Metric event: {:?}", event);
-                        }
+                        },
+                        Event::OutOfMemory => {
+                            let mut p = invocation_processor.lock().await;
+                            p.on_out_of_memory_error();
+                            drop(p);
+                        },
                         Event::Telemetry(event) =>
                             match event.record {
                                 TelemetryRecord::PlatformInitStart { .. } => {

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -28,7 +28,7 @@ use bottlecap::{
     telemetry::{
         self,
         client::TelemetryApiClient,
-        events::{TelemetryEvent, TelemetryRecord},
+        events::{Status, TelemetryEvent, TelemetryRecord},
         listener::TelemetryListener,
     },
     traces::{
@@ -452,7 +452,7 @@ async fn extension_loop_active(
                                     // pass the invocation deadline to
                                     // flush tasks here, so they can
                                     // retry if we have more time
-                                    if flush_control.should_flush_end() {
+                                    if flush_control.should_flush_end() || status == Status::Timeout {
                                         tokio::join!(
                                             logs_flusher.flush(),
                                             metrics_flusher.flush(),

--- a/bottlecap/src/events/mod.rs
+++ b/bottlecap/src/events/mod.rs
@@ -19,4 +19,5 @@ impl MetricEvent {
 pub enum Event {
     Metric(MetricEvent),
     Telemetry(TelemetryEvent),
+    OutOfMemory,
 }

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -256,6 +256,14 @@ impl Processor {
             // Increment the error type metric
             if status == Status::Timeout {
                 self.enhanced_metrics.increment_timeout_metric();
+                self.enhanced_metrics.increment_errors_metric();
+
+                // Invocation Span will never have the `trace_id` or `span_id` set
+                self.span.trace_id = generate_span_id();
+                self.span.span_id = generate_span_id();
+                self.span.error = 1;
+                self.span.meta.insert("error.msg".to_string(), "Datadog detected an Impending Timeout".to_string());
+                self.span.meta.insert("error.type".to_string(), "Impending Timeout".to_string());
             }
         }
 

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -280,8 +280,13 @@ impl Processor {
                 self.span.trace_id = generate_span_id();
                 self.span.span_id = generate_span_id();
                 self.span.error = 1;
-                self.span.meta.insert("error.msg".to_string(), "Datadog detected an Impending Timeout".to_string());
-                self.span.meta.insert("error.type".to_string(), "Impending Timeout".to_string());
+                self.span.meta.insert(
+                    "error.msg".to_string(),
+                    "Datadog detected an Impending Timeout".to_string(),
+                );
+                self.span
+                    .meta
+                    .insert("error.type".to_string(), "Impending Timeout".to_string());
             }
         }
 

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -274,7 +274,6 @@ impl Processor {
             // Increment the error type metric
             if status == Status::Timeout {
                 self.enhanced_metrics.increment_timeout_metric();
-                self.enhanced_metrics.increment_errors_metric();
 
                 // Invocation Span will never have the `trace_id` or `span_id` set
                 self.span.trace_id = generate_span_id();

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -602,4 +602,8 @@ impl Processor {
             // todo: handle timeout
         }
     }
+
+    pub fn on_out_of_memory_error(&mut self) {
+        self.enhanced_metrics.increment_oom_metric();
+    }
 }

--- a/bottlecap/src/metrics/enhanced/lambda.rs
+++ b/bottlecap/src/metrics/enhanced/lambda.rs
@@ -82,6 +82,10 @@ impl Lambda {
         self.increment_metric(constants::TIMEOUTS_METRIC);
     }
 
+    pub fn increment_oom_metric(&self) {
+        self.increment_metric(constants::OUT_OF_MEMORY_METRIC);
+    }
+
     pub fn set_init_duration_metric(&self, init_duration_ms: f64) {
         if !self.config.enhanced_metrics {
             return;


### PR DESCRIPTION
# What?

Handles OOM exceptions, sending enhanced metric as expected.

<img width="1255" alt="Screenshot 2024-11-21 at 4 23 14 PM" src="https://github.com/user-attachments/assets/b9d0b115-05fe-4589-9f72-680301de735c">

# Notes

Metrics look iffy, but that's OK, because when the sandbox get's signal-killed, there's no way for us to tell that we got OOM as of now.

