### PR TITLE
Bump go version to 1.23.6 to address CVE-2025-22866.

### DIFF
--- a/scripts/Dockerfile.alpine.build
+++ b/scripts/Dockerfile.alpine.build
@@ -7,7 +7,7 @@ ARG CMD_PATH
 ARG BUILD_TAGS
 
 RUN apk add --no-cache git make musl-dev gcc
-COPY --from=golang:1.23.2-alpine /usr/local/go/ /usr/lib/go
+COPY --from=golang:1.23.6-alpine /usr/local/go/ /usr/lib/go
 
 ENV GOROOT /usr/lib/go
 ENV GOPATH /go

--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -15,8 +15,8 @@ RUN arch="$(uname -m)"; \
     if [ "${arch}" = 'x86_64' ]; then \
     arch='amd64'; \
     fi; \
-    wget -O go1.23.2.linux-${arch}.tar.gz https://go.dev/dl/go1.23.2.linux-${arch}.tar.gz; \
-    tar -C /usr/local -xzf go1.23.2.linux-${arch}.tar.gz
+    wget -O go1.23.6.linux-${arch}.tar.gz https://go.dev/dl/go1.23.6.linux-${arch}.tar.gz; \
+    tar -C /usr/local -xzf go1.23.6.linux-${arch}.tar.gz
 
 # cache dependencies
 COPY ./scripts/.cache/go.mod /tmp/dd/datadog-agent


### PR DESCRIPTION
See vuln scan failure https://github.com/DataDog/datadog-lambda-extension/actions/runs/13190321135/job/36862794785. Fixed by upgrading go from v1.23.2 to v1.23.6.