### PR TITLE
Decode error message and error type

### DIFF
--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -596,8 +596,8 @@ impl Processor {
             }
 
             if let Some(s) = stack {
-                let decoded_stack = base64_to_string(s).unwrap_or_else(|_| {
-                    debug!("Error stack header may not be encoded, setting as is");
+                let decoded_stack = base64_to_string(s).unwrap_or_else(|e| {
+                    debug!("Failed to decode error stack: {e}");
                     s.to_string()
                 });
 

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -574,13 +574,10 @@ impl Processor {
             self.span.error = 1;
 
             if let Some(m) = message {
-                let decoded_message = match base64_to_string(m) {
-                    Ok(decoded) => decoded,
-                    Err(e) => {
-                        debug!("Failed to decode error message: {e}");
-                        m.to_string()
-                    }
-                };
+                let decoded_message = base64_to_string(m).unwrap_or_else(|_| {
+                    debug!("Error message header may not be encoded, setting as is");
+                    m.to_string()
+                });
 
                 self.span
                     .meta
@@ -588,13 +585,10 @@ impl Processor {
             }
 
             if let Some(t) = r#type {
-                let decoded_type = match base64_to_string(t) {
-                    Ok(decoded) => decoded,
-                    Err(e) => {
-                        debug!("Failed to decode error type: {e}");
-                        t.to_string()
-                    }
-                };
+                let decoded_type = base64_to_string(t).unwrap_or_else(|_| {
+                    debug!("Error type header may not be encoded, setting as is");
+                    t.to_string()
+                });
 
                 self.span
                     .meta
@@ -602,13 +596,10 @@ impl Processor {
             }
 
             if let Some(s) = stack {
-                let decoded_stack = match base64_to_string(s) {
-                    Ok(decoded) => decoded,
-                    Err(e) => {
-                        debug!("Failed to decode error stack: {e}");
-                        s.to_string()
-                    }
-                };
+                let decoded_stack = base64_to_string(s).unwrap_or_else(|_| {
+                    debug!("Error stack header may not be encoded, setting as is");
+                    s.to_string()
+                });
 
                 self.span
                     .meta
@@ -621,5 +612,88 @@ impl Processor {
 
     pub fn on_out_of_memory_error(&mut self) {
         self.enhanced_metrics.increment_oom_metric();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::LAMBDA_RUNTIME_SLUG;
+    use base64::Engine;
+    use dogstatsd::metric::EMPTY_TAGS;
+    use dogstatsd::aggregator::Aggregator;
+
+    use base64::engine::general_purpose::STANDARD;
+
+    fn setup() -> Processor {
+        let aws_config = AwsConfig {
+            region: "us-east-1".into(),
+            aws_access_key_id: "***".into(),
+            aws_secret_access_key: "***".into(),
+            aws_session_token: "***".into(),
+            function_name: "test-function".into(),
+            sandbox_init_time: Instant::now(),
+        };
+
+        let config = Arc::new(config::Config {
+            service: Some("test-service".to_string()),
+            tags: Some("test:tags".to_string()),
+            ..config::Config::default()
+        });
+
+        let tags_provider = Arc::new(
+            provider::Provider::new(Arc::clone(&config),
+            LAMBDA_RUNTIME_SLUG.to_string(),
+            &HashMap::from([("function_arn".to_string(), "test-arn".to_string())])));
+
+        let metrics_aggregator = Arc::new(Mutex::new(
+            Aggregator::new(EMPTY_TAGS, 1024).expect("failed to create aggregator"),
+        ));
+
+        Processor::new(tags_provider, config, &aws_config, metrics_aggregator)
+    }
+
+    #[test]
+    fn test_set_span_error_from_base64_encoded_headers() {
+        let mut p = setup();
+        let mut headers = HashMap::<String, String>::new();
+
+        let error_message = "Error message";
+        let error_type = "System.Exception";
+        let error_stack = "System.Exception: Error message \n at TestFunction.Handle(ILambdaContext context)";
+
+        headers.insert(DATADOG_INVOCATION_ERROR_KEY.into(), "true".into());
+        headers.insert(DATADOG_INVOCATION_ERROR_MESSAGE_KEY.into(), STANDARD.encode(error_message));
+        headers.insert(DATADOG_INVOCATION_ERROR_TYPE_KEY.into(), STANDARD.encode(error_type));
+        headers.insert(DATADOG_INVOCATION_ERROR_STACK_KEY.into(), STANDARD.encode(error_stack));
+        
+        p.set_span_error_from_headers(headers);
+
+        assert_eq!(p.span.error, 1);
+        assert_eq!(p.span.meta["error.msg"], error_message);
+        assert_eq!(p.span.meta["error.type"], error_type);
+        assert_eq!(p.span.meta["error.stack"], error_stack);
+    }
+
+    #[test]
+    fn test_set_span_error_from_non_encoded_headers() {
+        let mut p = setup();
+        let mut headers = HashMap::<String, String>::new();
+
+        let error_message = "Error message";
+        let error_type = "System.Exception";
+        let error_stack = "System.Exception: Error message \n at TestFunction.Handle(ILambdaContext context)";
+
+        headers.insert(DATADOG_INVOCATION_ERROR_KEY.into(), "true".into());
+        headers.insert(DATADOG_INVOCATION_ERROR_MESSAGE_KEY.into(), error_message.into());
+        headers.insert(DATADOG_INVOCATION_ERROR_TYPE_KEY.into(), error_type.into());
+        headers.insert(DATADOG_INVOCATION_ERROR_STACK_KEY.into(), error_stack.into());
+
+        p.set_span_error_from_headers(headers);
+
+        assert_eq!(p.span.error, 1);
+        assert_eq!(p.span.meta["error.msg"], error_message);
+        assert_eq!(p.span.meta["error.type"], error_type);
+        assert_eq!(p.span.meta["error.stack"], error_stack);
     }
 }

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -574,15 +574,31 @@ impl Processor {
             self.span.error = 1;
 
             if let Some(m) = message {
+                let decoded_message = match base64_to_string(m) {
+                    Ok(decoded) => decoded,
+                    Err(e) => {
+                        debug!("Failed to decode error message: {e}");
+                        m.to_string()
+                    }
+                };
+
                 self.span
                     .meta
-                    .insert(String::from("error.msg"), m.to_string());
+                    .insert(String::from("error.msg"), decoded_message);
             }
 
             if let Some(t) = r#type {
+                let decoded_type = match base64_to_string(t) {
+                    Ok(decoded) => decoded,
+                    Err(e) => {
+                        debug!("Failed to decode error type: {e}");
+                        t.to_string()
+                    }
+                };
+
                 self.span
                     .meta
-                    .insert(String::from("error.type"), t.to_string());
+                    .insert(String::from("error.type"), decoded_type);
             }
 
             if let Some(s) = stack {

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -619,11 +619,9 @@ impl Processor {
 mod tests {
     use super::*;
     use crate::LAMBDA_RUNTIME_SLUG;
-    use base64::Engine;
-    use dogstatsd::metric::EMPTY_TAGS;
+    use base64::{engine::general_purpose::STANDARD, Engine};
     use dogstatsd::aggregator::Aggregator;
-
-    use base64::engine::general_purpose::STANDARD;
+    use dogstatsd::metric::EMPTY_TAGS;
 
     fn setup() -> Processor {
         let aws_config = AwsConfig {
@@ -641,10 +639,11 @@ mod tests {
             ..config::Config::default()
         });
 
-        let tags_provider = Arc::new(
-            provider::Provider::new(Arc::clone(&config),
+        let tags_provider = Arc::new(provider::Provider::new(
+            Arc::clone(&config),
             LAMBDA_RUNTIME_SLUG.to_string(),
-            &HashMap::from([("function_arn".to_string(), "test-arn".to_string())])));
+            &HashMap::from([("function_arn".to_string(), "test-arn".to_string())]),
+        ));
 
         let metrics_aggregator = Arc::new(Mutex::new(
             Aggregator::new(EMPTY_TAGS, 1024).expect("failed to create aggregator"),
@@ -660,13 +659,23 @@ mod tests {
 
         let error_message = "Error message";
         let error_type = "System.Exception";
-        let error_stack = "System.Exception: Error message \n at TestFunction.Handle(ILambdaContext context)";
+        let error_stack =
+            "System.Exception: Error message \n at TestFunction.Handle(ILambdaContext context)";
 
         headers.insert(DATADOG_INVOCATION_ERROR_KEY.into(), "true".into());
-        headers.insert(DATADOG_INVOCATION_ERROR_MESSAGE_KEY.into(), STANDARD.encode(error_message));
-        headers.insert(DATADOG_INVOCATION_ERROR_TYPE_KEY.into(), STANDARD.encode(error_type));
-        headers.insert(DATADOG_INVOCATION_ERROR_STACK_KEY.into(), STANDARD.encode(error_stack));
-        
+        headers.insert(
+            DATADOG_INVOCATION_ERROR_MESSAGE_KEY.into(),
+            STANDARD.encode(error_message),
+        );
+        headers.insert(
+            DATADOG_INVOCATION_ERROR_TYPE_KEY.into(),
+            STANDARD.encode(error_type),
+        );
+        headers.insert(
+            DATADOG_INVOCATION_ERROR_STACK_KEY.into(),
+            STANDARD.encode(error_stack),
+        );
+
         p.set_span_error_from_headers(headers);
 
         assert_eq!(p.span.error, 1);
@@ -682,12 +691,19 @@ mod tests {
 
         let error_message = "Error message";
         let error_type = "System.Exception";
-        let error_stack = "System.Exception: Error message \n at TestFunction.Handle(ILambdaContext context)";
+        let error_stack =
+            "System.Exception: Error message \n at TestFunction.Handle(ILambdaContext context)";
 
         headers.insert(DATADOG_INVOCATION_ERROR_KEY.into(), "true".into());
-        headers.insert(DATADOG_INVOCATION_ERROR_MESSAGE_KEY.into(), error_message.into());
+        headers.insert(
+            DATADOG_INVOCATION_ERROR_MESSAGE_KEY.into(),
+            error_message.into(),
+        );
         headers.insert(DATADOG_INVOCATION_ERROR_TYPE_KEY.into(), error_type.into());
-        headers.insert(DATADOG_INVOCATION_ERROR_STACK_KEY.into(), error_stack.into());
+        headers.insert(
+            DATADOG_INVOCATION_ERROR_STACK_KEY.into(),
+            error_stack.into(),
+        );
 
         p.set_span_error_from_headers(headers);
 


### PR DESCRIPTION
### What does this PR do?
Decodes error.msg and error.type headers as was previously done for the error.stack header, because of https://github.com/DataDog/dd-trace-dotnet/pull/6438 encoding error.msg and error.type.

### Motivation
[\[SLES-2001\] .NET Datadog Tracer throws exception from AWS Lambda Function](https://datadoghq.atlassian.net/browse/SLES-2001)
[\[SVLS-6041\] Having non-ascii characters in a stack trace causes an exception within the tracer.](https://datadoghq.atlassian.net/browse/SVLS-6041)

### Testing
Tested with a lambda that throws an exception with an error message containing a non-ASCII character.
![image](https://github.com/user-attachments/assets/e017acd0-bd8e-49c0-9bf9-432c8f38130b)



[SLES-2001]: https://datadoghq.atlassian.net/browse/SLES-2001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SVLS-6041]: https://datadoghq.atlassian.net/browse/SVLS-6041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ