### PR TITLE
feat: Flush timeouts

### DIFF
--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -78,6 +78,7 @@ pub struct Config {
     pub logs_config_processing_rules: Option<Vec<ProcessingRule>>,
     pub serverless_flush_strategy: FlushStrategy,
     pub enhanced_metrics: bool,
+    pub flush_timeout: u64,
     pub https_proxy: Option<String>,
     pub capture_lambda_payload: bool,
     pub capture_lambda_payload_max_depth: u32,
@@ -102,6 +103,7 @@ impl Default for Config {
             api_key_secret_arn: String::default(),
             kms_api_key: String::default(),
             serverless_flush_strategy: FlushStrategy::Default,
+            flush_timeout: 5,
             // Unified Tagging
             env: None,
             service: None,

--- a/bottlecap/src/http_client.rs
+++ b/bottlecap/src/http_client.rs
@@ -1,4 +1,5 @@
 use crate::config;
+use core::time::Duration;
 use std::sync::Arc;
 use tracing::error;
 
@@ -16,7 +17,7 @@ pub fn get_client(config: Arc<config::Config>) -> reqwest::Client {
 }
 
 fn build_client(config: Arc<config::Config>) -> Result<reqwest::Client, reqwest::Error> {
-    let client = reqwest::Client::builder();
+    let client = reqwest::Client::builder().timeout(Duration::from_secs(config.flush_timeout));
     // This covers DD_PROXY_HTTPS and HTTPS_PROXY
     if let Some(https_uri) = &config.https_proxy {
         let proxy = reqwest::Proxy::https(https_uri.clone())?;


### PR DESCRIPTION
The main agent limits this to [5 seconds fixed](https://github.com/DataDog/datadog-agent/blob/924a1502fdb70f35064838fa1bbf27b54459fb1b/pkg/serverless/daemon/daemon.go#L34), I wanted to make it configurable.