### PR TITLE
feat: 1min default

### DIFF
--- a/bottlecap/src/lifecycle/flush_control.rs
+++ b/bottlecap/src/lifecycle/flush_control.rs
@@ -5,7 +5,7 @@ use tracing::debug;
 
 use crate::lifecycle::invocation_times::InvocationTimes;
 
-const DEFAULT_FLUSH_INTERVAL: u64 = 30 * 1000; // 30s
+const DEFAULT_FLUSH_INTERVAL: u64 = 60 * 1000; // 60s
 const TWENTY_SECONDS: u64 = 20 * 1000;
 
 #[derive(Clone, Copy, Debug, PartialEq)]


### PR DESCRIPTION
1min default is in line with the datadog-agent. To avoid a breaking change, we'll keep it at 1min here.
