### PR TITLE
do not override trace id or span id if they were already set during

### DIFF
--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -906,12 +906,10 @@ mod tests {
 
         let context = p.context_buffer.get(&request_id).unwrap();
 
-        assert!(
-            !context
-                .invocation_span
-                .metrics
-                .contains_key(TAG_SAMPLING_PRIORITY)
-        );
+        assert!(!context
+            .invocation_span
+            .metrics
+            .contains_key(TAG_SAMPLING_PRIORITY));
         assert_eq!(context.invocation_span.trace_id, 888);
         assert_eq!(context.invocation_span.parent_id, 999);
     }
@@ -931,12 +929,10 @@ mod tests {
 
         let context = p.context_buffer.get(&request_id).unwrap();
 
-        assert!(
-            !context
-                .invocation_span
-                .metrics
-                .contains_key(TAG_SAMPLING_PRIORITY)
-        );
+        assert!(!context
+            .invocation_span
+            .metrics
+            .contains_key(TAG_SAMPLING_PRIORITY));
         assert_eq!(context.invocation_span.trace_id, 111);
         assert_eq!(context.invocation_span.parent_id, 222);
     }

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -331,8 +331,12 @@ impl Processor {
 
         // Handle timeout error case
         if status == Status::Timeout {
-            context.invocation_span.trace_id = generate_span_id();
-            context.invocation_span.span_id = generate_span_id();
+            if context.invocation_span.trace_id == 0 {
+                context.invocation_span.trace_id = generate_span_id();
+            }
+            if context.invocation_span.span_id == 0 {
+                context.invocation_span.span_id = generate_span_id();
+            }
             context.invocation_span.error = 1; // Mark as error
             context.invocation_span.meta.insert(
                 "error.msg".to_string(),
@@ -902,12 +906,11 @@ mod tests {
 
         let context = p.context_buffer.get(&request_id).unwrap();
 
-        assert_eq!(
-            context
+        assert!(
+            !context
                 .invocation_span
                 .metrics
-                .contains_key(TAG_SAMPLING_PRIORITY),
-            false
+                .contains_key(TAG_SAMPLING_PRIORITY)
         );
         assert_eq!(context.invocation_span.trace_id, 888);
         assert_eq!(context.invocation_span.parent_id, 999);
@@ -928,12 +931,11 @@ mod tests {
 
         let context = p.context_buffer.get(&request_id).unwrap();
 
-        assert_eq!(
-            context
+        assert!(
+            !context
                 .invocation_span
                 .metrics
-                .contains_key(TAG_SAMPLING_PRIORITY),
-            false
+                .contains_key(TAG_SAMPLING_PRIORITY)
         );
         assert_eq!(context.invocation_span.trace_id, 111);
         assert_eq!(context.invocation_span.parent_id, 222);


### PR DESCRIPTION
timeout