### PR TITLE
bump go to 1.23.8 for serverless-init

### DIFF
--- a/scripts/Dockerfile.alpine.build
+++ b/scripts/Dockerfile.alpine.build
@@ -7,7 +7,7 @@ ARG CMD_PATH
 ARG BUILD_TAGS
 
 RUN apk add --no-cache git make musl-dev gcc
-COPY --from=golang:1.23.6-alpine /usr/local/go/ /usr/lib/go
+COPY --from=golang:1.23.8-alpine /usr/local/go/ /usr/lib/go
 
 ENV GOROOT /usr/lib/go
 ENV GOPATH /go

--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -15,8 +15,8 @@ RUN arch="$(uname -m)"; \
     if [ "${arch}" = 'x86_64' ]; then \
     arch='amd64'; \
     fi; \
-    wget -O go1.23.6.linux-${arch}.tar.gz https://go.dev/dl/go1.23.6.linux-${arch}.tar.gz; \
-    tar -C /usr/local -xzf go1.23.6.linux-${arch}.tar.gz
+    wget -O go1.23.8.linux-${arch}.tar.gz https://go.dev/dl/go1.23.8.linux-${arch}.tar.gz; \
+    tar -C /usr/local -xzf go1.23.8.linux-${arch}.tar.gz
 
 # cache dependencies
 COPY ./scripts/.cache/go.mod /tmp/dd/datadog-agent

--- a/scripts/Dockerfile.race.build
+++ b/scripts/Dockerfile.race.build
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:experimental
 
-FROM golang:1.22 as builder
+FROM golang:1.23.8 as builder
 ARG EXTENSION_VERSION
 ARG ENABLE_RACE_DETECTION
 ARG AGENT_VERSION


### PR DESCRIPTION
Vulnerability scan failure: https://github.com/DataDog/datadog-lambda-extension/actions/runs/14369347938/job/40331528479

<img width="853" alt="Screenshot 2025-04-10 at 11 09 39 AM" src="https://github.com/user-attachments/assets/04cb3c40-6495-44be-a1c1-8c68d9932b0f" />

https://datadoghq.atlassian.net/browse/SVLS-6593

Built rc image (1.6.1-rc1, 1.6.1-rc1-alpine), ran `trivy image` command against images to confirm vulnerability was addressed. Deployed to GCR self monitoring

