### PR TITLE
priority of decrypt: kms > arn > use dd_api_key

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -50,7 +50,6 @@ use dogstatsd::{
     dogstatsd::{DogStatsD, DogStatsDConfig},
     flusher::{build_fqdn_metrics, Flusher as MetricsFlusher},
 };
-use lazy_static::lazy_static;
 use reqwest::Client;
 use serde::Deserialize;
 use std::{
@@ -69,11 +68,6 @@ use tokio::sync::Mutex as TokioMutex;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error};
 use tracing_subscriber::EnvFilter;
-
-lazy_static! {
-    static ref API_KEY_REGEX: regex::Regex =
-        regex::Regex::new(r"^[a-f0-9]{32}$").expect("Invalid regex for DD API KEY");
-}
 
 #[derive(Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -181,9 +175,7 @@ async fn main() -> Result<()> {
         .await
         .map_err(|e| Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
 
-    if let Some(resolved_api_key) =
-        clean_api_key(resolve_secrets(Arc::clone(&config), &aws_config).await)
-    {
+    if let Some(resolved_api_key) = resolve_secrets(Arc::clone(&config), &aws_config).await {
         match extension_loop_active(&aws_config, &config, &client, &r, resolved_api_key).await {
             Ok(()) => {
                 debug!("Extension loop completed successfully");
@@ -200,17 +192,6 @@ async fn main() -> Result<()> {
         error!("Failed to resolve secrets, Datadog extension will be idle");
         extension_loop_idle(&client, &r).await
     }
-}
-
-fn clean_api_key(maybe_key: Option<String>) -> Option<String> {
-    if let Some(key) = maybe_key {
-        let clean_key = key.trim_end_matches('\n').replace(' ', "").to_string();
-        if API_KEY_REGEX.is_match(&clean_key) {
-            return Some(clean_key);
-        }
-        error!("API key has invalid format");
-    }
-    None
 }
 
 fn load_configs() -> (AwsConfig, Arc<Config>) {

--- a/bottlecap/src/secrets/decrypt.rs
+++ b/bottlecap/src/secrets/decrypt.rs
@@ -25,9 +25,9 @@ pub async fn resolve_secrets(config: Arc<Config>, aws_config: &AwsConfig) -> Opt
         };
 
         let decrypted_key = if config.kms_api_key.is_empty() {
-            decrypt_aws_kms(&client, config.api_key_secret_arn.clone(), aws_config).await
+            decrypt_aws_sm(&client, config.api_key_secret_arn.clone(), aws_config).await
         } else {
-            decrypt_aws_sm(&client, config.kms_api_key.clone(), aws_config).await
+            decrypt_aws_kms(&client, config.kms_api_key.clone(), aws_config).await
         };
 
         debug!("Decrypt took {}ms", before_decrypt.elapsed().as_millis());


### PR DESCRIPTION
Current logic was ignoring kms/secret arn when dd_api was set, but from the docs and goagent behavior it should be the other way around 
https://docs.datadoghq.com/serverless/libraries_integrations/cli/

> Datadog API Key encrypted using KMS. Sets the DD_KMS_API_KEY environment variable on your Lambda function configuration. Note: DD_API_KEY is ignored when DD_KMS_API_KEY is set.

> 	The ARN of the secret storing the Datadog API key in AWS Secrets Manager. Sets the DD_API_KEY_SECRET_ARN on your Lambda function configuration. Notes: DD_API_KEY_SECRET_ARN is ignored when DD_KMS_API_KEY is set. Add the secretsmanager:GetSecretValue permission to the Lambda execution role.


Also remove the 32 char hex validation