### PR TITLE
Update dogstatsd to use retry pushed to client

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -867,14 +867,13 @@ dependencies = [
 [[package]]
 name = "dogstatsd"
 version = "16.0.3"
-source = "git+https://github.com/DataDog/libdatadog?rev=89754a92d3725c10b6e6e14202efd541a9fdc5a7#89754a92d3725c10b6e6e14202efd541a9fdc5a7"
+source = "git+https://github.com/DataDog/libdatadog?rev=08bb6c2fe8a044bde3a5a4e483dbc6ce8486a1b0#08bb6c2fe8a044bde3a5a4e483dbc6ce8486a1b0"
 dependencies = [
  "datadog-protos 0.1.0 (git+https://github.com/DataDog/saluki/?rev=c89b58e5784b985819baf11f13f7d35876741222)",
  "ddsketch-agent 0.1.0 (git+https://github.com/DataDog/saluki/?rev=c89b58e5784b985819baf11f13f7d35876741222)",
  "derive_more",
  "fnv",
  "hashbrown 0.14.5",
- "lazy_static",
  "protobuf",
  "regex",
  "reqwest",

--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -867,7 +867,7 @@ dependencies = [
 [[package]]
 name = "dogstatsd"
 version = "16.0.3"
-source = "git+https://github.com/DataDog/libdatadog?rev=a39cea5db6c9b4f32925c3ffcf7b6eda79faa24a#a39cea5db6c9b4f32925c3ffcf7b6eda79faa24a"
+source = "git+https://github.com/DataDog/libdatadog?rev=18d44de3573b30dfad736a51c3120cc1207f05e3#18d44de3573b30dfad736a51c3120cc1207f05e3"
 dependencies = [
  "datadog-protos 0.1.0 (git+https://github.com/DataDog/saluki/?rev=c89b58e5784b985819baf11f13f7d35876741222)",
  "ddsketch-agent 0.1.0 (git+https://github.com/DataDog/saluki/?rev=c89b58e5784b985819baf11f13f7d35876741222)",

--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -867,7 +867,7 @@ dependencies = [
 [[package]]
 name = "dogstatsd"
 version = "16.0.3"
-source = "git+https://github.com/DataDog/libdatadog?rev=18d44de3573b30dfad736a51c3120cc1207f05e3#18d44de3573b30dfad736a51c3120cc1207f05e3"
+source = "git+https://github.com/DataDog/libdatadog?rev=7982adc0c6966925f66625ca57759c0d7089a54d#7982adc0c6966925f66625ca57759c0d7089a54d"
 dependencies = [
  "datadog-protos 0.1.0 (git+https://github.com/DataDog/saluki/?rev=c89b58e5784b985819baf11f13f7d35876741222)",
  "ddsketch-agent 0.1.0 (git+https://github.com/DataDog/saluki/?rev=c89b58e5784b985819baf11f13f7d35876741222)",

--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -867,7 +867,7 @@ dependencies = [
 [[package]]
 name = "dogstatsd"
 version = "16.0.3"
-source = "git+https://github.com/DataDog/libdatadog?rev=9e7d85bfb65331b18c49d054e0d0a6eee665bc75#9e7d85bfb65331b18c49d054e0d0a6eee665bc75"
+source = "git+https://github.com/DataDog/libdatadog?rev=a39cea5db6c9b4f32925c3ffcf7b6eda79faa24a#a39cea5db6c9b4f32925c3ffcf7b6eda79faa24a"
 dependencies = [
  "datadog-protos 0.1.0 (git+https://github.com/DataDog/saluki/?rev=c89b58e5784b985819baf11f13f7d35876741222)",
  "ddsketch-agent 0.1.0 (git+https://github.com/DataDog/saluki/?rev=c89b58e5784b985819baf11f13f7d35876741222)",

--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -867,7 +867,7 @@ dependencies = [
 [[package]]
 name = "dogstatsd"
 version = "16.0.3"
-source = "git+https://github.com/DataDog/libdatadog?rev=08bb6c2fe8a044bde3a5a4e483dbc6ce8486a1b0#08bb6c2fe8a044bde3a5a4e483dbc6ce8486a1b0"
+source = "git+https://github.com/DataDog/libdatadog?rev=9e7d85bfb65331b18c49d054e0d0a6eee665bc75#9e7d85bfb65331b18c49d054e0d0a6eee665bc75"
 dependencies = [
  "datadog-protos 0.1.0 (git+https://github.com/DataDog/saluki/?rev=c89b58e5784b985819baf11f13f7d35876741222)",
  "ddsketch-agent 0.1.0 (git+https://github.com/DataDog/saluki/?rev=c89b58e5784b985819baf11f13f7d35876741222)",

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -15,7 +15,7 @@ datadog-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "4b
 datadog-trace-mini-agent = { git = "https://github.com/DataDog/libdatadog", rev = "4ba2f3a7b6bc298035bad8721134a4c34fdd2f1a" }
 datadog-trace-normalization = { git = "https://github.com/DataDog/libdatadog", rev = "4ba2f3a7b6bc298035bad8721134a4c34fdd2f1a" }
 datadog-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "4ba2f3a7b6bc298035bad8721134a4c34fdd2f1a" }
-dogstatsd = { git = "https://github.com/DataDog/libdatadog", rev = "89754a92d3725c10b6e6e14202efd541a9fdc5a7" }
+dogstatsd = { git = "https://github.com/DataDog/libdatadog", rev = "08bb6c2fe8a044bde3a5a4e483dbc6ce8486a1b0" }
 figment = { version = "0.10", default-features = false, features = ["yaml", "env"] }
 hyper = { version = "0.14", default-features = false, features = ["server"] }
 lazy_static = { version = "1.5", default-features = false }

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -15,7 +15,7 @@ datadog-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "4b
 datadog-trace-mini-agent = { git = "https://github.com/DataDog/libdatadog", rev = "4ba2f3a7b6bc298035bad8721134a4c34fdd2f1a" }
 datadog-trace-normalization = { git = "https://github.com/DataDog/libdatadog", rev = "4ba2f3a7b6bc298035bad8721134a4c34fdd2f1a" }
 datadog-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "4ba2f3a7b6bc298035bad8721134a4c34fdd2f1a" }
-dogstatsd = { git = "https://github.com/DataDog/libdatadog", rev = "9e7d85bfb65331b18c49d054e0d0a6eee665bc75" }
+dogstatsd = { git = "https://github.com/DataDog/libdatadog", rev = "a39cea5db6c9b4f32925c3ffcf7b6eda79faa24a" }
 figment = { version = "0.10", default-features = false, features = ["yaml", "env"] }
 hyper = { version = "0.14", default-features = false, features = ["server"] }
 lazy_static = { version = "1.5", default-features = false }

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -15,7 +15,7 @@ datadog-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "4b
 datadog-trace-mini-agent = { git = "https://github.com/DataDog/libdatadog", rev = "4ba2f3a7b6bc298035bad8721134a4c34fdd2f1a" }
 datadog-trace-normalization = { git = "https://github.com/DataDog/libdatadog", rev = "4ba2f3a7b6bc298035bad8721134a4c34fdd2f1a" }
 datadog-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "4ba2f3a7b6bc298035bad8721134a4c34fdd2f1a" }
-dogstatsd = { git = "https://github.com/DataDog/libdatadog", rev = "18d44de3573b30dfad736a51c3120cc1207f05e3" }
+dogstatsd = { git = "https://github.com/DataDog/libdatadog", rev = "7982adc0c6966925f66625ca57759c0d7089a54d" }
 figment = { version = "0.10", default-features = false, features = ["yaml", "env"] }
 hyper = { version = "0.14", default-features = false, features = ["server"] }
 lazy_static = { version = "1.5", default-features = false }

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -15,7 +15,7 @@ datadog-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "4b
 datadog-trace-mini-agent = { git = "https://github.com/DataDog/libdatadog", rev = "4ba2f3a7b6bc298035bad8721134a4c34fdd2f1a" }
 datadog-trace-normalization = { git = "https://github.com/DataDog/libdatadog", rev = "4ba2f3a7b6bc298035bad8721134a4c34fdd2f1a" }
 datadog-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "4ba2f3a7b6bc298035bad8721134a4c34fdd2f1a" }
-dogstatsd = { git = "https://github.com/DataDog/libdatadog", rev = "08bb6c2fe8a044bde3a5a4e483dbc6ce8486a1b0" }
+dogstatsd = { git = "https://github.com/DataDog/libdatadog", rev = "9e7d85bfb65331b18c49d054e0d0a6eee665bc75" }
 figment = { version = "0.10", default-features = false, features = ["yaml", "env"] }
 hyper = { version = "0.14", default-features = false, features = ["server"] }
 lazy_static = { version = "1.5", default-features = false }

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -15,7 +15,7 @@ datadog-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "4b
 datadog-trace-mini-agent = { git = "https://github.com/DataDog/libdatadog", rev = "4ba2f3a7b6bc298035bad8721134a4c34fdd2f1a" }
 datadog-trace-normalization = { git = "https://github.com/DataDog/libdatadog", rev = "4ba2f3a7b6bc298035bad8721134a4c34fdd2f1a" }
 datadog-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "4ba2f3a7b6bc298035bad8721134a4c34fdd2f1a" }
-dogstatsd = { git = "https://github.com/DataDog/libdatadog", rev = "a39cea5db6c9b4f32925c3ffcf7b6eda79faa24a" }
+dogstatsd = { git = "https://github.com/DataDog/libdatadog", rev = "18d44de3573b30dfad736a51c3120cc1207f05e3" }
 figment = { version = "0.10", default-features = false, features = ["yaml", "env"] }
 hyper = { version = "0.14", default-features = false, features = ["server"] }
 lazy_static = { version = "1.5", default-features = false }

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -48,7 +48,8 @@ use dogstatsd::{
     aggregator::Aggregator as MetricsAggregator,
     constants::CONTEXTS,
     datadog::{
-        DdDdUrl, DdUrl, MetricsIntakeUrlPrefix, MetricsIntakeUrlPrefixOverride, Site as MetricsSite, RetryStrategy as DsdRetryStrategy,
+        DdDdUrl, DdUrl, MetricsIntakeUrlPrefix, MetricsIntakeUrlPrefixOverride,
+        RetryStrategy as DsdRetryStrategy, Site as MetricsSite,
     },
     dogstatsd::{DogStatsD, DogStatsDConfig},
     flusher::{Flusher as MetricsFlusher, FlusherConfig as MetricsFlusherConfig},

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -48,7 +48,7 @@ use dogstatsd::{
     aggregator::Aggregator as MetricsAggregator,
     constants::CONTEXTS,
     datadog::{
-        DdDdUrl, DdUrl, MetricsIntakeUrlPrefix, MetricsIntakeUrlPrefixOverride, Site as MetricsSite,
+        DdDdUrl, DdUrl, MetricsIntakeUrlPrefix, MetricsIntakeUrlPrefixOverride, Site as MetricsSite, RetryStrategy as DsdRetryStrategy,
     },
     dogstatsd::{DogStatsD, DogStatsDConfig},
     flusher::{Flusher as MetricsFlusher, FlusherConfig as MetricsFlusherConfig},
@@ -678,6 +678,7 @@ fn start_metrics_flusher(
         metrics_intake_url_prefix: metrics_intake_url.expect("can't parse site or override"),
         https_proxy: config.https_proxy.clone(),
         timeout: Duration::from_secs(config.flush_timeout),
+        retry_strategy: DsdRetryStrategy::Immediate(3),
     };
     MetricsFlusher::new(flusher_config)
 }

--- a/bottlecap/tests/metrics_integration_test.rs
+++ b/bottlecap/tests/metrics_integration_test.rs
@@ -50,6 +50,7 @@ async fn test_enhanced_metrics() {
             .expect("can't parse metrics intake URL from site"),
         https_proxy: None,
         timeout: std::time::Duration::from_secs(5),
+        retry_strategy: dogstatsd::datadog::RetryStrategy::Immediate(1),
     };
     let mut metrics_flusher = MetricsFlusher::new(flusher_config);
     let lambda_enhanced_metrics =


### PR DESCRIPTION
fixes: #612

also includes a faster tag sorter for startup
