### PR TITLE
Feat: support adaptive flush strategy again

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -501,10 +501,6 @@ async fn extension_loop_active(
                         trace_flusher.manual_flush(),
                         stats_flusher.manual_flush()
                     );
-                    if !flush_control.should_flush_end() {
-                        break;
-                    }
-
                     if matches!(flush_control.flush_strategy, FlushStrategy::Periodically(_)) {
                         break;
                     }

--- a/bottlecap/src/lifecycle/flush_control.rs
+++ b/bottlecap/src/lifecycle/flush_control.rs
@@ -3,7 +3,7 @@ use std::time;
 use tokio::time::Interval;
 use tracing::debug;
 
-use super::invocation_times::InvocationTimes;
+use crate::lifecycle::invocation_times::InvocationTimes;
 
 const DEFAULT_FLUSH_INTERVAL: u64 = 1000; // 1s
 const TWENTY_SECONDS: u64 = 20 * 1000;

--- a/bottlecap/src/lifecycle/flush_control.rs
+++ b/bottlecap/src/lifecycle/flush_control.rs
@@ -44,8 +44,7 @@ impl FlushControl {
         };
         self.invocation_times.add(now);
         match &self.flush_strategy {
-            FlushStrategy::End => true,
-            FlushStrategy::EndPeriodically(_) => true,
+            FlushStrategy::End | FlushStrategy::EndPeriodically(_) => true,
             FlushStrategy::Periodically(_) => false,
             FlushStrategy::Default => {
                 if self.invocation_times.should_adapt_to_periodic(now) {

--- a/bottlecap/src/lifecycle/invocation_times.rs
+++ b/bottlecap/src/lifecycle/invocation_times.rs
@@ -1,0 +1,89 @@
+const LOOKBACK_COUNT: usize = 20;
+const ONE_TWENTY_SECONDS: f64 = 120.0;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct InvocationTimes {
+    times: [u64; LOOKBACK_COUNT],
+    head: usize,
+}
+
+impl InvocationTimes {
+    pub(crate) fn new() -> InvocationTimes {
+        InvocationTimes {
+            times: [0; LOOKBACK_COUNT],
+            head: 0,
+        }
+    }
+
+    pub(crate) fn add(&mut self, timestamp: u64) {
+        self.times[self.head] = timestamp;
+        self.head = (self.head + 1) % LOOKBACK_COUNT;
+    }
+
+    pub(crate) fn should_adapt_to_periodic(&self, now: u64) -> bool {
+        let mut count = 0;
+        let mut last = 0;
+        for time in &self.times {
+            if *time != 0 {
+                count += 1;
+                last = *time;
+            }
+        }
+        // If we haven't seen enough invocations, we should flush
+        if count < LOOKBACK_COUNT {
+            return false;
+        }
+        let elapsed = now - last;
+        (elapsed as f64 / (count - 1) as f64) < ONE_TWENTY_SECONDS
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::lifecycle::invocation_times;
+
+    #[test]
+    fn new() {
+        let invocation_times = invocation_times::InvocationTimes::new();
+        assert_eq!(
+            invocation_times.times,
+            [0; invocation_times::LOOKBACK_COUNT]
+        );
+        assert_eq!(invocation_times.head, 0);
+    }
+
+    #[test]
+    fn insertion() {
+        let mut invocation_times = invocation_times::InvocationTimes::new();
+        let timestamp = 1;
+        invocation_times.add(timestamp);
+        assert_eq!(invocation_times.times[0], timestamp);
+        assert_eq!(invocation_times.head, 1);
+        assert!(!invocation_times.should_adapt_to_periodic(1));
+    }
+
+    #[test]
+    fn insertion_with_full_buffer_fast_invokes() {
+        let mut invocation_times = invocation_times::InvocationTimes::new();
+        for i in 0..=invocation_times::LOOKBACK_COUNT {
+            invocation_times.add(i as u64);
+        }
+        // should wrap around
+        assert_eq!(invocation_times.times[0], 20);
+        assert_eq!(invocation_times.head, 1);
+        assert!(invocation_times.should_adapt_to_periodic(21));
+    }
+
+    #[test]
+    fn insertion_with_full_buffer_slow_invokes() {
+        let mut invocation_times = invocation_times::InvocationTimes::new();
+        invocation_times.add(1_u64);
+        for i in 0..invocation_times::LOOKBACK_COUNT {
+            invocation_times.add((i + 5000) as u64);
+        }
+        // should wrap around
+        assert_eq!(invocation_times.times[0], 5019);
+        assert_eq!(invocation_times.head, 1);
+        assert!(!invocation_times.should_adapt_to_periodic(10000));
+    }
+}

--- a/bottlecap/src/lifecycle/mod.rs
+++ b/bottlecap/src/lifecycle/mod.rs
@@ -1,3 +1,4 @@
 pub mod flush_control;
 pub mod invocation;
+pub mod invocation_times;
 pub mod listener;


### PR DESCRIPTION
I removed this initially as I believed it either wasn't necessary or didn't help much (I think? I had just had a baby)
We've since gotten some feedback that, although users can set `DD_SERVERLESS_FLUSH_STRATEGY=periodically,10000` to flush every 10s regardless of the number of invocations, they prefer the automatic adaptive strategy we had earlier.

So I'm adding this back