### PR TITLE
Add _dd.tags.function to top level trace tags hashmap.

### DIFF
--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -44,6 +44,8 @@ const SERVICE_KEY: &str = "service";
 const COMPUTE_STATS_KEY: &str = "_dd.compute_stats";
 // ComputeStatsValue is the tag value indicating trace stats should be computed
 const COMPUTE_STATS_VALUE: &str = "1";
+// FunctionTagsKey is the tag key for a function's tags to be set on the top level tracepayload
+const FUNCTION_TAGS_KEY: &str = "_dd.tags.function";
 // TODO(astuyve) decide what to do with the version
 const EXTENSION_VERSION_KEY: &str = "dd_extension_version";
 // TODO(duncanista) figure out a better way to not hardcode this
@@ -248,6 +250,17 @@ impl Lambda {
     #[must_use]
     pub fn get_tags_map(&self) -> &hash_map::HashMap<String, String> {
         &self.tags_map
+    }
+
+    #[must_use]
+    pub fn get_function_tags_map(&self) -> hash_map::HashMap<String, String> {
+        let tags = self
+            .tags_map
+            .iter()
+            .map(|(k, v)| format!("{k}:{v}"))
+            .collect::<Vec<String>>()
+            .join(",");
+        hash_map::HashMap::from_iter([(FUNCTION_TAGS_KEY.to_string(), tags)])
     }
 }
 

--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -384,4 +384,43 @@ mod tests {
         fs::remove_file(path).unwrap();
         assert_eq!(runtime, "provided.al2023");
     }
+
+    #[test]
+    fn test_get_function_tags_map() {
+        let mut metadata = hash_map::HashMap::new();
+        metadata.insert(
+            FUNCTION_ARN_KEY.to_string(),
+            "arn:aws:lambda:us-west-2:123456789012:function:my-function".to_string(),
+        );
+        let config = Arc::new(Config {
+            service: Some("my-service".to_string()),
+            tags: Some("key1:value1,key2:value2".to_string()),
+            env: Some("test".to_string()),
+            version: Some("1.0.0".to_string()),
+            ..Config::default()
+        });
+        let tags = Lambda::new_from_config(config, &metadata);
+        let function_tags = tags.get_function_tags_map();
+        assert_eq!(function_tags.len(), 1);
+        let fn_tags_map: hash_map::HashMap<String, String> = hash_map::HashMap::from_iter(
+            function_tags
+                .get(FUNCTION_TAGS_KEY)
+                .unwrap()
+                .split(',')
+                .map(|tag| {
+                    let parts = tag.split(':').collect::<Vec<&str>>();
+                    (parts[0].to_string(), parts[1].to_string())
+                }),
+        );
+        assert_eq!(fn_tags_map.len(), 14);
+        assert_eq!(fn_tags_map.get("key1").unwrap(), "value1");
+        assert_eq!(fn_tags_map.get("key2").unwrap(), "value2");
+        assert_eq!(fn_tags_map.get(ACCOUNT_ID_KEY).unwrap(), "123456789012");
+        assert_eq!(fn_tags_map.get(ENV_KEY).unwrap(), "test");
+        assert_eq!(fn_tags_map.get(FUNCTION_ARN_KEY).unwrap(), "arn");
+        assert_eq!(fn_tags_map.get(FUNCTION_NAME_KEY).unwrap(), "my-function");
+        assert_eq!(fn_tags_map.get(REGION_KEY).unwrap(), "us-west-2");
+        assert_eq!(fn_tags_map.get(SERVICE_KEY).unwrap(), "my-service");
+        assert_eq!(fn_tags_map.get(VERSION_KEY).unwrap(), "1.0.0");
+    }
 }

--- a/bottlecap/src/tags/provider.rs
+++ b/bottlecap/src/tags/provider.rs
@@ -56,6 +56,11 @@ impl Provider {
     pub fn get_tags_map(&self) -> &hash_map::HashMap<String, String> {
         self.tag_provider.get_tags_map()
     }
+
+    #[must_use]
+    pub fn get_function_tags_map(&self) -> hash_map::HashMap<String, String> {
+        self.tag_provider.get_function_tags_map()
+    }
 }
 
 trait GetTags {
@@ -63,6 +68,7 @@ trait GetTags {
     fn get_canonical_id(&self) -> Option<String>;
     fn get_canonical_resource_name(&self) -> Option<String>;
     fn get_tags_map(&self) -> &hash_map::HashMap<String, String>;
+    fn get_function_tags_map(&self) -> hash_map::HashMap<String, String>;
 }
 
 impl GetTags for TagProvider {
@@ -87,6 +93,12 @@ impl GetTags for TagProvider {
     fn get_tags_map(&self) -> &hash_map::HashMap<String, String> {
         match self {
             TagProvider::Lambda(lambda_tags) => lambda_tags.get_tags_map(),
+        }
+    }
+
+    fn get_function_tags_map(&self) -> hash_map::HashMap<String, String> {
+        match self {
+            TagProvider::Lambda(lambda_tags) => lambda_tags.get_function_tags_map(),
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?

Adds all global tags to the top level trace tags hash map.

Working in conjunction with the apm-trace-intake team, intake will ensure that these tags are placed onto all spans in the trace and then are made available for our usage metric.

### Motivation

Part of the [usage metrics tagging](https://docs.google.com/document/d/18MYBXj2ugcaWlLUms8J0qBXN57Ct354YJM5y09XSUhw/edit?tab=t.0#heading=h.hn9uiefsp3ng) which will allow us to include more tags (including custom tags) on the `datadog.serverless.traced_invocations` metric.

### Additional Notes

Note that this change will duplicate the location of the global tags in the trace payload sent to intake. Currently, these payloads look like

```
TracePayload {
  ...
  Chunk {
    ...
    Span {
      ...
      Meta {
        ...
        "key1": "value1",
        "key2": "value2",
        "key3": "value3"
      }
    }
  }
  Tags {}
}
```

After this change they will look like

```
TracePayload {
  ...
  Chunk {
    ...
    Span {
      ...
      Meta {
        ...
        "key1": "value1",
        "key2": "value2",
        "key3": "value3"
      }
    }
  }
  Tags {
    "_dd.tags.function": "key1:value1,key2:value2,key3:value3"
  }
}
```

Once the changes are in place in intake, we can remove the tags from the spans themselves. The intake pipeline will manage unpacking and copying these tags for us, at which point trace payloads will look like

```
TracePayload {
  ...
  Chunk {
    ...
    Span {
      ...
      Meta {
        ...
      }
    }
  }
  Tags {
    "_dd.tags.function": "key1:value1,key2:value2,key3:value3"
  }
}
```