### PR TITLE
fix: Don't assume we're always getting a Full request payload, collec…

### DIFF
--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -902,11 +902,12 @@ mod tests {
 
         let context = p.context_buffer.get(&request_id).unwrap();
 
-        assert!(
-            !context
+        assert_eq!(
+            context
                 .invocation_span
                 .metrics
-                .contains_key(TAG_SAMPLING_PRIORITY)
+                .contains_key(TAG_SAMPLING_PRIORITY),
+            false
         );
         assert_eq!(context.invocation_span.trace_id, 888);
         assert_eq!(context.invocation_span.parent_id, 999);
@@ -927,11 +928,12 @@ mod tests {
 
         let context = p.context_buffer.get(&request_id).unwrap();
 
-        assert!(
-            !context
+        assert_eq!(
+            context
                 .invocation_span
                 .metrics
-                .contains_key(TAG_SAMPLING_PRIORITY)
+                .contains_key(TAG_SAMPLING_PRIORITY),
+            false
         );
         assert_eq!(context.invocation_span.trace_id, 111);
         assert_eq!(context.invocation_span.parent_id, 222);

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -902,12 +902,11 @@ mod tests {
 
         let context = p.context_buffer.get(&request_id).unwrap();
 
-        assert_eq!(
-            context
+        assert!(
+            !context
                 .invocation_span
                 .metrics
-                .contains_key(TAG_SAMPLING_PRIORITY),
-            false
+                .contains_key(TAG_SAMPLING_PRIORITY)
         );
         assert_eq!(context.invocation_span.trace_id, 888);
         assert_eq!(context.invocation_span.parent_id, 999);
@@ -928,12 +927,11 @@ mod tests {
 
         let context = p.context_buffer.get(&request_id).unwrap();
 
-        assert_eq!(
-            context
+        assert!(
+            !context
                 .invocation_span
                 .metrics
-                .contains_key(TAG_SAMPLING_PRIORITY),
-            false
+                .contains_key(TAG_SAMPLING_PRIORITY)
         );
         assert_eq!(context.invocation_span.trace_id, 111);
         assert_eq!(context.invocation_span.parent_id, 222);

--- a/bottlecap/src/traces/trace_agent.rs
+++ b/bottlecap/src/traces/trace_agent.rs
@@ -477,9 +477,7 @@ impl TraceAgent {
             ),
         );
         let body_bytes = match body.collect().await {
-            Ok(b) => {
-                b.to_bytes()
-            }
+            Ok(b) => b.to_bytes(),
             Err(err) => {
                 return log_and_create_http_response(
                     &format!("Error collecting request body: {err}"),

--- a/bottlecap/src/traces/trace_agent.rs
+++ b/bottlecap/src/traces/trace_agent.rs
@@ -476,9 +476,16 @@ impl TraceAgent {
                     .unwrap_or_default()
             ),
         );
-        let body_bytes = match body {
-            hyper_migration::Body::Single(bytes) => bytes.collect().await?.to_bytes(),
-            _ => unimplemented!(),
+        let body_bytes = match body.collect().await {
+            Ok(b) => {
+                b.to_bytes()
+            }
+            Err(err) => {
+                return log_and_create_http_response(
+                    &format!("Error collecting request body: {err}"),
+                    StatusCode::BAD_REQUEST,
+                );
+            }
         };
         let response = match request_builder.body(body_bytes).send().await {
             Ok(resp) => resp,


### PR DESCRIPTION
…t it anyway

Fixes an issue where hyper's `incoming` type fails here because I didn't fully understand the implementation details of the hyper_migration shim. Easy fix