### PR TITLE
fix: traces success response to be Ok instead of Accepted

### DIFF
--- a/bottlecap/src/traces/trace_agent.rs
+++ b/bottlecap/src/traces/trace_agent.rs
@@ -14,7 +14,9 @@ use tracing::{debug, error};
 use crate::config;
 use crate::tags::provider;
 use crate::traces::{stats_flusher, stats_processor, trace_flusher, trace_processor};
-use datadog_trace_mini_agent::http_utils::{self, log_and_create_http_response, log_and_create_traces_success_http_response};
+use datadog_trace_mini_agent::http_utils::{
+    self, log_and_create_http_response, log_and_create_traces_success_http_response,
+};
 use datadog_trace_protobuf::pb;
 use datadog_trace_utils::trace_utils::{self, SendData};
 

--- a/bottlecap/src/traces/trace_agent.rs
+++ b/bottlecap/src/traces/trace_agent.rs
@@ -14,7 +14,7 @@ use tracing::{debug, error};
 use crate::config;
 use crate::tags::provider;
 use crate::traces::{stats_flusher, stats_processor, trace_flusher, trace_processor};
-use datadog_trace_mini_agent::http_utils::{self, log_and_create_http_response};
+use datadog_trace_mini_agent::http_utils::{self, log_and_create_http_response, log_and_create_traces_success_http_response};
 use datadog_trace_protobuf::pb;
 use datadog_trace_utils::trace_utils::{self, SendData};
 
@@ -263,9 +263,9 @@ impl TraceAgent {
 
         // send trace payload to our trace flusher
         match trace_tx.send(send_data).await {
-            Ok(()) => log_and_create_http_response(
+            Ok(()) => log_and_create_traces_success_http_response(
                 "Successfully buffered traces to be flushed.",
-                StatusCode::ACCEPTED,
+                StatusCode::OK,
             ),
             Err(err) => log_and_create_http_response(
                 &format!("Error sending traces to the trace flusher: {err}"),


### PR DESCRIPTION
# What does this PR do?

- Updates the trace success response to report a 200 Ok status code instead of 202 Accepted status code
- Returns a `"rate_by_service"` map to satisfy this requirement by the tracer.

# Motivation
[Excessive warn logs reported by customer](https://github.com/DataDog/datadog-lambda-extension/issues/510)

# Additional Notes
The Java Tracer was sending warn logs because it expects a response status code of 200 on success:
```
{"message":"Successfully buffered traces to be flushed."} while sending 1 (size=2KB) traces. Total: 22, Received: 22, Sent: 0, Failed: 22. Status: 202 Accepted (Will not log warnings for 5 minutes)
```
After updating the status code, the Java tracer was sending an error since the success response body contains a `message` attribute instead of `rate_by_service`:
```
[dd.trace 2025-01-17 22:48:37:287 +0000] [dd-trace-processor] ERROR datadog.trace.agent.common.writer.TraceProcessingWorker$DaemonTraceSerializingHandler - Uncaught exception com.squareup.moshi.JsonDataException: Expected BEGIN_OBJECT but was STRING at path $.message in dd-trace-processor
```
Changing the response body to `{"rate_by_service":{"service:,env:":1}` fixed this error. 
- This sets a default per-service sampling rate, which should not impact Lambda as [ddtrace is already treating lambda as its own service](https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/2992540687/Serverless+Trace+Sampling#:~:text=Why%20does%20this,its%20own%20service.)

A similar issue was encountered earlier with Azure Spring Apps - https://github.com/DataDog/libdatadog/pull/547
