### PR TITLE
Add qemu setup to serverless vuln scan workflow

### DIFF
--- a/.github/workflows/serverless-vuln-scan.yml
+++ b/.github/workflows/serverless-vuln-scan.yml
@@ -101,6 +101,13 @@ jobs:
           repository: DataDog/datadog-lambda-extension
           path: go/src/github.com/DataDog/datadog-lambda-extension
 
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.2-52 #v3.6.0 latest
+          platforms: amd64,arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
 


### PR DESCRIPTION
Serverless Vulnerability Scan workflow is failing on the build step due to a segmentation fault error. Adding the latest version of the qemu setup Github job resolves this error.

Related to fix in datadog-agent: https://github.com/DataDog/datadog-agent/pull/34583

https://github.com/DataDog/datadog-lambda-extension/actions/runs/13665471225/job/38205999907

```
#14 13.87 Processing triggers for libc-bin (2.35-0ubuntu3.8) ...
#14 13.95 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
#14 14.35 Segmentation fault (core dumped)
#14 14.41 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
#14 14.80 Segmentation fault (core dumped)
#14 14.80 dpkg: error processing package libc-bin (--configure):
#14 14.80  installed libc-bin package post-installation script subprocess returned error exit status 139
#14 14.82 Errors were encountered while processing:
#14 14.82  libc-bin
#14 14.90 E: Sub-process /usr/bin/dpkg returned an error code (1)
#14 ERROR: process "/dev/.buildkit_qemu_emulator /bin/sh -c apt-get install -y zip binutils" did not complete successfully: exit code: 100

#13 [builder  3/11] RUN yum install -y wget tar gzip gcc
#13 24.31   Installing : mpfr-3.1.1-4.amzn2.0.2.aarch64                              1/16 
#13 24.44   Installing : libmpc-1.0.1-3.amzn2.0.2.aarch64                            2/16 
#13 27.63   Installing : cpp-7.3.1-17.amzn2.aarch64                                  3/16 
#13 30.77   Installing : binutils-2.29.1-31.amzn2.0.1.aarch64                        4/16 
#13 31.37   Installing : libidn-1.28-4.amzn2.0.5.aarch64                             5/16
#13 CANCELED
------
 > [compresser  3/10] RUN apt-get install -y zip binutils:
13.84 Setting up zip (3.0-12build2) ...
13.85 Setting up libbinutils:arm64 (2.38-4ubuntu2.7) ...
13.85 Setting up libctf0:arm64 (2.38-4ubuntu2.7) ...
13.86 Setting up binutils-aarch64-linux-gnu (2.38-4ubuntu2.7) ...
13.86 Setting up binutils (2.38-4ubuntu2.7) ...
13.87 Processing triggers for libc-bin (2.35-0ubuntu3.8) ...
13.95 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
14.35 Segmentation fault (core dumped)
14.41 qemu: uncaught target signal 11 (Segmentation fault) - core dumped

------
ERROR: failed to solve: process "/dev/.buildkit_qemu_emulator /bin/sh -c apt-get install -y zip binutils" did not complete successfully: exit code: 100
```