### PR TITLE
Check vint_runtime as well as vinternal_1 for network metrics

### DIFF
--- a/bottlecap/src/proc/constants.rs
+++ b/bottlecap/src/proc/constants.rs
@@ -5,5 +5,6 @@ pub const PROC_PATH: &str = "/proc";
 pub const ETC_PATH: &str = "/etc";
 
 pub const LAMDBA_NETWORK_INTERFACE: &str = "vinternal_1";
+pub const LAMDBA_RUNTIME_NETWORK_INTERFACE: &str = "vint_runtime";
 pub const LAMBDA_FILE_DESCRIPTORS_DEFAULT_LIMIT: f64 = 1024.0;
 pub const LAMBDA_EXECUTION_PROCESSES_DEFAULT_LIMIT: f64 = 1024.0;

--- a/bottlecap/src/proc/constants.rs
+++ b/bottlecap/src/proc/constants.rs
@@ -4,7 +4,7 @@ pub const PROC_UPTIME_PATH: &str = "/proc/uptime";
 pub const PROC_PATH: &str = "/proc";
 pub const ETC_PATH: &str = "/etc";
 
-pub const LAMDBA_NETWORK_INTERFACE: &str = "vinternal_1";
-pub const LAMDBA_RUNTIME_NETWORK_INTERFACE: &str = "vint_runtime";
+pub const LAMBDA_NETWORK_INTERFACE: &str = "vinternal_1";
+pub const LAMBDA_RUNTIME_NETWORK_INTERFACE: &str = "vint_runtime";
 pub const LAMBDA_FILE_DESCRIPTORS_DEFAULT_LIMIT: f64 = 1024.0;
 pub const LAMBDA_EXECUTION_PROCESSES_DEFAULT_LIMIT: f64 = 1024.0;

--- a/bottlecap/src/proc/mod.rs
+++ b/bottlecap/src/proc/mod.rs
@@ -8,7 +8,8 @@ use std::{
 };
 
 use constants::{
-    LAMBDA_RUNTIME_NETWORK_INTERFACE, LAMBDA_NETWORK_INTERFACE, PROC_NET_DEV_PATH, PROC_PATH, PROC_STAT_PATH, PROC_UPTIME_PATH,
+    LAMBDA_NETWORK_INTERFACE, LAMBDA_RUNTIME_NETWORK_INTERFACE, PROC_NET_DEV_PATH, PROC_PATH,
+    PROC_STAT_PATH, PROC_UPTIME_PATH,
 };
 use regex::Regex;
 use tracing::{debug, trace};
@@ -60,7 +61,8 @@ fn get_network_data_from_path(path: &str) -> Result<NetworkData, io::Error> {
         let mut values = line.split_whitespace();
 
         if values.next().map_or(false, |interface_name| {
-            interface_name.starts_with(LAMBDA_NETWORK_INTERFACE) || interface_name.starts_with(LAMBDA_RUNTIME_NETWORK_INTERFACE)
+            interface_name.starts_with(LAMBDA_NETWORK_INTERFACE)
+                || interface_name.starts_with(LAMBDA_RUNTIME_NETWORK_INTERFACE)
         }) {
             // Read the value for received bytes if present
             let rx_bytes: Option<f64> = values.next().and_then(|s| s.parse().ok());

--- a/bottlecap/src/proc/mod.rs
+++ b/bottlecap/src/proc/mod.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use constants::{
-    LAMDBA_NETWORK_INTERFACE, PROC_NET_DEV_PATH, PROC_PATH, PROC_STAT_PATH, PROC_UPTIME_PATH,
+    LAMDA_RUNTIME_NETWORK_INTERFACE, LAMDBA_NETWORK_INTERFACE, PROC_NET_DEV_PATH, PROC_PATH, PROC_STAT_PATH, PROC_UPTIME_PATH,
 };
 use regex::Regex;
 use tracing::{debug, trace};
@@ -60,7 +60,7 @@ fn get_network_data_from_path(path: &str) -> Result<NetworkData, io::Error> {
         let mut values = line.split_whitespace();
 
         if values.next().map_or(false, |interface_name| {
-            interface_name.starts_with(LAMDBA_NETWORK_INTERFACE)
+            interface_name.starts_with(LAMDBA_NETWORK_INTERFACE) || interface_name.starts_with(LAMDA_RUNTIME_NETWORK_INTERFACE)
         }) {
             // Read the value for received bytes if present
             let rx_bytes: Option<f64> = values.next().and_then(|s| s.parse().ok());

--- a/bottlecap/src/proc/mod.rs
+++ b/bottlecap/src/proc/mod.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use constants::{
-    LAMDA_RUNTIME_NETWORK_INTERFACE, LAMDBA_NETWORK_INTERFACE, PROC_NET_DEV_PATH, PROC_PATH, PROC_STAT_PATH, PROC_UPTIME_PATH,
+    LAMBDA_RUNTIME_NETWORK_INTERFACE, LAMBDA_NETWORK_INTERFACE, PROC_NET_DEV_PATH, PROC_PATH, PROC_STAT_PATH, PROC_UPTIME_PATH,
 };
 use regex::Regex;
 use tracing::{debug, trace};
@@ -60,7 +60,7 @@ fn get_network_data_from_path(path: &str) -> Result<NetworkData, io::Error> {
         let mut values = line.split_whitespace();
 
         if values.next().map_or(false, |interface_name| {
-            interface_name.starts_with(LAMDBA_NETWORK_INTERFACE) || interface_name.starts_with(LAMDA_RUNTIME_NETWORK_INTERFACE)
+            interface_name.starts_with(LAMBDA_NETWORK_INTERFACE) || interface_name.starts_with(LAMBDA_RUNTIME_NETWORK_INTERFACE)
         }) {
             // Read the value for received bytes if present
             let rx_bytes: Option<f64> = values.next().and_then(|s| s.parse().ok());


### PR DESCRIPTION
Modifies the network check to also look at `vint_runtime` which is present in some runtimes instead of the `vinternal_1` device
seems strange because node20 self monitoring has these metrics?

debug logs from my node20 test function:
```
DD_EXTENSION | DEBUG | astuyve line "Inter-|   Receive                                                |  Transmit"
DD_EXTENSION | DEBUG | astuyve line " face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed"
DD_EXTENSION | DEBUG | astuyve line "    lo:  304049     606    0    0    0     0          0         0   304049     606    0    0    0     0       0          0"
DD_EXTENSION | DEBUG | astuyve line "vint_runtime: 1333674    1153    0    0    0     0          0         0   507891    1170    0    0    0     0       0          0"
DD_EXTENSION | DEBUG | Platform report for request_id: "972d2681-94c2-46a6-b45d-06da778c0d02" with status: Success and error: "None"
DD_EXTENSION | DEBUG | Could not find data to generate network enhanced metrics
```

