### PR TITLE
feat: Set default flush interval to 30s

### DIFF
--- a/bottlecap/src/lifecycle/flush_control.rs
+++ b/bottlecap/src/lifecycle/flush_control.rs
@@ -5,7 +5,7 @@ use tracing::debug;
 
 use crate::lifecycle::invocation_times::InvocationTimes;
 
-const DEFAULT_FLUSH_INTERVAL: u64 = 1000; // 1s
+const DEFAULT_FLUSH_INTERVAL: u64 = 30 * 1000; // 30s
 const TWENTY_SECONDS: u64 = 20 * 1000;
 
 #[derive(Clone, Copy, Debug, PartialEq)]


### PR DESCRIPTION
Customer feedback from high volume functions shows this tick rate is simply too frequent. Customers can always change this with the `DD_SERVERLESS_FLUSH_STRATEGY` option.