### PR TITLE
fix: Honor noproxy and skip proxying if ddsite is in the noproxy list

### DIFF
--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -529,6 +529,33 @@ pub mod tests {
     }
 
     #[test]
+    fn test_proxy_config() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+            jail.set_env("DD_PROXY_HTTPS", "my-proxy:3128");
+            let config = get_config(Path::new("")).expect("should parse config");
+            assert_eq!(config.https_proxy, Some("my-proxy:3128".to_string()));
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_noproxy_config() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+            jail.set_env("DD_SITE", "datadoghq.eu");
+            jail.set_env("DD_PROXY_HTTPS", "my-proxy:3128");
+            jail.set_env(
+                "NO_PROXY",
+                "127.0.0.1,localhost,172.16.0.0/12,us-east-1.amazonaws.com,datadoghq.eu",
+            );
+            let config = get_config(Path::new("")).expect("should parse noproxy");
+            assert_eq!(config.https_proxy, None);
+            Ok(())
+        });
+    }
+
+    #[test]
     fn test_parse_flush_strategy_end() {
         figment::Jail::expect_with(|jail| {
             jail.clear_env();

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -261,11 +261,12 @@ pub fn get_config(config_directory: &Path) -> Result<Config, ConfigError> {
     if config.site.is_empty() {
         config.site = "datadoghq.com".to_string();
     }
-    if let Ok(no_proxy_string) = std::env::var("NO_PROXY") {
-        if no_proxy_string.contains(&config.site) {
-            debug!("NO_PROXY contains DD_SITE, disabling proxy");
-            config.https_proxy = None;
-        }
+    // TODO(astuyve)
+    // Bit of a hack as we're not checking individual privatelink setups
+    // potentially a user could use the proxy for logs and privatelink for APM
+    if std::env::var("NO_PROXY").map_or(false, |no_proxy| no_proxy.contains(&config.site)) {
+        debug!("NO_PROXY contains DD_SITE, disabling proxy");
+        config.https_proxy = None;
     }
     // Merge YAML nested fields
     //


### PR DESCRIPTION
Fixes #514 by checking if NO_PROXY contains DD_SITE domain, and the the user is likely relying on privatelink endpoints + private DNS isntead of an HTTP proxy for telemetry data.

This is kind of a hack in 2 ways:
1. `reqwest` has some support for NO_PROXY but `hyper-proxy` doesn't. I could use the built in version, but either way I'd need to build it myself
2. We simply pass a proxy string to libdatadog for APM + statsd, we don't actually pass config anywhere. So we'd have to add that.

This solution works for the customer reporting it, as their NO_PROXY string includes `datadoghq.com`.

But I wonder if there's a use case for a customer who would use privatelink for, say metrics only - but then use an HTTP proxy for logs (perhaps to inspect logs for PII or some other form of compliance).

In that case our entire shared http client architecture (complete with shared threadpools) would need to change. I think we should leave that for the future at this time, and help our friends in #514 move on.


Screenshots of my config:
<img width="887" alt="image" src="https://github.com/user-attachments/assets/3fa25f74-b928-4f1d-8a9d-ddf245d2c616" />

VPC endpoints as per our [docs](https://docs.datadoghq.com/agent/guide/private-link/?tab=connectfromsameregion):
<img width="1802" alt="image" src="https://github.com/user-attachments/assets/9fbb8d8f-c050-487e-9412-73efff00b0f9" />

Logs/metrics/traces:
<img width="2305" alt="image" src="https://github.com/user-attachments/assets/02f34ff4-46fc-4777-820d-a3832df94ff7" />
<img width="2327" alt="image" src="https://github.com/user-attachments/assets/b137dc91-5060-4266-bf18-4a51d162d405" />
<img width="1858" alt="image" src="https://github.com/user-attachments/assets/24993980-96a1-4fb0-b4b6-6cd9b006bfd6" />
