### PR TITLE
fix: do not allocate memory for buffer

### DIFF
--- a/bottlecap/src/traces/stats_aggregator.rs
+++ b/bottlecap/src/traces/stats_aggregator.rs
@@ -29,7 +29,7 @@ impl Default for StatsAggregator {
         StatsAggregator {
             queue: VecDeque::new(),
             max_content_size_bytes: MAX_CONTENT_SIZE_BYTES,
-            buffer: Vec::with_capacity(MAX_CONTENT_SIZE_BYTES),
+            buffer: Vec::new(),
         }
     }
 }
@@ -41,7 +41,7 @@ impl StatsAggregator {
         StatsAggregator {
             queue: VecDeque::new(),
             max_content_size_bytes,
-            buffer: Vec::with_capacity(max_content_size_bytes),
+            buffer: Vec::new(),
         }
     }
 

--- a/bottlecap/src/traces/trace_aggregator.rs
+++ b/bottlecap/src/traces/trace_aggregator.rs
@@ -19,7 +19,7 @@ impl Default for TraceAggregator {
         TraceAggregator {
             queue: VecDeque::new(),
             max_content_size_bytes: MAX_CONTENT_SIZE_BYTES,
-            buffer: Vec::with_capacity(MAX_CONTENT_SIZE_BYTES),
+            buffer: Vec::new(),
         }
     }
 }
@@ -31,7 +31,7 @@ impl TraceAggregator {
         TraceAggregator {
             queue: VecDeque::new(),
             max_content_size_bytes,
-            buffer: Vec::with_capacity(max_content_size_bytes),
+            buffer: Vec::new(),
         }
     }
 


### PR DESCRIPTION
# What?

Removes allocating memory for the buffer batch

# Why?

Since the buffer is set as:
- `SendData` for traces
- `ClientStatsPayload` for stats

I'm allocating the buffer with the max content size in bytes, so it's around 3 million allocations of the object, instead of actual bytes.
