### PR TITLE
aj/use secret region

### DIFF
--- a/bottlecap/src/secrets/decrypt.rs
+++ b/bottlecap/src/secrets/decrypt.rs
@@ -54,8 +54,8 @@ pub async fn resolve_secrets(config: Arc<Config>, aws_config: &mut AwsConfig) ->
 
             let decrypted_key = if config.kms_api_key.is_empty() {
                 let secret_region = config
-                    .kms_api_key
-                    .split(":")
+                    .api_key_secret_arn
+                    .split(':')
                     .nth(3)
                     .unwrap_or(&aws_config.region);
                 decrypt_aws_sm(
@@ -256,7 +256,7 @@ fn build_get_secret_signed_headers(
     let algorithm = "AWS4-HMAC-SHA256";
     let credential_scope = format!(
         "{}/{}/{}/aws4_request",
-        date_stamp, aws_config.region, header_values.service
+        date_stamp, region, header_values.service
     );
     let string_to_sign = format!(
         "{}\n{}\n{}\n{}",
@@ -269,7 +269,7 @@ fn build_get_secret_signed_headers(
     let signing_key = get_aws4_signature_key(
         &aws_config.aws_secret_access_key,
         &date_stamp,
-        aws_config.region.as_str(),
+        region.as_str(),
         header_values.service.as_str(),
     )?;
 

--- a/bottlecap/src/secrets/decrypt.rs
+++ b/bottlecap/src/secrets/decrypt.rs
@@ -155,6 +155,7 @@ async fn decrypt_aws_sm(
     aws_config: &AwsConfig,
 ) -> Result<String, Box<dyn std::error::Error>> {
     let json_body = &serde_json::json!({ "SecretId": secret_arn});
+    // Supports cross-region secrets
     let secret_region = secret_arn
         .split(':')
         .nth(3)


### PR DESCRIPTION
Fixes #594

you can verify with [this function](https://us-west-2.console.aws.amazon.com/lambda/home?region=us-west-2#/functions/secrets-manager-dev-hello?subtab=envVars&tab=configure) using a secret in us-east-1, while running in us-west-2.

Metrics appearing:
<img width="1626" alt="image" src="https://github.com/user-attachments/assets/9e6b68c4-dd6c-4041-be57-cb1a70071748" />