### PR TITLE
feat: parse env and service as strings or ints

### DIFF
--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -812,14 +812,16 @@ pub mod tests {
     }
 
     #[test]
-    fn parse_number_or_string_dd_version_env() {
+    fn parse_number_or_string_env_vars() {
         figment::Jail::expect_with(|jail| {
             jail.clear_env();
             jail.set_env("DD_VERSION", "123");
             jail.set_env("DD_ENV", "123456890");
+            jail.set_env("DD_SERVICE", "123456");
             let config = get_config(Path::new(""), MOCK_REGION).expect("should parse config");
             assert_eq!(config.version.expect("failed to parse DD_VERSION"), "123");
             assert_eq!(config.env.expect("failed to parse DD_ENV"), "123456890");
+            assert_eq!(config.service.expect("failed to parse DD_SERVICE"), "123456");
             Ok(())
         });
     }

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -112,7 +112,9 @@ pub struct Config {
     pub api_key: String,
     pub api_key_secret_arn: String,
     pub kms_api_key: String,
+    #[serde(deserialize_with = "deserialize_string_or_int")]
     pub env: Option<String>,
+    #[serde(deserialize_with = "deserialize_string_or_int")]
     pub service: Option<String>,
     #[serde(deserialize_with = "deserialize_string_or_int")]
     pub version: Option<String>,
@@ -810,12 +812,14 @@ pub mod tests {
     }
 
     #[test]
-    fn parse_dd_version() {
+    fn parse_number_or_string_dd_version_env() {
         figment::Jail::expect_with(|jail| {
             jail.clear_env();
             jail.set_env("DD_VERSION", "123");
+            jail.set_env("DD_ENV", "123456890");
             let config = get_config(Path::new(""), MOCK_REGION).expect("should parse config");
             assert_eq!(config.version.expect("failed to parse DD_VERSION"), "123");
+            assert_eq!(config.env.expect("failed to parse DD_ENV"), "123456890");
             Ok(())
         });
     }

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -821,7 +821,10 @@ pub mod tests {
             let config = get_config(Path::new(""), MOCK_REGION).expect("should parse config");
             assert_eq!(config.version.expect("failed to parse DD_VERSION"), "123");
             assert_eq!(config.env.expect("failed to parse DD_ENV"), "123456890");
-            assert_eq!(config.service.expect("failed to parse DD_SERVICE"), "123456");
+            assert_eq!(
+                config.service.expect("failed to parse DD_SERVICE"),
+                "123456"
+            );
             Ok(())
         });
     }


### PR DESCRIPTION
Fixes #606, also accounts for DD_SERVICE which, in unusual but possible circumstances, could be an int
