### PR TITLE
fix(bottlecap): fix `aws.lambda` service naming

### DIFF
--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -40,6 +40,12 @@ impl TraceChunkProcessor for ChunkProcessor {
             .spans
             .retain(|span| !filter_span_from_lambda_library_or_runtime(span));
         for span in &mut chunk.spans {
+            if span.service == "aws.lambda" {
+                if let Some(service) = self.tags_provider.get_tags_map().get("service") {
+                    span.service.clone_from(service);
+                }
+            }
+
             self.tags_provider.get_tags_map().iter().for_each(|(k, v)| {
                 span.meta.insert(k.clone(), v.clone());
             });

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -40,6 +40,8 @@ impl TraceChunkProcessor for ChunkProcessor {
             .spans
             .retain(|span| !filter_span_from_lambda_library_or_runtime(span));
         for span in &mut chunk.spans {
+            // Service name could be incorrectly set to 'aws.lambda'
+            // in datadog lambda libraries
             if span.service == "aws.lambda" {
                 if let Some(service) = self.tags_provider.get_tags_map().get("service") {
                     span.service.clone_from(service);


### PR DESCRIPTION
# What?

When `DD_SERVICE` is set, `aws.lambda` spans service should be that, this can happen in NodeJS