### PR TITLE
Update QEMU step in workflow

### DIFF
--- a/.github/workflows/release-serverless-init.yml
+++ b/.github/workflows/release-serverless-init.yml
@@ -54,7 +54,11 @@ jobs:
           path: datadog-agent
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        id: qemu
+        uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25 # v3.4.0
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
+          platforms: amd64,arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/scripts/Dockerfile.serverless-init.build
+++ b/scripts/Dockerfile.serverless-init.build
@@ -1,5 +1,5 @@
 FROM gcr.io/distroless/cc-debian12
-COPY --from=busybox:1.35.0-uclibc /bin/sh /bin/sh
+COPY --from=busybox:1.37-uclibc /bin/sh /bin/sh
 ARG TARGETARCH
 
 COPY ./bin/datadog_extension-$TARGETARCH/extensions/datadog-agent /datadog-init


### PR DESCRIPTION
There is an issue with the qemu action that results in build failures. Pinning to `tonistiigi/binfmt:qemu-v7.0.0-28` fixes the issue.