### PR TITLE
feat: add an Aggregator for Traces and Stats

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -433,6 +433,7 @@ dependencies = [
  "log",
  "nix",
  "proptest",
+ "prost 0.11.9",
  "protobuf",
  "rand",
  "regex",

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -39,6 +39,7 @@ base64 = { version = "0.22", default-features = false }
 rmp-serde = { version = "1.3.0", default-features = false }
 rustls = { version = "0.23.18", default-features = false, features = ["aws-lc-rs"] }
 rand = { version = "0.8", default-features = false }
+prost = { version = "0.11.6", default-features = false }
 
 [dev-dependencies]
 figment = { version = "0.10", default-features = false, features = ["yaml", "env", "test"] }

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -432,8 +432,8 @@ async fn extension_loop_active(
                                         tokio::join!(
                                             logs_flusher.flush(),
                                             metrics_flusher.flush(),
-                                            trace_flusher.manual_flush(),
-                                            stats_flusher.manual_flush()
+                                            trace_flusher.flush(),
+                                            stats_flusher.flush()
                                         );
                                     }
 
@@ -468,8 +468,8 @@ async fn extension_loop_active(
                     tokio::join!(
                         logs_flusher.flush(),
                         metrics_flusher.flush(),
-                        trace_flusher.manual_flush(),
-                        stats_flusher.manual_flush()
+                        trace_flusher.flush(),
+                        stats_flusher.flush()
                     );
                     if matches!(flush_control.flush_strategy, FlushStrategy::Periodically(_)) {
                         break;
@@ -484,8 +484,8 @@ async fn extension_loop_active(
             tokio::join!(
                 logs_flusher.flush(),
                 metrics_flusher.flush(),
-                trace_flusher.manual_flush(),
-                stats_flusher.manual_flush()
+                trace_flusher.flush(),
+                stats_flusher.flush()
             );
             return Ok(());
         }

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -43,7 +43,6 @@ use bottlecap::{
     LAMBDA_RUNTIME_SLUG, TELEMETRY_PORT,
 };
 use datadog_trace_obfuscation::obfuscation_config;
-use datadog_trace_protobuf::pb;
 use decrypt::resolve_secrets;
 use dogstatsd::{
     aggregator::Aggregator as MetricsAggregator,
@@ -543,9 +542,7 @@ fn start_trace_agent(
     Arc<stats_flusher::ServerlessStatsFlusher>,
 ) {
     // Stats
-    let stats_aggregator = Arc::new(TokioMutex::new(
-        StatsAggregator::<pb::ClientStatsPayload>::default(),
-    ));
+    let stats_aggregator = Arc::new(TokioMutex::new(StatsAggregator::default()));
     let stats_flusher = Arc::new(stats_flusher::ServerlessStatsFlusher::new(
         resolved_api_key.clone(),
         stats_aggregator.clone(),

--- a/bottlecap/src/logs/aggregator.rs
+++ b/bottlecap/src/logs/aggregator.rs
@@ -36,7 +36,7 @@ impl Aggregator {
             max_batch_entries_size,
             max_content_size_bytes,
             max_log_size_bytes,
-            buffer: Vec::with_capacity(max_batch_entries_size),
+            buffer: Vec::with_capacity(max_content_size_bytes),
         }
     }
 

--- a/bottlecap/src/traces/aggregator.rs
+++ b/bottlecap/src/traces/aggregator.rs
@@ -1,0 +1,54 @@
+use prost::Message;
+use std::collections::VecDeque;
+
+#[allow(clippy::module_name_repetitions)]
+pub struct MessageAggregator<T>
+where
+    T: Message,
+{
+    queue: VecDeque<T>,
+    max_content_size_bytes: usize,
+    buffer: Vec<T>,
+}
+
+impl<T> MessageAggregator<T>
+where
+    T: Message,
+{
+    #[allow(dead_code)]
+    #[allow(clippy::must_use_candidate)]
+    pub fn new(max_content_size_bytes: usize) -> Self {
+        MessageAggregator {
+            queue: VecDeque::new(),
+            max_content_size_bytes,
+            buffer: Vec::with_capacity(max_content_size_bytes),
+        }
+    }
+
+    pub fn add(&mut self, message: T) {
+        self.queue.push_back(message);
+    }
+
+    pub fn get_batch(&mut self) -> Vec<T> {
+        let mut batch_size = 0;
+
+        // Fill the batch
+        while batch_size < self.max_content_size_bytes {
+            if let Some(message) = self.queue.pop_front() {
+                let message_size = message.encoded_len();
+
+                // Put stats back in the queue
+                if batch_size + message_size > self.max_content_size_bytes {
+                    self.queue.push_front(message);
+                    break;
+                }
+                batch_size += message_size;
+                self.buffer.push(message);
+            } else {
+                break;
+            }
+        }
+
+        std::mem::take(&mut self.buffer)
+    }
+}

--- a/bottlecap/src/traces/mod.rs
+++ b/bottlecap/src/traces/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod aggregator;
 pub mod context;
 pub mod propagation;
 pub mod span_pointers;
@@ -30,3 +31,9 @@ const AWS_XRAY_DAEMON_ADDRESS_URL_PREFIX: &str = "169.254.79.129";
 
 // Name of the placeholder invocation span set by Java and Go tracers
 const INVOCATION_SPAN_RESOURCE: &str = "dd-tracer-serverless-span";
+
+/// Maximum content size per payload uncompressed in bytes,
+/// that the Datadog Trace API accepts. The value is 3.2 MB.
+///
+/// <https://github.com/DataDog/datadog-agent/blob/9d57c10a9eeb3916e661d35dbd23c6e36395a99d/pkg/trace/writer/trace.go#L27-L31>
+pub const MAX_CONTENT_SIZE_BYTES: usize = (32 * 1_024 * 1_024) / 10;

--- a/bottlecap/src/traces/mod.rs
+++ b/bottlecap/src/traces/mod.rs
@@ -1,13 +1,14 @@
 // Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod aggregator;
 pub mod context;
 pub mod propagation;
 pub mod span_pointers;
+pub mod stats_aggregator;
 pub mod stats_flusher;
 pub mod stats_processor;
 pub mod trace_agent;
+pub mod trace_aggregator;
 pub mod trace_flusher;
 pub mod trace_processor;
 
@@ -31,9 +32,3 @@ const AWS_XRAY_DAEMON_ADDRESS_URL_PREFIX: &str = "169.254.79.129";
 
 // Name of the placeholder invocation span set by Java and Go tracers
 const INVOCATION_SPAN_RESOURCE: &str = "dd-tracer-serverless-span";
-
-/// Maximum content size per payload uncompressed in bytes,
-/// that the Datadog Trace API accepts. The value is 3.2 MB.
-///
-/// <https://github.com/DataDog/datadog-agent/blob/9d57c10a9eeb3916e661d35dbd23c6e36395a99d/pkg/trace/writer/trace.go#L27-L31>
-pub const MAX_CONTENT_SIZE_BYTES: usize = (32 * 1_024 * 1_024) / 10;

--- a/bottlecap/src/traces/stats_aggregator.rs
+++ b/bottlecap/src/traces/stats_aggregator.rs
@@ -1,3 +1,4 @@
+use datadog_trace_protobuf::pb::ClientStatsPayload;
 use prost::Message;
 use std::collections::VecDeque;
 
@@ -17,19 +18,13 @@ use std::collections::VecDeque;
 const MAX_CONTENT_SIZE_BYTES: usize = 3 * 1024 * 1024; // ~3MB
 
 #[allow(clippy::module_name_repetitions)]
-pub struct StatsAggregator<T>
-where
-    T: Message,
-{
-    queue: VecDeque<T>,
+pub struct StatsAggregator {
+    queue: VecDeque<ClientStatsPayload>,
     max_content_size_bytes: usize,
-    buffer: Vec<T>,
+    buffer: Vec<ClientStatsPayload>,
 }
 
-impl<T> Default for StatsAggregator<T>
-where
-    T: Message,
-{
+impl Default for StatsAggregator {
     fn default() -> Self {
         StatsAggregator {
             queue: VecDeque::new(),
@@ -39,10 +34,7 @@ where
     }
 }
 
-impl<T> StatsAggregator<T>
-where
-    T: Message,
-{
+impl StatsAggregator {
     #[allow(dead_code)]
     #[allow(clippy::must_use_candidate)]
     pub fn new(max_content_size_bytes: usize) -> Self {
@@ -53,11 +45,11 @@ where
         }
     }
 
-    pub fn add(&mut self, message: T) {
+    pub fn add(&mut self, message: ClientStatsPayload) {
         self.queue.push_back(message);
     }
 
-    pub fn get_batch(&mut self) -> Vec<T> {
+    pub fn get_batch(&mut self) -> Vec<ClientStatsPayload> {
         let mut batch_size = 0;
 
         // Fill the batch

--- a/bottlecap/src/traces/stats_flusher.rs
+++ b/bottlecap/src/traces/stats_flusher.rs
@@ -8,10 +8,9 @@ use tokio::sync::Mutex;
 use tracing::{debug, error};
 
 use crate::config;
-use crate::traces::aggregator::MessageAggregator as StatsAggregator;
+use crate::traces::stats_aggregator::StatsAggregator;
 use datadog_trace_protobuf::pb;
-use datadog_trace_utils::config_utils::trace_stats_url;
-use datadog_trace_utils::stats_utils;
+use datadog_trace_utils::{config_utils::trace_stats_url, stats_utils};
 use ddcommon::Endpoint;
 
 #[async_trait]

--- a/bottlecap/src/traces/stats_flusher.rs
+++ b/bottlecap/src/traces/stats_flusher.rs
@@ -17,7 +17,7 @@ use ddcommon::Endpoint;
 pub trait StatsFlusher {
     fn new(
         api_key: String,
-        aggregator: Arc<Mutex<StatsAggregator<pb::ClientStatsPayload>>>,
+        aggregator: Arc<Mutex<StatsAggregator>>,
         config: Arc<config::Config>,
     ) -> Self
     where
@@ -32,7 +32,7 @@ pub trait StatsFlusher {
 #[derive(Clone)]
 pub struct ServerlessStatsFlusher {
     // pub buffer: Arc<Mutex<Vec<pb::ClientStatsPayload>>>,
-    aggregator: Arc<Mutex<StatsAggregator<pb::ClientStatsPayload>>>,
+    aggregator: Arc<Mutex<StatsAggregator>>,
     config: Arc<config::Config>,
     endpoint: Endpoint,
 }
@@ -41,7 +41,7 @@ pub struct ServerlessStatsFlusher {
 impl StatsFlusher for ServerlessStatsFlusher {
     fn new(
         api_key: String,
-        aggregator: Arc<Mutex<StatsAggregator<pb::ClientStatsPayload>>>,
+        aggregator: Arc<Mutex<StatsAggregator>>,
         config: Arc<config::Config>,
     ) -> Self {
         let stats_url = trace_stats_url(&config.site);

--- a/bottlecap/src/traces/trace_agent.rs
+++ b/bottlecap/src/traces/trace_agent.rs
@@ -33,7 +33,7 @@ pub const MAX_CONTENT_LENGTH: usize = 10 * 1024 * 1024;
 pub struct TraceAgent {
     pub config: Arc<config::Config>,
     pub trace_processor: Arc<dyn trace_processor::TraceProcessor + Send + Sync>,
-    pub stats_aggregator: Arc<Mutex<stats_aggregator::StatsAggregator<pb::ClientStatsPayload>>>,
+    pub stats_aggregator: Arc<Mutex<stats_aggregator::StatsAggregator>>,
     pub stats_processor: Arc<dyn stats_processor::StatsProcessor + Send + Sync>,
     pub tags_provider: Arc<provider::Provider>,
     tx: Sender<SendData>,
@@ -52,7 +52,7 @@ impl TraceAgent {
         config: Arc<config::Config>,
         trace_aggregator: Arc<Mutex<trace_aggregator::TraceAggregator>>,
         trace_processor: Arc<dyn trace_processor::TraceProcessor + Send + Sync>,
-        stats_aggregator: Arc<Mutex<stats_aggregator::StatsAggregator<pb::ClientStatsPayload>>>,
+        stats_aggregator: Arc<Mutex<stats_aggregator::StatsAggregator>>,
         stats_processor: Arc<dyn stats_processor::StatsProcessor + Send + Sync>,
         tags_provider: Arc<provider::Provider>,
     ) -> TraceAgent {

--- a/bottlecap/src/traces/trace_aggregator.rs
+++ b/bottlecap/src/traces/trace_aggregator.rs
@@ -1,0 +1,65 @@
+use datadog_trace_utils::send_data::SendData;
+use std::collections::VecDeque;
+
+/// Maximum content size per payload uncompressed in bytes,
+/// that the Datadog Trace API accepts. The value is 3.2 MB.
+///
+/// <https://github.com/DataDog/datadog-agent/blob/9d57c10a9eeb3916e661d35dbd23c6e36395a99d/pkg/trace/writer/trace.go#L27-L31>
+pub const MAX_CONTENT_SIZE_BYTES: usize = (32 * 1_024 * 1_024) / 10;
+
+#[allow(clippy::module_name_repetitions)]
+pub struct TraceAggregator {
+    queue: VecDeque<SendData>,
+    max_content_size_bytes: usize,
+    buffer: Vec<SendData>,
+}
+
+impl Default for TraceAggregator {
+    fn default() -> Self {
+        TraceAggregator {
+            queue: VecDeque::new(),
+            max_content_size_bytes: MAX_CONTENT_SIZE_BYTES,
+            buffer: Vec::with_capacity(MAX_CONTENT_SIZE_BYTES),
+        }
+    }
+}
+
+impl TraceAggregator {
+    #[allow(dead_code)]
+    #[allow(clippy::must_use_candidate)]
+    pub fn new(max_content_size_bytes: usize) -> Self {
+        TraceAggregator {
+            queue: VecDeque::new(),
+            max_content_size_bytes,
+            buffer: Vec::with_capacity(max_content_size_bytes),
+        }
+    }
+
+    pub fn add(&mut self, p: SendData) {
+        self.queue.push_back(p);
+    }
+
+    pub fn get_batch(&mut self) -> Vec<SendData> {
+        let mut batch_size = 0;
+
+        // Fill the batch
+        while batch_size < self.max_content_size_bytes {
+            if let Some(payload) = self.queue.pop_front() {
+                // TODO(duncanista): revisit if this is bigger than limit
+                let payload_size = payload.len();
+
+                // Put stats back in the queue
+                if batch_size + payload_size > self.max_content_size_bytes {
+                    self.queue.push_front(payload);
+                    break;
+                }
+                batch_size += payload_size;
+                self.buffer.push(payload);
+            } else {
+                break;
+            }
+        }
+
+        std::mem::take(&mut self.buffer)
+    }
+}

--- a/bottlecap/src/traces/trace_flusher.rs
+++ b/bottlecap/src/traces/trace_flusher.rs
@@ -3,18 +3,19 @@
 
 use async_trait::async_trait;
 use std::sync::Arc;
-use tokio::sync::{mpsc::Receiver, Mutex};
+use tokio::sync::Mutex;
 use tracing::{debug, error};
 
 use datadog_trace_utils::trace_utils::{self, SendData};
 
 use crate::config::Config;
+use crate::traces::trace_aggregator::TraceAggregator;
 
 #[async_trait]
 pub trait TraceFlusher {
-    /// Starts a trace flusher that listens for trace payloads sent to the tokio mpsc Receiver,
-    /// implementing flushing logic that calls flush_traces.
-    async fn start_trace_flusher(&self, mut rx: Receiver<SendData>);
+    fn new(aggregator: Arc<Mutex<TraceAggregator>>, config: Arc<Config>) -> Self
+    where
+        Self: Sized;
     /// Flushes traces to the Datadog trace intake.
     async fn send(&self, traces: Vec<SendData>);
 
@@ -24,27 +25,24 @@ pub trait TraceFlusher {
 #[derive(Clone)]
 #[allow(clippy::module_name_repetitions)]
 pub struct ServerlessTraceFlusher {
-    pub buffer: Arc<Mutex<Vec<SendData>>>,
+    pub aggregator: Arc<Mutex<TraceAggregator>>,
     pub config: Arc<Config>,
 }
 
 #[async_trait]
 impl TraceFlusher for ServerlessTraceFlusher {
-    async fn start_trace_flusher(&self, mut rx: Receiver<SendData>) {
-        let buffer_producer = self.buffer.clone();
-        tokio::spawn(async move {
-            while let Some(tracer_payload) = rx.recv().await {
-                let mut buffer = buffer_producer.lock().await;
-                buffer.push(tracer_payload);
-            }
-        });
+    fn new(aggregator: Arc<Mutex<TraceAggregator>>, config: Arc<Config>) -> Self {
+        ServerlessTraceFlusher { aggregator, config }
     }
 
     async fn flush(&self) {
-        let mut buffer = self.buffer.lock().await;
-        if !buffer.is_empty() {
-            self.send(buffer.to_vec()).await;
-            buffer.clear();
+        let mut guard = self.aggregator.lock().await;
+
+        let mut traces = guard.get_batch();
+        while !traces.is_empty() {
+            self.send(traces).await;
+
+            traces = guard.get_batch();
         }
     }
 

--- a/bottlecap/src/traces/trace_flusher.rs
+++ b/bottlecap/src/traces/trace_flusher.rs
@@ -16,9 +16,9 @@ pub trait TraceFlusher {
     /// implementing flushing logic that calls flush_traces.
     async fn start_trace_flusher(&self, mut rx: Receiver<SendData>);
     /// Flushes traces to the Datadog trace intake.
-    async fn flush_traces(&self, traces: Vec<SendData>);
+    async fn send(&self, traces: Vec<SendData>);
 
-    async fn manual_flush(&self);
+    async fn flush(&self);
 }
 
 #[derive(Clone)]
@@ -40,15 +40,15 @@ impl TraceFlusher for ServerlessTraceFlusher {
         });
     }
 
-    async fn manual_flush(&self) {
+    async fn flush(&self) {
         let mut buffer = self.buffer.lock().await;
         if !buffer.is_empty() {
-            self.flush_traces(buffer.to_vec()).await;
+            self.send(buffer.to_vec()).await;
             buffer.clear();
         }
     }
 
-    async fn flush_traces(&self, traces: Vec<SendData>) {
+    async fn send(&self, traces: Vec<SendData>) {
         if traces.is_empty() {
             return;
         }

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -22,8 +22,7 @@ use crate::traces::{
 };
 use datadog_trace_obfuscation::obfuscate::obfuscate_span;
 use datadog_trace_protobuf::pb::Span;
-use datadog_trace_utils::trace_utils::SendData;
-use datadog_trace_utils::trace_utils::{self};
+use datadog_trace_utils::trace_utils::{self, SendData};
 
 #[derive(Clone)]
 #[allow(clippy::module_name_repetitions)]


### PR DESCRIPTION
# What?

Adds aggregators for Traces and Stats.

# Motivation

Large trace payloads are being dropped, because they're rejected by the backend.
Also [SVLS-6250](https://datadoghq.atlassian.net/browse/SVLS-6250)

# Test

- Added unit tests
- Tested in an AWS Lambda with a heavy amount of incoming traces

[SVLS-6250]: https://datadoghq.atlassian.net/browse/SVLS-6250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ