### PR TITLE
fix: turn headers serializer into a deserializer

### DIFF
--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_http_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_http_event.rs
@@ -16,7 +16,7 @@ use crate::lifecycle::invocation::{
 pub struct APIGatewayHttpEvent {
     #[serde(rename = "routeKey")]
     pub route_key: String,
-    #[serde(serialize_with = "lowercase_key")]
+    #[serde(deserialize_with = "lowercase_key")]
     pub headers: HashMap<String, String>,
     #[serde(rename = "requestContext")]
     pub request_context: RequestContext,

--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_rest_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_rest_event.rs
@@ -14,7 +14,7 @@ use crate::lifecycle::invocation::{
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct APIGatewayRestEvent {
-    #[serde(serialize_with = "lowercase_key")]
+    #[serde(deserialize_with = "lowercase_key")]
     pub headers: HashMap<String, String>,
     #[serde(rename = "requestContext")]
     pub request_context: RequestContext,
@@ -205,8 +205,8 @@ mod tests {
 
         let expected = APIGatewayRestEvent {
             headers: HashMap::from([
-                ("Header1".to_string(), "value1".to_string()),
-                ("Header2".to_string(), "value2".to_string()),
+                ("header1".to_string(), "value1".to_string()),
+                ("header2".to_string(), "value2".to_string()),
             ]),
             request_context: RequestContext {
                 stage: "$default".to_string(),

--- a/bottlecap/src/lifecycle/invocation/triggers/lambda_function_url_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/lambda_function_url_event.rs
@@ -11,7 +11,7 @@ use crate::lifecycle::invocation::{
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct LambdaFunctionUrlEvent {
-    #[serde(serialize_with = "lowercase_key")]
+    #[serde(deserialize_with = "lowercase_key")]
     pub headers: HashMap<String, String>,
     #[serde(rename = "requestContext")]
     pub request_context: RequestContext,

--- a/bottlecap/tests/payloads/api_gateway_http_event.json
+++ b/bottlecap/tests/payloads/api_gateway_http_event.json
@@ -4,17 +4,17 @@
     "rawPath": "/httpapi/get",
     "rawQueryString": "",
     "headers": {
-        "accept": "*/*",
-        "content-length": "0",
-        "host": "x02yirxc7a.execute-api.sa-east-1.amazonaws.com",
-        "user-agent": "curl/7.64.1",
-        "x-amzn-trace-id": "Root=1-613a52fb-4c43cfc95e0241c1471bfa05",
-        "x-forwarded-for": "38.122.226.210",
-        "x-forwarded-port": "443",
-        "x-forwarded-proto": "https",
-        "x-datadog-trace-id": "12345",
-        "x-datadog-parent-id": "67890",
-        "x-datadog-sampling-priority": "2"
+        "Accept": "*/*",
+        "Content-Length": "0",
+        "Host": "x02yirxc7a.execute-api.sa-east-1.amazonaws.com",
+        "User-Agent": "curl/7.64.1",
+        "X-amzn-trace-id": "Root=1-613a52fb-4c43cfc95e0241c1471bfa05",
+        "X-forwarded-for": "38.122.226.210",
+        "X-forwarded-port": "443",
+        "X-forwarded-proto": "https",
+        "X-datadog-trace-id": "12345",
+        "X-datadog-parent-id": "67890",
+        "X-datadog-sampling-priority": "2"
     },
     "requestContext": {
         "accountId": "425362996713",


### PR DESCRIPTION
# What?

Converts a serializer into a deserializer

# Motivation

I confused `serializer` with `deserializer`, so header keys were never lowercased, causing issues in trace propagation, because the propagator expects `x-datadog-trace-id`, but in some tracers, this data is sent as `X-Datadog-Trace-Id`, like the Ruby tracer.