### PR TITLE
Fallback on gov regions

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -211,7 +211,7 @@ fn load_configs() -> (AwsConfig, Arc<Config>) {
         sandbox_init_time: Instant::now(),
     };
     let lambda_directory = env::var("LAMBDA_TASK_ROOT").unwrap_or_else(|_| "/var/task".to_string());
-    let config = match config::get_config(Path::new(&lambda_directory), aws_config.region.clone()) {
+    let config = match config::get_config(Path::new(&lambda_directory), &aws_config.region) {
         Ok(config) => Arc::new(config),
         Err(_e) => {
             let err = Command::new("/opt/datadog-agent-go").exec();

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -211,7 +211,7 @@ fn load_configs() -> (AwsConfig, Arc<Config>) {
         sandbox_init_time: Instant::now(),
     };
     let lambda_directory = env::var("LAMBDA_TASK_ROOT").unwrap_or_else(|_| "/var/task".to_string());
-    let config = match config::get_config(Path::new(&lambda_directory)) {
+    let config = match config::get_config(Path::new(&lambda_directory), aws_config.region.clone()) {
         Ok(config) => Arc::new(config),
         Err(_e) => {
             let err = Command::new("/opt/datadog-agent-go").exec();

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -381,6 +381,19 @@ pub mod tests {
             Ok(())
         });
     }
+    #[test]
+    fn test_reject_on_gov_region() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+            jail.set_env("AWS_REGION", "us-gov-east-1");
+            let config = get_config(Path::new("")).expect_err("should reject unknown fields");
+            assert_eq!(
+                config,
+                ConfigError::UnsupportedField("gov_region".to_string())
+            );
+            Ok(())
+        });
+    }
 
     #[test]
     fn test_fallback_on_otel() {

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -187,20 +187,21 @@ fn fallback(figment: &Figment, yaml_figment: &Figment) -> Result<(), ConfigError
     let region = env::var("AWS_REGION").ok();
     let is_gov_region = region
         .as_ref()
-        .map(|region| region.starts_with("us-gov-"))
-        .unwrap_or(false);
+        .is_some_and(|region| region.starts_with("us-gov-"));
 
     let opted_out = is_compatibility || is_gov_region;
 
     if opted_out {
-        log_fallback_reason(if is_compatibility { "extension_version" } else { "gov_region" });
-        return Err(ConfigError::UnsupportedField(
-            if is_compatibility {
-                "extension_version".to_string()
-            } else {
-                "gov_region".to_string()
-            }
-        ));
+        log_fallback_reason(if is_compatibility {
+            "extension_version"
+        } else {
+            "gov_region"
+        });
+        return Err(ConfigError::UnsupportedField(if is_compatibility {
+            "extension_version".to_string()
+        } else {
+            "gov_region".to_string()
+        }));
     }
 
     if config.serverless_appsec_enabled || config.appsec_enabled {


### PR DESCRIPTION
For FIPs compliance, we're falling back to the Go agent when the Lambda is in a govcloud region.

Tested manually, we do fall back as expected on gov regions:
```
{
  "DD_EXTENSION_FALLBACK_REASON": "gov_region"
}
```