### PR TITLE
Partially Revert Mirrored Images

### DIFF
--- a/scripts/Dockerfile.alpine.build
+++ b/scripts/Dockerfile.alpine.build
@@ -1,13 +1,13 @@
 # syntax = docker/dockerfile:experimental
 
-FROM registry.ddbuild.io/images/mirror/alpine:3.16 as builder
+FROM alpine:3.16 as builder
 ARG EXTENSION_VERSION
 ARG AGENT_VERSION
 ARG CMD_PATH
 ARG BUILD_TAGS
 
 RUN apk add --no-cache git make musl-dev gcc
-COPY --from=registry.ddbuild.io/images/mirror/golang:1.23.0-alpine /usr/local/go/ /usr/lib/go
+COPY --from=golang:1.23.6-alpine /usr/local/go/ /usr/lib/go
 
 ENV GOROOT /usr/lib/go
 ENV GOPATH /go
@@ -45,7 +45,7 @@ RUN /usr/lib/go/bin/go tool nm datadog-agent | grep -w 'github.com/DataDog/datad
     (echo "agentVersionDefault variable doesn't exist" && exit 1)
 
 # zip the extension
-FROM registry.ddbuild.io/images/mirror/ubuntu:22.04 as compresser
+FROM ubuntu:22.04 as compresser
 ARG CMD_PATH
 ARG DATADOG_WRAPPER=datadog_wrapper
 RUN apt-get update

--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -47,7 +47,7 @@ RUN /usr/local/go/bin/go tool nm datadog-agent | grep -w 'github.com/DataDog/dat
     (echo "agentVersionDefault variable doesn't exist" && exit 1)
 
 # zip the extension
-FROM registry.ddbuild.io/images/mirror/ubuntu:22.04 as compresser
+FROM ubuntu:22.04 as compresser
 ARG CMD_PATH
 ARG DATADOG_WRAPPER=datadog_wrapper
 

--- a/scripts/Dockerfile.race.build
+++ b/scripts/Dockerfile.race.build
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:experimental
 
-FROM registry.ddbuild.io/images/mirror/golang:1.23.0 as builder
+FROM golang:1.22 as builder
 ARG EXTENSION_VERSION
 ARG ENABLE_RACE_DETECTION
 ARG AGENT_VERSION
@@ -36,7 +36,7 @@ RUN go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/ver
     (echo "agentVersionDefault variable doesn't exist" && exit 1)
 
 # zip the extension
-FROM registry.ddbuild.io/images/mirror/ubuntu:22.04 as compresser
+FROM ubuntu:22.04 as compresser
 RUN apt-get update
 RUN apt-get install -y zip
 RUN mkdir /extensions


### PR DESCRIPTION
This partially reverts commit 9a3e8ada9ea0dbbc4e2fa426947f32221b82629e. [#633](https://github.com/DataDog/datadog-lambda-extension/pull/633)

Datadog Agent Serverless Integration Tests, Vulnerability Scan, and Serverless-Init Release Github Workflows are failing due to not being able to pull the mirrored Datadog images.

Only the images in `scripts`, which are used in Github Workflows are reverted as part of this PR. Images in `images` used in GitLab CI/CD for Bottlecap will continue to use the mirrored Datadog images.

https://github.com/DataDog/datadog-agent/actions/runs/14197727594/job/39776831216

```
ERROR: failed to solve: DeadlineExceeded: DeadlineExceeded: DeadlineExceeded: DeadlineExceeded: failed to resolve source metadata for registry.ddbuild.io/images/mirror/ubuntu:22.04: failed to do request: Head "https://registry.ddbuild.io/v2/images/mirror/ubuntu/manifests/22.04": dial tcp 172.27.5.68:443: i/o timeout
```

