### PR TITLE
feat(bottlecap): Update Step Functions trace extraction

### DIFF
--- a/bottlecap/src/lifecycle/invocation/triggers/step_function_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/step_function_event.rs
@@ -11,8 +11,7 @@ use crate::{
     traces::{
         context::{Sampling, SpanContext},
         propagation::text_map_propagator::{
-            DatadogHeaderPropagator, DATADOG_HIGHER_ORDER_TRACE_ID_BITS_KEY,
-            DATADOG_SAMPLING_DECISION_KEY, DATADOG_TAGS_KEY,
+            DatadogHeaderPropagator, DATADOG_HIGHER_ORDER_TRACE_ID_BITS_KEY, DATADOG_TAGS_KEY,
         },
     },
 };
@@ -262,6 +261,7 @@ impl ServiceNameResolver for StepFunctionEvent {
 mod tests {
     use super::*;
     use crate::lifecycle::invocation::triggers::test_utils::read_json_file;
+    use crate::traces::propagation::text_map_propagator::DATADOG_SAMPLING_DECISION_KEY;
 
     #[test]
     fn test_new_event() {

--- a/bottlecap/src/lifecycle/invocation/triggers/step_function_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/step_function_event.rs
@@ -159,8 +159,8 @@ impl StepFunctionEvent {
             self.execution.id.clone(),
             self.state.name.clone(),
             self.state.entered_time.clone(),
-            self.state.retry_count.clone(),
-            self.execution.redrive_count.clone(),
+            self.state.retry_count,
+            self.execution.redrive_count,
         );
 
         SpanContext {
@@ -178,7 +178,7 @@ impl StepFunctionEvent {
     }
 
     /// Generates a random 64 bit ID from the formatted hash of the
-    /// Step Function context object. Omit retry_count and redrive_count
+    /// Step Function context object. We omit `retry_count` and `redrive_count`
     /// when both are 0 to maintain backwards compatibility.
     ///
     fn generate_parent_id(

--- a/bottlecap/src/lifecycle/invocation/triggers/step_function_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/step_function_event.rs
@@ -17,6 +17,8 @@ use crate::{
     },
 };
 
+use super::DATADOG_CARRIER_KEY;
+
 pub const DATADOG_LEGACY_LAMBDA_PAYLOAD: &str = "Payload";
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -69,7 +71,7 @@ impl Trigger for StepFunctionEvent {
         let p = payload
             .get(DATADOG_LEGACY_LAMBDA_PAYLOAD)
             .unwrap_or(&payload)
-            .get(super::DATADOG_CARRIER_KEY)
+            .get(DATADOG_CARRIER_KEY)
             .unwrap_or(
                 payload
                     .get(DATADOG_LEGACY_LAMBDA_PAYLOAD)
@@ -93,7 +95,7 @@ impl Trigger for StepFunctionEvent {
         let p = payload
             .get(DATADOG_LEGACY_LAMBDA_PAYLOAD)
             .unwrap_or(payload)
-            .get(super::DATADOG_CARRIER_KEY)
+            .get(DATADOG_CARRIER_KEY)
             .unwrap_or(
                 payload
                     .get(DATADOG_LEGACY_LAMBDA_PAYLOAD)

--- a/bottlecap/src/traces/propagation/text_map_propagator.rs
+++ b/bottlecap/src/traces/propagation/text_map_propagator.rs
@@ -22,7 +22,7 @@ pub const DATADOG_TAGS_KEY: &str = "x-datadog-tags";
 pub const DATADOG_HIGHER_ORDER_TRACE_ID_BITS_KEY: &str = "_dd.p.tid";
 const DATADOG_PROPAGATION_ERROR_KEY: &str = "_dd.propagation_error";
 pub const DATADOG_LAST_PARENT_ID_KEY: &str = "_dd.parent_id";
-const DATADOG_SAMPLING_DECISION_KEY: &str = "_dd.p.dm";
+pub const DATADOG_SAMPLING_DECISION_KEY: &str = "_dd.p.dm";
 
 // Traceparent Keys
 const TRACEPARENT_KEY: &str = "traceparent";

--- a/bottlecap/tests/payloads/step_function_lambda_root_event.json
+++ b/bottlecap/tests/payloads/step_function_lambda_root_event.json
@@ -1,24 +1,24 @@
 {
-    "_datadog": {
-      "Execution": {
-        "Id": "arn:aws:states:sa-east-1:425362996713:execution:invokeJavaLambda:c0ca8d0f-a3af-4c42-bfd4-b3b100e77f01",
-        "Input": {},
-        "StartTime": "2024-08-29T21:48:55.187Z",
-        "Name": "c0ca8d0f-a3af-4c42-bfd4-b3b100e77f01",
-        "RoleArn": "arn:aws:iam::425362996713:role/new-extension-test-java-dev-InvokeJavaLambdaRole-LtJmnJReIOTS",
-        "RedriveCount": 0
-      },
-      "StateMachine": {
-        "Id": "arn:aws:states:sa-east-1:425362996713:stateMachine:invokeJavaLambda",
-        "Name": "invokeJavaLambda"
-      },
-      "State": {
-        "Name": "invoker",
-        "EnteredTime": "2024-08-29T21:48:55.275Z",
-        "RetryCount": 0
-      },
-      "x-datadog-trace-id": "5821803790426892636",
-      "x-datadog-tags": "_dd.p.dm=-0,_dd.p.tid=672a7cb100000000",
-      "serverless-version": "v1"
-    }
+  "_datadog": {
+    "Execution": {
+      "Id": "arn:aws:states:us-east-1:425362996713:execution:agocsTestSF:aa6c9316-713a-41d4-9c30-61131716744f",
+      "Input": {},
+      "StartTime": "2024-08-29T21:48:55.187Z",
+      "Name": "c0ca8d0f-a3af-4c42-bfd4-b3b100e77f01",
+      "RoleArn": "arn:aws:iam::425362996713:role/new-extension-test-java-dev-InvokeJavaLambdaRole-LtJmnJReIOTS",
+      "RedriveCount": 0
+    },
+    "StateMachine": {
+      "Id": "arn:aws:states:us-east-1:425362996713:stateMachine:agocsTestSF",
+      "Name": "invokeJavaLambda"
+    },
+    "State": {
+      "Name": "agocsTest1",
+      "EnteredTime": "2024-07-30T20:46:20.824Z",
+      "RetryCount": 0
+    },
+    "x-datadog-trace-id": "5821803790426892636",
+    "x-datadog-tags": "_dd.p.dm=-0,_dd.p.tid=672a7cb100000000",
+    "serverless-version": "v1"
   }
+}

--- a/bottlecap/tests/payloads/step_function_lambda_root_event.json
+++ b/bottlecap/tests/payloads/step_function_lambda_root_event.json
@@ -1,0 +1,24 @@
+{
+    "_datadog": {
+      "Execution": {
+        "Id": "arn:aws:states:sa-east-1:425362996713:execution:invokeJavaLambda:c0ca8d0f-a3af-4c42-bfd4-b3b100e77f01",
+        "Input": {},
+        "StartTime": "2024-08-29T21:48:55.187Z",
+        "Name": "c0ca8d0f-a3af-4c42-bfd4-b3b100e77f01",
+        "RoleArn": "arn:aws:iam::425362996713:role/new-extension-test-java-dev-InvokeJavaLambdaRole-LtJmnJReIOTS",
+        "RedriveCount": 0
+      },
+      "StateMachine": {
+        "Id": "arn:aws:states:sa-east-1:425362996713:stateMachine:invokeJavaLambda",
+        "Name": "invokeJavaLambda"
+      },
+      "State": {
+        "Name": "invoker",
+        "EnteredTime": "2024-08-29T21:48:55.275Z",
+        "RetryCount": 0
+      },
+      "x-datadog-trace-id": "5821803790426892636",
+      "x-datadog-tags": "_dd.p.dm=-0,_dd.p.tid=672a7cb100000000",
+      "serverless-version": "v1"
+    }
+  }

--- a/bottlecap/tests/payloads/step_function_lambda_root_legacy_event.json
+++ b/bottlecap/tests/payloads/step_function_lambda_root_legacy_event.json
@@ -1,0 +1,26 @@
+{
+  "Payload": {
+    "_datadog": {
+      "Execution": {
+        "Id": "arn:aws:states:sa-east-1:425362996713:execution:invokeJavaLambda:c0ca8d0f-a3af-4c42-bfd4-b3b100e77f01",
+        "Input": {},
+        "StartTime": "2024-08-29T21:48:55.187Z",
+        "Name": "c0ca8d0f-a3af-4c42-bfd4-b3b100e77f01",
+        "RoleArn": "arn:aws:iam::425362996713:role/new-extension-test-java-dev-InvokeJavaLambdaRole-LtJmnJReIOTS",
+        "RedriveCount": 0
+      },
+      "StateMachine": {
+        "Id": "arn:aws:states:sa-east-1:425362996713:stateMachine:invokeJavaLambda",
+        "Name": "invokeJavaLambda"
+      },
+      "State": {
+        "Name": "invoker",
+        "EnteredTime": "2024-08-29T21:48:55.275Z",
+        "RetryCount": 0
+      },
+      "x-datadog-trace-id": "5821803790426892636",
+      "x-datadog-tags": "_dd.p.dm=-0,_dd.p.tid=672a7cb100000000",
+      "serverless-version": "v1"
+    }
+  }
+}

--- a/bottlecap/tests/payloads/step_function_lambda_root_legacy_event.json
+++ b/bottlecap/tests/payloads/step_function_lambda_root_legacy_event.json
@@ -2,7 +2,7 @@
   "Payload": {
     "_datadog": {
       "Execution": {
-        "Id": "arn:aws:states:sa-east-1:425362996713:execution:invokeJavaLambda:c0ca8d0f-a3af-4c42-bfd4-b3b100e77f01",
+        "Id": "arn:aws:states:us-east-1:425362996713:execution:agocsTestSF:aa6c9316-713a-41d4-9c30-61131716744f",
         "Input": {},
         "StartTime": "2024-08-29T21:48:55.187Z",
         "Name": "c0ca8d0f-a3af-4c42-bfd4-b3b100e77f01",
@@ -10,12 +10,12 @@
         "RedriveCount": 0
       },
       "StateMachine": {
-        "Id": "arn:aws:states:sa-east-1:425362996713:stateMachine:invokeJavaLambda",
+        "Id": "arn:aws:states:us-east-1:425362996713:stateMachine:agocsTestSF",
         "Name": "invokeJavaLambda"
       },
       "State": {
-        "Name": "invoker",
-        "EnteredTime": "2024-08-29T21:48:55.275Z",
+        "Name": "agocsTest1",
+        "EnteredTime": "2024-07-30T20:46:20.824Z",
         "RetryCount": 0
       },
       "x-datadog-trace-id": "5821803790426892636",

--- a/bottlecap/tests/payloads/step_function_nested_event.json
+++ b/bottlecap/tests/payloads/step_function_nested_event.json
@@ -1,0 +1,23 @@
+{
+    "_datadog": {
+      "Execution": {
+        "Id": "arn:aws:states:sa-east-1:425362996713:execution:invokeJavaLambda:c0ca8d0f-a3af-4c42-bfd4-b3b100e77f01",
+        "Input": {},
+        "StartTime": "2024-08-29T21:48:55.187Z",
+        "Name": "c0ca8d0f-a3af-4c42-bfd4-b3b100e77f01",
+        "RoleArn": "arn:aws:iam::425362996713:role/new-extension-test-java-dev-InvokeJavaLambdaRole-LtJmnJReIOTS",
+        "RedriveCount": 0
+      },
+      "StateMachine": {
+        "Id": "arn:aws:states:sa-east-1:425362996713:stateMachine:invokeJavaLambda",
+        "Name": "invokeJavaLambda"
+      },
+      "State": {
+        "Name": "invoker",
+        "EnteredTime": "2024-08-29T21:48:55.275Z",
+        "RetryCount": 0
+      },
+      "RootExecutionId": "arn:aws:states:sa-east-1:425362996713:execution:invokeJavaLambda:4875aba4-ae31-4a4c-bf8a-63e9eee31dad",
+      "serverless-version": "v1"
+    }
+  }

--- a/bottlecap/tests/payloads/step_function_nested_event.json
+++ b/bottlecap/tests/payloads/step_function_nested_event.json
@@ -1,23 +1,23 @@
 {
-    "_datadog": {
-      "Execution": {
-        "Id": "arn:aws:states:sa-east-1:425362996713:execution:invokeJavaLambda:c0ca8d0f-a3af-4c42-bfd4-b3b100e77f01",
-        "Input": {},
-        "StartTime": "2024-08-29T21:48:55.187Z",
-        "Name": "c0ca8d0f-a3af-4c42-bfd4-b3b100e77f01",
-        "RoleArn": "arn:aws:iam::425362996713:role/new-extension-test-java-dev-InvokeJavaLambdaRole-LtJmnJReIOTS",
-        "RedriveCount": 0
-      },
-      "StateMachine": {
-        "Id": "arn:aws:states:sa-east-1:425362996713:stateMachine:invokeJavaLambda",
-        "Name": "invokeJavaLambda"
-      },
-      "State": {
-        "Name": "invoker",
-        "EnteredTime": "2024-08-29T21:48:55.275Z",
-        "RetryCount": 0
-      },
-      "RootExecutionId": "arn:aws:states:sa-east-1:425362996713:execution:invokeJavaLambda:4875aba4-ae31-4a4c-bf8a-63e9eee31dad",
-      "serverless-version": "v1"
-    }
+  "_datadog": {
+    "Execution": {
+      "Id": "arn:aws:states:us-east-1:425362996713:execution:agocsTestSF:aa6c9316-713a-41d4-9c30-61131716744f",
+      "Input": {},
+      "StartTime": "2024-08-29T21:48:55.187Z",
+      "Name": "c0ca8d0f-a3af-4c42-bfd4-b3b100e77f01",
+      "RoleArn": "arn:aws:iam::425362996713:role/new-extension-test-java-dev-InvokeJavaLambdaRole-LtJmnJReIOTS",
+      "RedriveCount": 0
+    },
+    "StateMachine": {
+      "Id": "arn:aws:states:us-east-1:425362996713:stateMachine:agocsTestSF",
+      "Name": "invokeJavaLambda"
+    },
+    "State": {
+      "Name": "agocsTest1",
+      "EnteredTime": "2024-07-30T20:46:20.824Z",
+      "RetryCount": 0
+    },
+    "RootExecutionId": "arn:aws:states:sa-east-1:425362996713:execution:invokeJavaLambda:4875aba4-ae31-4a4c-bf8a-63e9eee31dad",
+    "serverless-version": "v1"
   }
+}

--- a/bottlecap/tests/payloads/step_function_nested_legacy_event.json
+++ b/bottlecap/tests/payloads/step_function_nested_legacy_event.json
@@ -1,0 +1,25 @@
+{
+  "Payload": {
+    "_datadog": {
+      "Execution": {
+        "Id": "arn:aws:states:sa-east-1:425362996713:execution:invokeJavaLambda:c0ca8d0f-a3af-4c42-bfd4-b3b100e77f01",
+        "Input": {},
+        "StartTime": "2024-08-29T21:48:55.187Z",
+        "Name": "c0ca8d0f-a3af-4c42-bfd4-b3b100e77f01",
+        "RoleArn": "arn:aws:iam::425362996713:role/new-extension-test-java-dev-InvokeJavaLambdaRole-LtJmnJReIOTS",
+        "RedriveCount": 0
+      },
+      "StateMachine": {
+        "Id": "arn:aws:states:sa-east-1:425362996713:stateMachine:invokeJavaLambda",
+        "Name": "invokeJavaLambda"
+      },
+      "State": {
+        "Name": "invoker",
+        "EnteredTime": "2024-08-29T21:48:55.275Z",
+        "RetryCount": 0
+      },
+      "RootExecutionId": "arn:aws:states:sa-east-1:425362996713:execution:invokeJavaLambda:4875aba4-ae31-4a4c-bf8a-63e9eee31dad",
+      "serverless-version": "v1"
+    }
+  }
+}

--- a/bottlecap/tests/payloads/step_function_nested_legacy_event.json
+++ b/bottlecap/tests/payloads/step_function_nested_legacy_event.json
@@ -2,7 +2,7 @@
   "Payload": {
     "_datadog": {
       "Execution": {
-        "Id": "arn:aws:states:sa-east-1:425362996713:execution:invokeJavaLambda:c0ca8d0f-a3af-4c42-bfd4-b3b100e77f01",
+        "Id": "arn:aws:states:us-east-1:425362996713:execution:agocsTestSF:aa6c9316-713a-41d4-9c30-61131716744f",
         "Input": {},
         "StartTime": "2024-08-29T21:48:55.187Z",
         "Name": "c0ca8d0f-a3af-4c42-bfd4-b3b100e77f01",
@@ -10,12 +10,12 @@
         "RedriveCount": 0
       },
       "StateMachine": {
-        "Id": "arn:aws:states:sa-east-1:425362996713:stateMachine:invokeJavaLambda",
+        "Id": "arn:aws:states:us-east-1:425362996713:stateMachine:agocsTestSF",
         "Name": "invokeJavaLambda"
       },
       "State": {
-        "Name": "invoker",
-        "EnteredTime": "2024-08-29T21:48:55.275Z",
+        "Name": "agocsTest1",
+        "EnteredTime": "2024-07-30T20:46:20.824Z",
         "RetryCount": 0
       },
       "RootExecutionId": "arn:aws:states:sa-east-1:425362996713:execution:invokeJavaLambda:4875aba4-ae31-4a4c-bf8a-63e9eee31dad",


### PR DESCRIPTION
### What

Updates the creation of trace context from a Step Function execution's context object to...
1. Make use of `State.RetryCount` and `Execution.RedriveCount` for inferable parent ID generation in a backwards compatible manner (related to https://github.com/DataDog/datadog-lambda-python/pull/559)
2. Support the new trace context propagation for multi-level trace merging. These are cases where we're receiving a Step Function event but that Step Function has another parent service which can be either a Lambda or another Step Function (related https://github.com/DataDog/datadog-lambda-python/pull/537)

### Why

Parity of https://github.com/DataDog/datadog-agent/pull/34264
1. Using these new values for parent ID generation will prevent collisions with "retry spans" which are Step Function spans that parent a Lambda. Without using the `State.RetryCount` the other values we use for the hash are identical across tries
2. Multi-level trace merging is the future, it lets us merge an arbitrary number of Lambda and Step Function traces. The previous approach only lets us do a max depth of 2 services, losing the context after that. We're able to always preserve some about the top-most service or the root service to keep the Trace ID intact while using the context object to infer the parent ID.

### Testing
Expanded unit tests to account for new cases

Live [trace](https://dd.datad0g.com/apm/trace/67bf8e940e01810a48f7a6ab796c8fb6?graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=5660659611008214469&timeHint=1741299793519) of the nested step function trace merging (SFN -> SFN -> Lambda)
<img width="1250" alt="Screenshot 2025-03-06 at 5 37 33 PM" src="https://github.com/user-attachments/assets/db1ec7e8-2f20-4880-841b-647c9c1374f4" />

Live [trace](https://dd.datad0g.com/apm/trace/67ca23940000000005c88b1e34b10f25?graphType=waterfall&panel_tab=flamegraph&shouldShowLegend=true&sort=time&spanID=4604307312880118210&timeHint=1741300628495.9663) of the lambda root trace merging (Lambda -> SFN -> SFN -> Lambda)
<img width="1250" alt="Screenshot 2025-03-06 at 5 41 10 PM" src="https://github.com/user-attachments/assets/01685cf9-f4a7-436c-8a2f-6dda7c497325" />
