### PR TITLE
aj/add timeout log

### DIFF
--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -201,7 +201,7 @@ impl LambdaProcessor {
 
                 let init_duration_ms = metrics.init_duration_ms;
                 if let Some(init_duration_ms) = init_duration_ms {
-                    message = format!("{message} Init Duration: {:.2} ms", init_duration_ms);
+                    message = format!("{message} Init Duration: {init_duration_ms:.2} ms");
                 }
 
                 Ok(Message::new(

--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -443,6 +443,31 @@ mod tests {
                 },
         ),
 
+        // platform runtime done
+        platform_runtime_done_timeout: (
+            &TelemetryEvent {
+                time: Utc.with_ymd_and_hms(2023, 1, 7, 3, 23, 47).unwrap(),
+                record: TelemetryRecord::PlatformRuntimeDone {
+                    request_id: "test-request-id".to_string(),
+                    status: Status::Timeout,
+                    error_type: None,
+                    metrics: Some(RuntimeDoneMetrics {
+                        duration_ms: 5000.0,
+                        produced_bytes: Some(42)
+                    })
+                }
+            },
+            Message {
+                    message: "END RequestId: test-request-id Task timed out after 5.00 seconds".to_string(),
+                    lambda: Lambda {
+                        arn: "test-arn".to_string(),
+                        request_id: Some("test-request-id".to_string()),
+                    },
+                    timestamp: 1_673_061_827_000,
+                    status: "info".to_string(),
+                },
+        ),
+
         // platform report
         platform_report: (
             &TelemetryEvent {

--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -201,7 +201,7 @@ impl LambdaProcessor {
 
                 let init_duration_ms = metrics.init_duration_ms;
                 if let Some(init_duration_ms) = init_duration_ms {
-                    message = format!("{message} Init Duration: {init_duration_ms} ms");
+                    message = format!("{message} Init Duration: {:.2} ms", init_duration_ms);
                 }
 
                 Ok(Message::new(
@@ -462,7 +462,7 @@ mod tests {
                 }
             },
             Message {
-                    message: "REPORT RequestId: test-request-id Duration: 100 ms Runtime Duration: 0 ms Post Runtime Duration: 0 ms Billed Duration: 128 ms Memory Size: 256 MB Max Memory Used: 64 MB Init Duration: 50 ms".to_string(),
+                    message: "REPORT RequestId: test-request-id Duration: 100.00 ms Runtime Duration: 0.00 ms Post Runtime Duration: 0.00 ms Billed Duration: 128 ms Memory Size: 256 MB Max Memory Used: 64 MB Init Duration: 50.00 ms".to_string(),
                     lambda: Lambda {
                         arn: "test-arn".to_string(),
                         request_id: Some("test-request-id".to_string()),


### PR DESCRIPTION
Completes a feature request: adds a timeout log to the END log.

Not using the REPORT log because we won't get that until the _next_ invocation. This way customers can see the timeout log right away.

Also, rounds the ms down to 2 digits because 10 repeating digits is kind of annoying
<img width="1281" alt="image" src="https://github.com/user-attachments/assets/fc7032ba-0634-4fd4-9d7e-a0f672f8677a" />

