### PR TITLE
Elevate permissions to write packages for release-serverless-init.yml

### DIFF
--- a/.github/workflows/release-serverless-init.yml
+++ b/.github/workflows/release-serverless-init.yml
@@ -35,6 +35,9 @@ env:
 jobs:
   release-serverless-init:
     runs-on: ubuntu-22.04
+    permissions:
+      packages: write
+      contents: write
     strategy:
       matrix:
         arrays: [

--- a/.github/workflows/release-serverless-init.yml
+++ b/.github/workflows/release-serverless-init.yml
@@ -37,7 +37,6 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       packages: write
-      contents: write
     strategy:
       matrix:
         arrays: [


### PR DESCRIPTION
Adds write permissions for packages and content for release-serverless-init.yml 
Based on [VULN-8322](https://datadoghq.atlassian.net/browse/VULN-8322?atlOrigin=eyJpIjoiMTBiNzNmZjRkM2VjNDdmMWFkODFhYzNiMWQyYjM0MDQiLCJwIjoiaiJ9) repo update

[VULN-8322]: https://datadoghq.atlassian.net/browse/VULN-8322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
tested [here](https://github.com/DataDog/datadog-lambda-extension/actions/runs/12992195548) successfully 