### PR TITLE
fix(gitlab): private image builds

### DIFF
--- a/.gitlab/scripts/build_layer.sh
+++ b/.gitlab/scripts/build_layer.sh
@@ -42,7 +42,6 @@ docker_build() {
 
     cp $EXTENSION_PATH/datadog_extension.zip $TARGET_DIR/datadog_extension-${FILE_SUFFIX}.zip
     unzip $EXTENSION_PATH/datadog_extension.zip -d $TARGET_DIR/datadog_extension-${FILE_SUFFIX}
-    rm -rf ${EXTENSION_PATH}
 }
 
 docker_build $ARCHITECTURE

--- a/.gitlab/scripts/build_private_image.sh
+++ b/.gitlab/scripts/build_private_image.sh
@@ -29,12 +29,12 @@ else
     TARGET_IMAGE="Dockerfile.extension_image.alpine"
 fi
 
-LAYER_NAME="Datadog-Extension$SUFFIX"
+LAYER_NAME="Datadog-Extension"
 if [ -z "$LAYER_SUFFIX" ]; then
     printf "Building container images tagged without suffix\n"
 else
     printf "Building container images tagged with suffix: ${LAYER_SUFFIX}\n"
-    LAYER_NAME="${LAYER_NAME}-${LAYER_SUFFIX}${SUFFIX}"
+    LAYER_NAME="${LAYER_NAME}-${LAYER_SUFFIX}"
 fi
 
 # Increment last version
@@ -49,4 +49,4 @@ docker buildx build \
     --tag "$DOCKER_TARGET_IMAGE:${VERSION}${SUFFIX}" \
     --push .
 
-printf "Image built and pushed to $DOCKER_TARGET_IMAGE:${IMAGE_TAG}${SUFFIX} for arm64 and amd64\n"
+printf "Image built and pushed to $DOCKER_TARGET_IMAGE:${IMAGE_TAG}${SUFFIX} for ${PLATFORM}\n"


### PR DESCRIPTION
# What?

Fixes private image builds

# Notes

Now it will just check the latest version on sandbox for the layer, which is what we normally use for testing RCs