### PR TITLE
Use QEMU action to fix builds

### DIFF
--- a/.github/workflows/release-serverless-init.yml
+++ b/.github/workflows/release-serverless-init.yml
@@ -54,7 +54,7 @@ jobs:
           path: datadog-agent
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 #v3.6.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release-serverless-init.yml
+++ b/.github/workflows/release-serverless-init.yml
@@ -54,11 +54,7 @@ jobs:
           path: datadog-agent
 
       - name: Set up QEMU
-        id: qemu
-        uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25 # v3.4.0
-        with:
-          image: tonistiigi/binfmt:qemu-v7.0.0-28
-          platforms: amd64,arm64
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -47,12 +47,12 @@ RUN /usr/local/go/bin/go tool nm datadog-agent | grep -w 'github.com/DataDog/dat
     (echo "agentVersionDefault variable doesn't exist" && exit 1)
 
 # zip the extension
-FROM ubuntu:22.04 as compresser
+FROM ubuntu:25.04 as compresser
 ARG CMD_PATH
 ARG DATADOG_WRAPPER=datadog_wrapper
 
 RUN apt-get update
-RUN apt-get install -y zip binutils=2.38-4ubuntu2.6
+RUN apt-get install -y zip binutils
 RUN mkdir /extensions
 WORKDIR /extensions
 COPY --from=builder /tmp/dd/datadog-agent/"${CMD_PATH}"/datadog-agent /extensions/datadog-agent

--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -47,7 +47,7 @@ RUN /usr/local/go/bin/go tool nm datadog-agent | grep -w 'github.com/DataDog/dat
     (echo "agentVersionDefault variable doesn't exist" && exit 1)
 
 # zip the extension
-FROM ubuntu:25.04 as compresser
+FROM ubuntu:22.04 as compresser
 ARG CMD_PATH
 ARG DATADOG_WRAPPER=datadog_wrapper
 

--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -52,7 +52,7 @@ ARG CMD_PATH
 ARG DATADOG_WRAPPER=datadog_wrapper
 
 RUN apt-get update
-RUN apt-get install -y zip binutils
+RUN apt-get install -y zip binutils=2.38-4ubuntu2.6
 RUN mkdir /extensions
 WORKDIR /extensions
 COPY --from=builder /tmp/dd/datadog-agent/"${CMD_PATH}"/datadog-agent /extensions/datadog-agent


### PR DESCRIPTION
Switched back to the QEMU action instead of pinning the version. 

It was fixed in the [latest version](https://github.com/tonistiigi/binfmt/issues/215#issuecomment-2689340770)