### PR TITLE
chore: remove mutex lock for `ContextBuffer` 

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -15,8 +15,7 @@ use bottlecap::{
     event_bus::bus::EventBus,
     events::Event,
     lifecycle::{
-        flush_control::FlushControl,
-        invocation::{context::ContextBuffer, processor::Processor as InvocationProcessor},
+        flush_control::FlushControl, invocation::processor::Processor as InvocationProcessor,
         listener::Listener as LifecycleListener,
     },
     logger,
@@ -330,20 +329,18 @@ async fn extension_loop_active(
     let mut metrics_flusher =
         start_metrics_flusher(resolved_api_key.clone(), &metrics_aggr, config);
     // Lifecycle Invocation Processor
-    let context_buffer = Arc::new(Mutex::new(ContextBuffer::default()));
     let invocation_processor = Arc::new(TokioMutex::new(InvocationProcessor::new(
         Arc::clone(&tags_provider),
         Arc::clone(config),
         aws_config,
         Arc::clone(&metrics_aggr),
-        Arc::clone(&context_buffer),
     )));
 
     let (trace_agent_channel, trace_flusher, trace_processor, stats_flusher) = start_trace_agent(
         config,
         resolved_api_key.clone(),
         &tags_provider,
-        context_buffer.clone(),
+        Arc::clone(&invocation_processor),
     );
 
     let lifecycle_listener = LifecycleListener {
@@ -695,7 +692,7 @@ fn start_trace_agent(
     config: &Arc<Config>,
     resolved_api_key: String,
     tags_provider: &Arc<TagProvider>,
-    context_buffer: Arc<Mutex<ContextBuffer>>,
+    invocation_processor: Arc<TokioMutex<InvocationProcessor>>,
 ) -> (
     Sender<datadog_trace_utils::send_data::SendData>,
     Arc<trace_flusher::ServerlessTraceFlusher>,
@@ -739,8 +736,8 @@ fn start_trace_agent(
         trace_processor.clone(),
         stats_aggregator,
         stats_processor,
+        invocation_processor,
         Arc::clone(tags_provider),
-        context_buffer,
         resolved_api_key,
     ));
     let trace_agent_channel = trace_agent.get_sender_copy();

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -649,14 +649,14 @@ impl Processor {
         self.enhanced_metrics.increment_oom_metric(timestamp);
     }
 
-    /// Add a tracer span to the context buffer for the given request_id, if present.
+    /// Add a tracer span to the context buffer for the given `request_id`, if present.
     ///
     /// This is used to enrich the invocation span with additional metadata from the tracers
     /// top level span, since we discard the tracer span when we create the invocation span.
-    pub fn add_tracer_span(&mut self, tracer_top_level_span: &Span) {
-        if let Some(request_id) = tracer_top_level_span.meta.get("request_id") {
+    pub fn add_tracer_span(&mut self, span: &Span) {
+        if let Some(request_id) = span.meta.get("request_id") {
             self.context_buffer
-                .add_tracer_span(request_id, Some(tracer_top_level_span.clone()));
+                .add_tracer_span(request_id, Some(span.clone()));
         }
     }
 }

--- a/bottlecap/src/traces/trace_agent.rs
+++ b/bottlecap/src/traces/trace_agent.rs
@@ -8,7 +8,6 @@ use serde_json::json;
 use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::sync::Mutex as SyncMutex;
 use std::time::Instant;
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::sync::Mutex;
@@ -16,9 +15,11 @@ use tracing::{debug, error};
 
 use crate::config;
 use crate::http_client;
-use crate::lifecycle::invocation::context::ContextBuffer;
+use crate::lifecycle::invocation::processor::Processor as InvocationProcessor;
 use crate::tags::provider;
-use crate::traces::{stats_aggregator, stats_processor, trace_aggregator, trace_processor};
+use crate::traces::{
+    stats_aggregator, stats_processor, trace_aggregator, trace_processor, INVOCATION_SPAN_RESOURCE,
+};
 use datadog_trace_mini_agent::http_utils::{
     self, log_and_create_http_response, log_and_create_traces_success_http_response,
 };
@@ -45,7 +46,7 @@ pub struct TraceAgent {
     pub stats_aggregator: Arc<Mutex<stats_aggregator::StatsAggregator>>,
     pub stats_processor: Arc<dyn stats_processor::StatsProcessor + Send + Sync>,
     pub tags_provider: Arc<provider::Provider>,
-    pub context_buffer: Arc<SyncMutex<ContextBuffer>>,
+    invocation_processor: Arc<Mutex<InvocationProcessor>>,
     http_client: reqwest::Client,
     api_key: String,
     tx: Sender<SendData>,
@@ -66,8 +67,8 @@ impl TraceAgent {
         trace_processor: Arc<dyn trace_processor::TraceProcessor + Send + Sync>,
         stats_aggregator: Arc<Mutex<stats_aggregator::StatsAggregator>>,
         stats_processor: Arc<dyn stats_processor::StatsProcessor + Send + Sync>,
+        invocation_processor: Arc<Mutex<InvocationProcessor>>,
         tags_provider: Arc<provider::Provider>,
-        context_buffer: Arc<SyncMutex<ContextBuffer>>,
         resolved_api_key: String,
     ) -> TraceAgent {
         // setup a channel to send processed traces to our flusher. tx is passed through each
@@ -91,8 +92,8 @@ impl TraceAgent {
             trace_processor,
             stats_aggregator,
             stats_processor,
+            invocation_processor,
             tags_provider,
-            context_buffer,
             http_client: http_client::get_client(config),
             tx: trace_tx,
             api_key: resolved_api_key,
@@ -123,7 +124,7 @@ impl TraceAgent {
         let stats_processor = self.stats_processor.clone();
         let endpoint_config = self.config.clone();
         let tags_provider = self.tags_provider.clone();
-        let context_buffer = self.context_buffer.clone();
+        let invocation_processor = self.invocation_processor.clone();
         let client = self.http_client.clone();
         let api_key = self.api_key.clone();
 
@@ -136,7 +137,7 @@ impl TraceAgent {
 
             let endpoint_config = endpoint_config.clone();
             let tags_provider = tags_provider.clone();
-            let context_buffer = context_buffer.clone();
+            let invocation_processor = invocation_processor.clone();
             let client = client.clone();
             let api_key = api_key.clone();
 
@@ -148,8 +149,8 @@ impl TraceAgent {
                     trace_tx.clone(),
                     stats_processor.clone(),
                     stats_tx.clone(),
+                    invocation_processor.clone(),
                     tags_provider.clone(),
-                    context_buffer.clone(),
                     client.clone(),
                     api_key.clone(),
                 )
@@ -187,8 +188,8 @@ impl TraceAgent {
         trace_tx: Sender<SendData>,
         stats_processor: Arc<dyn stats_processor::StatsProcessor + Send + Sync>,
         stats_tx: Sender<pb::ClientStatsPayload>,
+        invocation_processor: Arc<Mutex<InvocationProcessor>>,
         tags_provider: Arc<provider::Provider>,
-        context_buffer: Arc<SyncMutex<ContextBuffer>>,
         client: reqwest::Client,
         api_key: String,
     ) -> http::Result<Response<Body>> {
@@ -198,9 +199,9 @@ impl TraceAgent {
                 req,
                 trace_processor.clone(),
                 trace_tx,
+                invocation_processor.clone(),
                 tags_provider,
                 ApiVersion::V04,
-                context_buffer.clone(),
             )
             .await
             {
@@ -215,9 +216,9 @@ impl TraceAgent {
                 req,
                 trace_processor.clone(),
                 trace_tx,
+                invocation_processor.clone(),
                 tags_provider,
                 ApiVersion::V05,
-                context_buffer.clone(),
             )
             .await
             {
@@ -276,9 +277,9 @@ impl TraceAgent {
         req: Request<Body>,
         trace_processor: Arc<dyn trace_processor::TraceProcessor + Send + Sync>,
         trace_tx: Sender<SendData>,
+        invocation_processor: Arc<Mutex<InvocationProcessor>>,
         tags_provider: Arc<provider::Provider>,
         version: ApiVersion,
-        context_buffer: Arc<SyncMutex<ContextBuffer>>,
     ) -> http::Result<Response<Body>> {
         let (parts, body) = req.into_parts();
 
@@ -313,6 +314,16 @@ impl TraceAgent {
             },
         };
 
+        // Search for trace invocation span and send it to the invocation processor
+        for chunk in &traces {
+            for span in chunk {
+                if span.resource == INVOCATION_SPAN_RESOURCE {
+                    let mut invocation_processor = invocation_processor.lock().await;
+                    invocation_processor.add_tracer_span(span);
+                }
+            }
+        }
+
         let send_data = trace_processor.process_traces(
             config,
             tags_provider,
@@ -320,7 +331,6 @@ impl TraceAgent {
             traces,
             body_size,
             None,
-            context_buffer,
         );
 
         // send trace payload to our trace flusher

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config;
-use crate::lifecycle::invocation::context::ContextBuffer;
 use crate::tags::provider;
 use crate::traces::span_pointers::{attach_span_pointers_to_meta, SpanPointer};
 use crate::traces::{
@@ -23,7 +22,7 @@ use datadog_trace_utils::tracer_payload::{
 };
 use ddcommon::Endpoint;
 use std::str::FromStr;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tracing::error;
 
 #[derive(Clone)]
@@ -37,14 +36,13 @@ struct ChunkProcessor {
     obfuscation_config: Arc<obfuscation_config::ObfuscationConfig>,
     tags_provider: Arc<provider::Provider>,
     span_pointers: Option<Vec<SpanPointer>>,
-    context_buffer: Arc<Mutex<ContextBuffer>>,
 }
 
 impl TraceChunkProcessor for ChunkProcessor {
     fn process(&mut self, chunk: &mut pb::TraceChunk, root_span_index: usize) {
-        chunk.spans.retain(|span| {
-            !filter_span_from_lambda_library_or_runtime(span, self.context_buffer.clone())
-        });
+        chunk
+            .spans
+            .retain(|span| !filter_span_from_lambda_library_or_runtime(span));
         for span in &mut chunk.spans {
             // Service name could be incorrectly set to 'aws.lambda'
             // in datadog lambda libraries
@@ -70,10 +68,7 @@ impl TraceChunkProcessor for ChunkProcessor {
     }
 }
 
-fn filter_span_from_lambda_library_or_runtime(
-    span: &Span,
-    context_buffer: Arc<Mutex<ContextBuffer>>,
-) -> bool {
+fn filter_span_from_lambda_library_or_runtime(span: &Span) -> bool {
     if let Some(url) = span.meta.get("http.url") {
         if url.starts_with(LAMBDA_RUNTIME_URL_PREFIX)
             || url.starts_with(LAMBDA_EXTENSION_URL_PREFIX)
@@ -107,10 +102,6 @@ fn filter_span_from_lambda_library_or_runtime(
         }
     }
     if span.resource == INVOCATION_SPAN_RESOURCE {
-        let mut guard = context_buffer.lock().expect("lock poisoned");
-        if let Some(request_id) = span.meta.get("request_id") {
-            guard.add_tracer_span(request_id, Some(span.clone()));
-        }
         return true;
     }
 
@@ -135,7 +126,6 @@ pub trait TraceProcessor {
         traces: Vec<Vec<pb::Span>>,
         body_size: usize,
         span_pointers: Option<Vec<SpanPointer>>,
-        context_buffer: Arc<Mutex<ContextBuffer>>,
     ) -> SendData;
 }
 
@@ -148,7 +138,6 @@ impl TraceProcessor for ServerlessTraceProcessor {
         traces: Vec<Vec<pb::Span>>,
         body_size: usize,
         span_pointers: Option<Vec<SpanPointer>>,
-        context_buffer: Arc<Mutex<ContextBuffer>>,
     ) -> SendData {
         let mut payload = trace_utils::collect_trace_chunks(
             V07(traces),
@@ -157,7 +146,6 @@ impl TraceProcessor for ServerlessTraceProcessor {
                 obfuscation_config: self.obfuscation_config.clone(),
                 tags_provider: tags_provider.clone(),
                 span_pointers,
-                context_buffer,
             },
             true,
             false,
@@ -197,19 +185,16 @@ impl TraceProcessor for ServerlessTraceProcessor {
 
 #[cfg(test)]
 mod tests {
-    use datadog_trace_obfuscation::obfuscation_config::ObfuscationConfig;
     use std::{
         collections::HashMap,
-        sync::{Arc, Mutex},
         time::{SystemTime, UNIX_EPOCH},
     };
 
-    use crate::tags::provider::Provider;
-    use crate::traces::trace_processor::{self, TraceProcessor};
-    use crate::LAMBDA_RUNTIME_SLUG;
-    use crate::{config::Config, lifecycle::invocation::context::ContextBuffer};
-    use datadog_trace_protobuf::pb;
-    use datadog_trace_utils::{tracer_header_tags, tracer_payload::TracerPayloadCollection};
+    use datadog_trace_obfuscation::obfuscation_config::ObfuscationConfig;
+
+    use crate::{config::Config, tags::provider::Provider, LAMBDA_RUNTIME_SLUG};
+
+    use super::*;
 
     fn get_current_timestamp_nanos() -> i64 {
         i64::try_from(
@@ -306,7 +291,7 @@ mod tests {
             dropped_p0_spans: 0,
         };
 
-        let trace_processor = trace_processor::ServerlessTraceProcessor {
+        let trace_processor = ServerlessTraceProcessor {
             resolved_api_key: "foo".to_string(),
             obfuscation_config: Arc::new(ObfuscationConfig::new().unwrap()),
         };
@@ -319,7 +304,6 @@ mod tests {
             traces,
             100,
             None,
-            Arc::new(Mutex::new(ContextBuffer::default())),
         );
 
         let expected_tracer_payload = pb::TracerPayload {


### PR DESCRIPTION
# What?

Removes the Mutex Lock on `ContextBuffer`

# Motivation

We were using `ContextBuffer` to share `tracer_span` so that we can enrich the top level span generated by the Extension. Instead, we now share the already existing `InvocationProcessor` lock which allows us to set the `tracer_span` on the given context.

# Tests

Works as before.

# Notes

There is a known issue which only makes it work on cold start spans, this was also something that appeared on the previous approach.
