### PR TITLE
fix: set right domain and arn by region on secrets manager

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -156,7 +156,13 @@ async fn register(client: &reqwest::Client) -> Result<RegisterResponse> {
 }
 
 fn build_function_arn(account_id: &str, region: &str, function_name: &str) -> String {
-    format!("arn:aws:lambda:{region}:{account_id}:function:{function_name}")
+    let arn_prefix = if region.starts_with("cn-") {
+        "aws-ch"
+    } else {
+        "aws"
+    };
+
+    format!("arn:{arn_prefix}:lambda:{region}:{account_id}:function:{function_name}")
 }
 
 #[tokio::main]

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -10,14 +10,8 @@
 #![deny(missing_debug_implementations)]
 
 use bottlecap::{
-    config::{
-        get_aws_partition_by_region,
-        self,
-        flush_strategy::FlushStrategy,
-        AwsConfig,
-        Config
-    },
     base_url,
+    config::{self, flush_strategy::FlushStrategy, get_aws_partition_by_region, AwsConfig, Config},
     event_bus::bus::EventBus,
     events::Event,
     lifecycle::{
@@ -50,16 +44,15 @@ use bottlecap::{
 use datadog_trace_obfuscation::obfuscation_config;
 use decrypt::resolve_secrets;
 use dogstatsd::{
-    metric::{SortedTags, EMPTY_TAGS},
     aggregator::Aggregator as MetricsAggregator,
     constants::CONTEXTS,
     dogstatsd::{DogStatsD, DogStatsDConfig},
-    flusher::{build_fqdn_metrics, Flusher as MetricsFlusher}
+    flusher::{build_fqdn_metrics, Flusher as MetricsFlusher},
+    metric::{SortedTags, EMPTY_TAGS},
 };
 use reqwest::Client;
 use serde::Deserialize;
 use std::{
-    time::Duration,
     collections::{hash_map, HashMap},
     env,
     io::{Error, Result},
@@ -67,13 +60,11 @@ use std::{
     path::Path,
     process::Command,
     sync::{Arc, Mutex},
-    time::Instant
+    time::Duration,
+    time::Instant,
 };
 use telemetry::listener::TelemetryListenerConfig;
-use tokio::{
-    sync::mpsc::Sender,
-    sync::Mutex as TokioMutex
-};
+use tokio::{sync::mpsc::Sender, sync::Mutex as TokioMutex};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error};
 use tracing_subscriber::EnvFilter;

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -157,7 +157,7 @@ async fn register(client: &reqwest::Client) -> Result<RegisterResponse> {
 
 fn build_function_arn(account_id: &str, region: &str, function_name: &str) -> String {
     let arn_prefix = if region.starts_with("cn-") {
-        "aws-ch"
+        "aws-cn"
     } else {
         "aws"
     };

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -9,10 +9,15 @@
 #![deny(missing_copy_implementations)]
 #![deny(missing_debug_implementations)]
 
-use bottlecap::config::get_aws_partition_by_region;
 use bottlecap::{
+    config::{
+        get_aws_partition_by_region,
+        self,
+        flush_strategy::FlushStrategy,
+        AwsConfig,
+        Config
+    },
     base_url,
-    config::{self, flush_strategy::FlushStrategy, AwsConfig, Config},
     event_bus::bus::EventBus,
     events::Event,
     lifecycle::{
@@ -44,17 +49,17 @@ use bottlecap::{
 };
 use datadog_trace_obfuscation::obfuscation_config;
 use decrypt::resolve_secrets;
-use dogstatsd::metric::{SortedTags, EMPTY_TAGS};
 use dogstatsd::{
+    metric::{SortedTags, EMPTY_TAGS},
     aggregator::Aggregator as MetricsAggregator,
     constants::CONTEXTS,
     dogstatsd::{DogStatsD, DogStatsDConfig},
-    flusher::{build_fqdn_metrics, Flusher as MetricsFlusher},
+    flusher::{build_fqdn_metrics, Flusher as MetricsFlusher}
 };
 use reqwest::Client;
 use serde::Deserialize;
-use std::time::Duration;
 use std::{
+    time::Duration,
     collections::{hash_map, HashMap},
     env,
     io::{Error, Result},
@@ -62,11 +67,13 @@ use std::{
     path::Path,
     process::Command,
     sync::{Arc, Mutex},
-    time::Instant,
+    time::Instant
 };
 use telemetry::listener::TelemetryListenerConfig;
-use tokio::sync::mpsc::Sender;
-use tokio::sync::Mutex as TokioMutex;
+use tokio::{
+    sync::mpsc::Sender,
+    sync::Mutex as TokioMutex
+};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error};
 use tracing_subscriber::EnvFilter;

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -9,6 +9,7 @@
 #![deny(missing_copy_implementations)]
 #![deny(missing_debug_implementations)]
 
+use bottlecap::config::get_aws_partition_by_region;
 use bottlecap::{
     base_url,
     config::{self, flush_strategy::FlushStrategy, AwsConfig, Config},
@@ -156,13 +157,8 @@ async fn register(client: &reqwest::Client) -> Result<RegisterResponse> {
 }
 
 fn build_function_arn(account_id: &str, region: &str, function_name: &str) -> String {
-    let arn_prefix = if region.starts_with("cn-") {
-        "aws-cn"
-    } else {
-        "aws"
-    };
-
-    format!("arn:{arn_prefix}:lambda:{region}:{account_id}:function:{function_name}")
+    let aws_partition = get_aws_partition_by_region(region);
+    format!("arn:{aws_partition}:lambda:{region}:{account_id}:function:{function_name}")
 }
 
 #[tokio::main]

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -311,6 +311,15 @@ pub struct AwsConfig {
     pub sandbox_init_time: Instant,
 }
 
+#[must_use]
+pub fn get_aws_partition_by_region(region: &str) -> String {
+    match region {
+        r if r.starts_with("us-gov-") => "aws-us-gov".to_string(),
+        r if r.starts_with("cn-") => "aws-cn".to_string(),
+        _ => "aws".to_string(),
+    }
+}
+
 #[cfg(test)]
 pub mod tests {
     use super::*;

--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_http_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_http_event.rs
@@ -1,13 +1,13 @@
-use datadog_trace_protobuf::pb::Span;
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
-use std::collections::HashMap;
-use tracing::debug;
 use crate::config::get_aws_partition_by_region;
 use crate::lifecycle::invocation::{
     processor::MS_TO_NS,
     triggers::{lowercase_key, ServiceNameResolver, Trigger, FUNCTION_TRIGGER_EVENT_SOURCE_TAG},
 };
+use datadog_trace_protobuf::pb::Span;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use tracing::debug;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct APIGatewayHttpEvent {

--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_http_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_http_event.rs
@@ -1,13 +1,13 @@
-use crate::config::get_aws_partition_by_region;
-use crate::lifecycle::invocation::{
-    processor::MS_TO_NS,
-    triggers::{lowercase_key, ServiceNameResolver, Trigger, FUNCTION_TRIGGER_EVENT_SOURCE_TAG},
-};
 use datadog_trace_protobuf::pb::Span;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use tracing::debug;
+use crate::config::get_aws_partition_by_region;
+use crate::lifecycle::invocation::{
+    processor::MS_TO_NS,
+    triggers::{lowercase_key, ServiceNameResolver, Trigger, FUNCTION_TRIGGER_EVENT_SOURCE_TAG},
+};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct APIGatewayHttpEvent {

--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_http_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_http_event.rs
@@ -1,16 +1,13 @@
+use crate::config::get_aws_partition_by_region;
+use crate::lifecycle::invocation::{
+    processor::MS_TO_NS,
+    triggers::{lowercase_key, ServiceNameResolver, Trigger, FUNCTION_TRIGGER_EVENT_SOURCE_TAG},
+};
 use datadog_trace_protobuf::pb::Span;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use tracing::debug;
-
-use crate::lifecycle::invocation::{
-    processor::MS_TO_NS,
-    triggers::{
-        get_aws_partition_by_region, lowercase_key, ServiceNameResolver, Trigger,
-        FUNCTION_TRIGGER_EVENT_SOURCE_TAG,
-    },
-};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct APIGatewayHttpEvent {

--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_rest_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_rest_event.rs
@@ -1,13 +1,13 @@
-use datadog_trace_protobuf::pb::Span;
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
-use std::collections::HashMap;
-use tracing::debug;
 use crate::config::get_aws_partition_by_region;
 use crate::lifecycle::invocation::{
     processor::MS_TO_NS,
     triggers::{lowercase_key, ServiceNameResolver, Trigger, FUNCTION_TRIGGER_EVENT_SOURCE_TAG},
 };
+use datadog_trace_protobuf::pb::Span;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use tracing::debug;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct APIGatewayRestEvent {

--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_rest_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_rest_event.rs
@@ -1,16 +1,13 @@
+use crate::config::get_aws_partition_by_region;
+use crate::lifecycle::invocation::{
+    processor::MS_TO_NS,
+    triggers::{lowercase_key, ServiceNameResolver, Trigger, FUNCTION_TRIGGER_EVENT_SOURCE_TAG},
+};
 use datadog_trace_protobuf::pb::Span;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use tracing::debug;
-
-use crate::lifecycle::invocation::{
-    processor::MS_TO_NS,
-    triggers::{
-        get_aws_partition_by_region, lowercase_key, ServiceNameResolver, Trigger,
-        FUNCTION_TRIGGER_EVENT_SOURCE_TAG,
-    },
-};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct APIGatewayRestEvent {

--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_rest_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_rest_event.rs
@@ -1,13 +1,13 @@
-use crate::config::get_aws_partition_by_region;
-use crate::lifecycle::invocation::{
-    processor::MS_TO_NS,
-    triggers::{lowercase_key, ServiceNameResolver, Trigger, FUNCTION_TRIGGER_EVENT_SOURCE_TAG},
-};
 use datadog_trace_protobuf::pb::Span;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use tracing::debug;
+use crate::config::get_aws_partition_by_region;
+use crate::lifecycle::invocation::{
+    processor::MS_TO_NS,
+    triggers::{lowercase_key, ServiceNameResolver, Trigger, FUNCTION_TRIGGER_EVENT_SOURCE_TAG},
+};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct APIGatewayRestEvent {

--- a/bottlecap/src/lifecycle/invocation/triggers/mod.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/mod.rs
@@ -57,15 +57,6 @@ pub trait Trigger: ServiceNameResolver {
     }
 }
 
-#[must_use]
-pub fn get_aws_partition_by_region(region: &str) -> String {
-    match region {
-        r if r.starts_with("us-gov-") => "aws-us-gov".to_string(),
-        r if r.starts_with("cn-") => "aws-cn".to_string(),
-        _ => "aws".to_string(),
-    }
-}
-
 /// Serialize a `HashMap` with lowercase keys
 ///
 pub fn lowercase_key<'de, D, V>(deserializer: D) -> Result<HashMap<String, V>, D::Error>

--- a/bottlecap/src/lifecycle/invocation/triggers/sqs_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/sqs_event.rs
@@ -1,19 +1,18 @@
-use datadog_trace_protobuf::pb::Span;
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
-use std::collections::HashMap;
-use tracing::debug;
-
+use crate::config::get_aws_partition_by_region;
 use crate::lifecycle::invocation::{
     processor::MS_TO_NS,
     triggers::{
         event_bridge_event::EventBridgeEvent,
-        get_aws_partition_by_region,
         sns_event::{SnsEntity, SnsRecord},
         ServiceNameResolver, Trigger, DATADOG_CARRIER_KEY, FUNCTION_TRIGGER_EVENT_SOURCE_TAG,
     },
 };
 use crate::traces::context::{Sampling, SpanContext};
+use datadog_trace_protobuf::pb::Span;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use tracing::debug;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct SqsEvent {

--- a/bottlecap/src/secrets/decrypt.rs
+++ b/bottlecap/src/secrets/decrypt.rs
@@ -170,10 +170,14 @@ fn build_get_secret_signed_headers(
 ) -> Result<HeaderMap, Box<dyn std::error::Error>> {
     let amz_date = header_values.time.format("%Y%m%dT%H%M%SZ").to_string();
     let date_stamp = header_values.time.format("%Y%m%d").to_string();
-    let host = format!(
-        "{}.{}.amazonaws.com",
-        header_values.service, aws_config.region
-    );
+
+    let domain = if aws_config.region.starts_with("cn-") {
+        "amazonaws.com.cn"
+    } else {
+        "amazonaws.com"
+    };
+
+    let host = format!("{}.{}.{}", header_values.service, aws_config.region, domain);
 
     let canonical_uri = "/";
     let canonical_querystring = "";


### PR DESCRIPTION
Addressing bug report https://github.com/DataDog/datadog-lambda-extension/issues/508

As per AWS doc https://aws.amazon.com/blogs/enterprise-strategy/getting-started-with-aws-services-in-aws-china-beijing-region-and-aws-china-ningxia-region/ the AWS regions in China have different domain and arn

>- AWS China Regions names are as follows. Beijing: cn-north-1; Ningxia: cn-northwest-1.
>- In AWS China Regions, the Amazon Resource Name (ARN) syntax includes a cn. For example: arn:aws-cn:iam::123456789012:user/division_abc/subdivision_xyz/Bob.


the domain in ARN for the services should be `amazonaws.com.cn` as per doc
https://docs.amazonaws.cn/en_us/aws/latest/userguide/endpoints-Beijing.html
https://docs.amazonaws.cn/en_us/aws/latest/userguide/endpoints-Ningxia.html
