### PR TITLE
chore: fix upx compression

### DIFF
--- a/.gitlab/Dockerfile
+++ b/.gitlab/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.ddbuild.io/images/docker:24.0.5
 
 RUN apt-get update && apt-get install -y --fix-missing --no-install-recommends \
-  curl gcc gnupg g++ make cmake unzip openssl g++ uuid-runtime upx-ucl=3.96-3
+  curl gcc gnupg g++ make cmake unzip openssl g++ uuid-runtime
 
 # Install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"

--- a/.gitlab/Dockerfile
+++ b/.gitlab/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.ddbuild.io/images/docker:24.0.5
 
 RUN apt-get update && apt-get install -y --fix-missing --no-install-recommends \
-  curl gcc gnupg g++ make cmake unzip openssl g++ uuid-runtime
+  curl gcc gnupg g++ make cmake unzip openssl g++ uuid-runtime upx-ucl=3.96-3
 
 # Install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"

--- a/images/Dockerfile.build_layer
+++ b/images/Dockerfile.build_layer
@@ -4,13 +4,26 @@ ARG FILE_SUFFIX
 
 # Install dependencies
 RUN apt-get update
-RUN apt-get install -y zip binutils
+RUN apt-get install -y zip binutils wget tar xz-utils
+
+# UPX installation directly from GitHub
+ENV UPX_VERSION=5.0.0
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        ARCH_NAME="amd64"; \
+    elif [ "$ARCH" = "aarch64" ]; then \
+        ARCH_NAME="arm64"; \
+    fi && \
+    wget https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-${ARCH_NAME}_linux.tar.xz && \
+    tar -xf upx-${UPX_VERSION}-${ARCH_NAME}_linux.tar.xz && \
+    mv upx-${UPX_VERSION}-${ARCH_NAME}_linux/upx /usr/local/bin/ && \
+    rm -rf upx-${UPX_VERSION}-${ARCH_NAME}_linux upx-${UPX_VERSION}-${ARCH_NAME}_linux.tar.xz
 
 # Copy Go Agent binary
 COPY .binaries/datadog-agent-$FILE_SUFFIX /datadog-agent-go
 
-# UPX compress on x86_64
-RUN if [ "$PLATFORM" = "x86_64" ]; then apt-get install -y upx=3.96-r0 && upx -1 /datadog-agent-go; fi
+# UPX compress
+RUN upx -1 /datadog-agent-go
 
 RUN mkdir /extensions
 WORKDIR /extensions

--- a/images/Dockerfile.go_agent.alpine.compile
+++ b/images/Dockerfile.go_agent.alpine.compile
@@ -48,12 +48,6 @@ RUN /usr/lib/go/bin/go tool nm datadog-agent | grep -w 'github.com/DataDog/datad
 # Strip the binary to reduce size
 RUN strip datadog-agent
 
-# Compress the binary with UPX, but only if the architecture is x86_64
-RUN arch="$(uname -m)"; \
-    if [ "${arch}" = 'x86_64' ]; then \
-      apk add --no-cache upx=3.96-r1 && upx -1 datadog-agent; \
-    fi;
-
 # Use the smallest image possible
 FROM scratch
 COPY --from=compiler /tmp/dd/datadog-agent/cmd/serverless/datadog-agent /

--- a/images/Dockerfile.go_agent.compile
+++ b/images/Dockerfile.go_agent.compile
@@ -50,9 +50,6 @@ RUN /usr/local/go/bin/go tool nm datadog-agent | grep -w 'github.com/DataDog/dat
 # Strip the binary to reduce size
 RUN strip datadog-agent
 
-# Compress the binary with UPX, but only if the architecture is x86_64
-RUN if [ "$arch" = "x86_64" ]; then apt-get install -y upx=3.96-r0 && upx -1 /datadog-agent; fi
-
 # Use the smallest image possible
 FROM scratch
 COPY --from=compiler /tmp/dd/datadog-agent/cmd/serverless/datadog-agent /


### PR DESCRIPTION
# What?

Fixes UPX compression to use latest `v5.0.0`
Previous one wasn't performant enough for cross-architecture compression

# How?

- Install UPX from GitHub in layer builder
- Remove compression on Go compilation

#Tests

- Tested manually in AWS Lambda by running scripts locally