### PR TITLE
aj/support log tags

### DIFF
--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -234,6 +234,7 @@ impl LambdaProcessor {
         let parsed_message = serde_json::from_str::<serde_json::Value>(&lambda_message.message.as_str());
         let log = match parsed_message {
             Ok(serde_json::Value::Object(obj)) => {
+                println!("ASTUYVE parsed log");
                 let mut tags = self.tags.clone();
                 if let Some(message_tags) = obj.get("tags") {
                     tags.push_str(",");
@@ -257,13 +258,16 @@ impl LambdaProcessor {
                     }
                 }
             },
-            _ => IntakeLog {
+            _ => {
+                println!("ASTUYVE cant parse log");
+                IntakeLog {
                 hostname: self.function_arn.clone(),
                 source: LAMBDA_RUNTIME_SLUG.to_string(),
                 service: self.service.clone(),
                 tags: self.tags.clone(),
                 message: lambda_message,
                 }
+            }
         };
 
         if log.message.lambda.request_id.is_some() {

--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -231,16 +231,21 @@ impl LambdaProcessor {
         lambda_message.lambda.request_id = request_id;
         // Test if message is a JSON object, it may have tags we need to pass along.
         // Don't care about host, service, and status, since we'll override them.
-        let parsed_message = serde_json::from_str::<serde_json::Value>(&lambda_message.message.as_str());
+        let parsed_message =
+            serde_json::from_str::<serde_json::Value>(lambda_message.message.as_str());
         let log = match parsed_message {
-            Ok(serde_json::Value::Object(obj)) => {
-                println!("ASTUYVE parsed log");
+            Ok(serde_json::Value::Object(mut obj)) => {
                 let mut tags = self.tags.clone();
-                if let Some(message_tags) = obj.get("tags") {
-                    tags.push_str(",");
-                    tags.push_str(message_tags.to_string().as_str());
-                }
-                let final_message = if let Some(inner_message) = obj.get("message") {
+                let final_message = if let Some(inner_message) = obj.get_mut("message") {
+                    if let Some(serde_json::Value::String(message_tags)) =
+                        inner_message.get("ddtags")
+                    {
+                        tags.push(',');
+                        tags.push_str(message_tags);
+                        if let Some(inner_message_object) = inner_message.as_object_mut() {
+                            inner_message_object.remove("ddtags");
+                        }
+                    }
                     inner_message.to_string()
                 } else {
                     lambda_message.message.clone()
@@ -255,19 +260,16 @@ impl LambdaProcessor {
                         lambda: lambda_message.lambda,
                         timestamp: lambda_message.timestamp,
                         status: lambda_message.status,
-                    }
+                    },
                 }
-            },
-            _ => {
-                println!("ASTUYVE cant parse log");
-                IntakeLog {
+            }
+            _ => IntakeLog {
                 hostname: self.function_arn.clone(),
                 source: LAMBDA_RUNTIME_SLUG.to_string(),
                 service: self.service.clone(),
                 tags: self.tags.clone(),
                 message: lambda_message,
-                }
-            }
+            },
         };
 
         if log.message.lambda.request_id.is_some() {
@@ -882,5 +884,63 @@ mod tests {
             serde_json::to_string(&function_log).unwrap()
         );
         assert_eq!(batch, serialized_log.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn test_process_logs_structured_ddtags() {
+        let config = Arc::new(config::Config {
+            service: Some("test-service".to_string()),
+            tags: Some("test:tags".to_string()),
+            ..config::Config::default()
+        });
+
+        let tags_provider = Arc::new(provider::Provider::new(
+            Arc::clone(&config),
+            LAMBDA_RUNTIME_SLUG.to_string(),
+            &HashMap::from([("function_arn".to_string(), "test-arn".to_string())]),
+        ));
+
+        let (tx, _rx) = tokio::sync::mpsc::channel(2);
+        let mut processor =
+            LambdaProcessor::new(tags_provider.clone(), Arc::clone(&config), tx.clone());
+        let start_event = TelemetryEvent {
+            time: Utc.with_ymd_and_hms(2023, 1, 7, 3, 23, 47).unwrap(),
+            record: TelemetryRecord::PlatformStart {
+                request_id: "test-request-id".to_string(),
+                version: Some("test".to_string()),
+            },
+        };
+
+        let start_lambda_message = processor.get_message(start_event.clone()).await.unwrap();
+        processor.get_intake_log(start_lambda_message).unwrap();
+        let event = TelemetryEvent {
+            time: Utc.with_ymd_and_hms(2023, 1, 7, 3, 23, 47).unwrap(),
+            record: TelemetryRecord::Function(Value::String(r#"{"message":{"custom_details": "my-structured-message","ddtags":"added_tag1:added_value1,added_tag2:added_value2"}}"#.to_string())),
+        };
+
+        let lambda_message = processor.get_message(event.clone()).await.unwrap();
+        let intake_log = processor.get_intake_log(lambda_message).unwrap();
+
+        assert_eq!(intake_log.source, LAMBDA_RUNTIME_SLUG.to_string());
+        assert_eq!(intake_log.hostname, "test-arn".to_string());
+        assert_eq!(intake_log.service, "test-service".to_string());
+        assert!(intake_log.tags.contains("added_tag1:added_value1"));
+        let function_log = IntakeLog {
+            message: Message {
+                message: r#"{"custom_details":"my-structured-message"}"#.to_string(),
+                lambda: Lambda {
+                    arn: "test-arn".to_string(),
+                    request_id: Some("test-request-id".to_string()),
+                },
+                timestamp: 1_673_061_827_000,
+                status: "info".to_string(),
+            },
+            hostname: "test-arn".to_string(),
+            source: LAMBDA_RUNTIME_SLUG.to_string(),
+            service: "test-service".to_string(),
+            tags: tags_provider.get_tags_string()
+                + ",added_tag1:added_value1,added_tag2:added_value2",
+        };
+        assert_eq!(intake_log, function_log);
     }
 }


### PR DESCRIPTION
Fixes #515 

You can reproduce by creating a new lambda function, enabling `JSON` logs in Lambda, and then logging something like this:
```
  console.log({ddtags: 'aj:test,aj_type:added_tags', message: {input: event, more_items: "are working"}});
```
  
You should be able to search for those tags in the app:
<img width="1194" alt="image" src="https://github.com/user-attachments/assets/95644ece-5355-4971-99db-0424fe1b7ce6" />