### PR TITLE
fix(bottlecap): dogstatsd to filter invocations from lambda library

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -799,13 +799,14 @@ dependencies = [
 
 [[package]]
 name = "dogstatsd"
-version = "13.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=92272e90a7919f07178f3246ef8f82295513cfed#92272e90a7919f07178f3246ef8f82295513cfed"
+version = "14.3.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=9ead10a46220be96ccfefccbc23bc3f88a6e7200#9ead10a46220be96ccfefccbc23bc3f88a6e7200"
 dependencies = [
  "datadog-protos 0.1.0 (git+https://github.com/DataDog/saluki-backport/?rev=3c5d87ab82dea4a1a98ef0c60fb3659ca35c2751)",
  "ddsketch-agent 0.1.0 (git+https://github.com/DataDog/saluki-backport/?rev=3c5d87ab82dea4a1a98ef0c60fb3659ca35c2751)",
  "fnv",
  "hashbrown 0.14.5",
+ "lazy_static",
  "protobuf",
  "regex",
  "reqwest",

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -15,7 +15,7 @@ datadog-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "92
 datadog-trace-mini-agent = { git = "https://github.com/DataDog/libdatadog", rev = "92272e90a7919f07178f3246ef8f82295513cfed" }
 datadog-trace-normalization = { git = "https://github.com/DataDog/libdatadog", rev = "92272e90a7919f07178f3246ef8f82295513cfed" }
 datadog-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "92272e90a7919f07178f3246ef8f82295513cfed" }
-dogstatsd = { git = "https://github.com/DataDog/libdatadog", rev = "92272e90a7919f07178f3246ef8f82295513cfed" }
+dogstatsd = { git = "https://github.com/DataDog/libdatadog", rev = "9ead10a46220be96ccfefccbc23bc3f88a6e7200" }
 figment = { version = "0.10", default-features = false, features = ["yaml", "env"] }
 hyper = { version = "0.14", default-features = false, features = ["server"] }
 lazy_static = { version = "1.5", default-features = false }

--- a/bottlecap/LICENSE-3rdparty.yml
+++ b/bottlecap/LICENSE-3rdparty.yml
@@ -6370,7 +6370,7 @@ third_party_libraries:
       See the License for the specific language governing permissions and
       limitations under the License.
 - package_name: dogstatsd
-  package_version: 13.1.0
+  package_version: 14.3.0
   repository: ''
   license: Apache-2.0
   licenses:


### PR DESCRIPTION
# What?

Lambda library sends the invocation metric, we send it from here too.

Just ignore it so we don't duplicate it.