### PR TITLE
chore: update Go version in multiple places

### DIFF
--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -15,8 +15,8 @@ RUN arch="$(uname -m)"; \
     if [ "${arch}" = 'x86_64' ]; then \
     arch='amd64'; \
     fi; \
-    wget -O go1.23.1.linux-${arch}.tar.gz https://go.dev/dl/go1.23.1.linux-${arch}.tar.gz; \
-    tar -C /usr/local -xzf go1.23.1.linux-${arch}.tar.gz
+    wget -O go1.23.2.linux-${arch}.tar.gz https://go.dev/dl/go1.23.2.linux-${arch}.tar.gz; \
+    tar -C /usr/local -xzf go1.23.2.linux-${arch}.tar.gz
 
 # cache dependencies
 COPY ./scripts/.cache/go.mod /tmp/dd/datadog-agent

--- a/scripts_v2/Dockerfile.build
+++ b/scripts_v2/Dockerfile.build
@@ -14,8 +14,8 @@ RUN arch="$(uname -m)"; \
     if [ "${arch}" = 'x86_64' ]; then \
     arch='amd64'; \
     fi; \
-    wget -O go1.23.1.linux-${arch}.tar.gz https://go.dev/dl/go1.23.1.linux-${arch}.tar.gz; \
-    tar -C /usr/local -xzf go1.23.1.linux-${arch}.tar.gz
+    wget -O go1.23.2.linux-${arch}.tar.gz https://go.dev/dl/go1.23.2.linux-${arch}.tar.gz; \
+    tar -C /usr/local -xzf go1.23.2.linux-${arch}.tar.gz
 
 RUN mkdir -p /tmp/dd
 


### PR DESCRIPTION
# What?

Updates Go version to `1.23.2`

# Motivation

Go version was updated for alpine in #426 but not for all other places