### PR TITLE
feat(bottlecap): add API Gateway Websocket inferred spans

### DIFF
--- a/bottlecap/src/lifecycle/invocation/span_inferrer.rs
+++ b/bottlecap/src/lifecycle/invocation/span_inferrer.rs
@@ -11,6 +11,7 @@ use crate::lifecycle::invocation::{
     triggers::{
         api_gateway_http_event::APIGatewayHttpEvent,
         api_gateway_rest_event::APIGatewayRestEvent,
+        api_gateway_websocket_event::APIGatewayWebSocketEvent,
         dynamodb_event::DynamoDbRecord,
         event_bridge_event::EventBridgeEvent,
         kinesis_event::KinesisRecord,
@@ -88,6 +89,12 @@ impl SpanInferrer {
             }
         } else if APIGatewayRestEvent::is_match(payload_value) {
             if let Some(t) = APIGatewayRestEvent::new(payload_value.clone()) {
+                t.enrich_span(&mut inferred_span, &self.service_mapping);
+
+                trigger = Some(Box::new(t));
+            }
+        } else if APIGatewayWebSocketEvent::is_match(payload_value) {
+            if let Some(t) = APIGatewayWebSocketEvent::new(payload_value.clone()) {
                 t.enrich_span(&mut inferred_span, &self.service_mapping);
 
                 trigger = Some(Box::new(t));

--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
@@ -26,6 +26,17 @@ pub struct RequestContext {
     pub domain_name: String,
     #[serde(rename = "requestTimeEpoch")]
     pub time_epoch: i64,
+    #[serde(rename = "requestId")]
+    pub request_id: String,
+    #[serde(rename = "apiId")]
+    pub api_id: String,
+    pub stage: String,
+    #[serde(rename = "connectionId")]
+    pub connection_id: String,
+    #[serde(rename = "eventType")]
+    pub event_type: String,
+    #[serde(rename = "messageDirection")]
+    pub message_direction: String,
 }
 
 impl Trigger for APIGatewayWebSocketEvent {
@@ -65,7 +76,37 @@ impl Trigger for APIGatewayWebSocketEvent {
         span.resource.clone_from(&resource);
         span.r#type = "web".to_string();
         span.start = start_time;
-        // TODO meta
+        span.meta.extend(HashMap::from([
+            (
+                "endpoint".to_string(),
+                self.request_context.route_key.clone(),
+            ),
+            (
+                "resource_names".to_string(),
+                self.request_context.route_key.clone(),
+            ),
+            ("http.url".to_string(), http_url),
+            ("operation_name".to_string(), "aws.apigateway".to_string()),
+            (
+                "request_id".to_string(),
+                self.request_context.request_id.clone(),
+            ),
+            ("apiid".to_string(), self.request_context.api_id.clone()),
+            ("apiname".to_string(), self.request_context.api_id.clone()),
+            ("stage".to_string(), self.request_context.stage.clone()),
+            (
+                "connection_id".to_string(),
+                self.request_context.connection_id.clone(),
+            ),
+            (
+                "event_type".to_string(),
+                self.request_context.event_type.clone(),
+            ),
+            (
+                "message_direction".to_string(),
+                self.request_context.message_direction.clone(),
+            ),
+        ]));
     }
 
     fn get_tags(&self) -> HashMap<String, String> {

--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
@@ -140,18 +140,19 @@ impl Trigger for APIGatewayWebSocketEvent {
         todo!()
     }
 
-    fn get_carrier(&self) -> HashMap<String, String> {
-        todo!()
+    fn is_async(&self) -> bool {
+        // WebSocket events are always async
+        true
     }
 
-    fn is_async(&self) -> bool {
-        todo!()
+    fn get_carrier(&self) -> HashMap<String, String> {
+        self.headers.clone()
     }
 }
 
 impl ServiceNameResolver for APIGatewayWebSocketEvent {
     fn get_specific_identifier(&self) -> String {
-        todo!()
+        self.request_context.api_id.clone()
     }
 
     fn get_generic_identifier(&self) -> &'static str {

--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
@@ -169,3 +169,84 @@ impl ServiceNameResolver for APIGatewayWebSocketEvent {
         "lambda_api_gateway"
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lifecycle::invocation::triggers::test_utils::read_json_file;
+
+    #[test]
+    fn test_new_connect_event() {
+        let json = read_json_file("api_gateway_websocket_connect_event.json");
+        let payload = serde_json::from_str(&json).expect("Failed to deserialize into Value");
+        let result = APIGatewayWebSocketEvent::new(payload)
+            .expect("Failed to deserialize into APIGatewayWebSocketEvent");
+
+        let expected = APIGatewayWebSocketEvent {
+            headers: HashMap::new(),
+            request_context: RequestContext {
+                route_key: "hello".to_string(),
+                domain_name: "85fj5nw29d.execute-api.eu-west-1.amazonaws.com".to_string(),
+                time_epoch: 1666633666203,
+                request_id: "ahVmYGOMmjQFhyg=".to_string(),
+                api_id: "85fj5nw29d".to_string(),
+                stage: "dev".to_string(),
+                connection_id: "ahVWscZqmjQCI1w=".to_string(),
+                event_type: "MESSAGE".to_string(),
+                message_direction: "IN".to_string(),
+            },
+        };
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_new_message_event() {
+        let json = read_json_file("api_gateway_websocket_message_event.json");
+        let payload = serde_json::from_str(&json).expect("Failed to deserialize into Value");
+        let result = APIGatewayWebSocketEvent::new(payload)
+            .expect("Failed to deserialize into APIGatewayWebSocketEvent");
+
+        let expected = APIGatewayWebSocketEvent {
+            headers: HashMap::new(),
+            request_context: RequestContext {
+                route_key: "hello".to_string(),
+                domain_name: "85fj5nw29d.execute-api.eu-west-1.amazonaws.com".to_string(),
+                time_epoch: 1666633666203,
+                request_id: "ahVmYGOMmjQFhyg=".to_string(),
+                api_id: "85fj5nw29d".to_string(),
+                stage: "dev".to_string(),
+                connection_id: "ahVWscZqmjQCI1w=".to_string(),
+                event_type: "MESSAGE".to_string(),
+                message_direction: "IN".to_string(),
+            },
+        };
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_new_disconnect_event() {
+        let json = read_json_file("api_gateway_websocket_disconnect_event.json");
+        let payload = serde_json::from_str(&json).expect("Failed to deserialize into Value");
+        let result = APIGatewayWebSocketEvent::new(payload)
+            .expect("Failed to deserialize into APIGatewayWebSocketEvent");
+
+        let expected = APIGatewayWebSocketEvent {
+            headers: HashMap::new(),
+            request_context: RequestContext {
+                route_key: "hello".to_string(),
+                domain_name: "85fj5nw29d.execute-api.eu-west-1.amazonaws.com".to_string(),
+                time_epoch: 1666633666203,
+                request_id: "ahVmYGOMmjQFhyg=".to_string(),
+                api_id: "85fj5nw29d".to_string(),
+                stage: "production".to_string(),
+                connection_id: "ahVWscZqmjQCI1w=".to_string(),
+                event_type: "DISCONNECT".to_string(), // Note: The example payload shows MESSAGE event type, not DISCONNECT
+                message_direction: "IN".to_string(),
+            },
+        };
+
+        assert_eq!(result, expected);
+    }
+}

--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
@@ -1,0 +1,79 @@
+use crate::lifecycle::invocation::triggers::{lowercase_key, Trigger};
+use datadog_trace_protobuf::pb::Span;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use tracing::debug;
+
+use super::ServiceNameResolver;
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct APIGatewayWebSocketEvent {
+    #[serde(deserialize_with = "lowercase_key")]
+    pub headers: HashMap<String, String>,
+    #[serde(rename = "requestContext")]
+    pub request_context: RequestContext,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct RequestContext {
+    pub stage: String,
+}
+
+impl Trigger for APIGatewayWebSocketEvent {
+    fn new(payload: Value) -> Option<Self> {
+        match serde_json::from_value(payload) {
+            Ok(event) => Some(event),
+            Err(e) => {
+                debug!("Failed to deserialize APIGatewayWebSocketEvent: {}", e);
+                None
+            }
+        }
+    }
+
+    fn is_match(payload: &Value) -> bool {
+        let message_direction = payload
+            .get("requestContext")
+            .and_then(|v| v.get("messageDirection"));
+        message_direction.is_some()
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    fn enrich_span(&self, span: &mut Span, service_mapping: &HashMap<String, String>) {
+        todo!()
+    }
+
+    fn get_tags(&self) -> HashMap<String, String> {
+        todo!()
+    }
+
+    fn get_arn(&self, region: &str) -> String {
+        todo!()
+    }
+
+    fn get_carrier(&self) -> HashMap<String, String> {
+        todo!()
+    }
+
+    fn is_async(&self) -> bool {
+        todo!()
+    }
+
+    fn resolve_service_name(
+        &self,
+        service_mapping: &HashMap<String, String>,
+        fallback: &str,
+    ) -> String {
+        todo!()
+    }
+}
+
+impl ServiceNameResolver for APIGatewayWebSocketEvent {
+    fn get_specific_identifier(&self) -> String {
+        todo!()
+    }
+
+    fn get_generic_identifier(&self) -> &'static str {
+        "lambda_api_gateway"
+    }
+}

--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
@@ -1,6 +1,9 @@
-use crate::lifecycle::invocation::{
-    processor::MS_TO_NS,
-    triggers::{lowercase_key, Trigger, FUNCTION_TRIGGER_EVENT_SOURCE_TAG},
+use crate::{
+    config::get_aws_partition_by_region,
+    lifecycle::invocation::{
+        processor::MS_TO_NS,
+        triggers::{lowercase_key, Trigger, FUNCTION_TRIGGER_EVENT_SOURCE_TAG},
+    },
 };
 use datadog_trace_protobuf::pb::Span;
 use serde::{Deserialize, Serialize};
@@ -137,7 +140,14 @@ impl Trigger for APIGatewayWebSocketEvent {
     }
 
     fn get_arn(&self, region: &str) -> String {
-        todo!()
+        let partition = get_aws_partition_by_region(region);
+        format!(
+            "arn:{partition}:apigateway:{region}::/apis/{api_id}/stages/{stage}",
+            partition = partition,
+            region = region,
+            api_id = self.request_context.api_id,
+            stage = self.request_context.stage
+        )
     }
 
     fn is_async(&self) -> bool {

--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
@@ -267,4 +267,34 @@ mod tests {
         let payload = serde_json::from_str(&json).expect("Failed to deserialize into Value");
         assert!(!APIGatewayWebSocketEvent::is_match(&payload));
     }
+
+    #[test]
+    fn test_enrich_span() {
+        let json = read_json_file("api_gateway_websocket_connect_event.json");
+        let payload = serde_json::from_str(&json).expect("Failed to deserialize into Value");
+        let event = APIGatewayWebSocketEvent::new(payload)
+            .expect("Failed to deserialize APIGatewayWebSocketEvent");
+
+        let mut span = Span::default();
+        let service_mapping = HashMap::new();
+        event.enrich_span(&mut span, &service_mapping);
+
+        assert_eq!(span.name, "aws.apigateway");
+        assert_eq!(span.service, "85fj5nw29d.execute-api.eu-west-1.amazonaws.com");
+        assert_eq!(span.resource, "hello");
+        assert_eq!(span.r#type, "web");
+        assert_eq!(span.meta, HashMap::from([
+            ("endpoint".to_string(), "hello".to_string()),
+            ("resource_names".to_string(), "hello".to_string()),
+            ("http.url".to_string(), "85fj5nw29d.execute-api.eu-west-1.amazonaws.comhello".to_string()),
+            ("operation_name".to_string(), "aws.apigateway".to_string()),
+            ("request_id".to_string(), "ahVmYGOMmjQFhyg=".to_string()),
+            ("apiid".to_string(), "85fj5nw29d".to_string()),
+            ("apiname".to_string(), "85fj5nw29d".to_string()),
+            ("stage".to_string(), "dev".to_string()),
+            ("connection_id".to_string(), "ahVWscZqmjQCI1w=".to_string()),
+            ("event_type".to_string(), "MESSAGE".to_string()),
+            ("message_direction".to_string(), "IN".to_string()),
+        ]));
+    }
 }

--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
@@ -249,4 +249,22 @@ mod tests {
 
         assert_eq!(result, expected);
     }
+
+    #[test]
+    fn test_is_match() {
+        let json = read_json_file("api_gateway_websocket_connect_event.json");
+        let payload = serde_json::from_str(&json).expect("Failed to deserialize into Value");
+        assert!(APIGatewayWebSocketEvent::is_match(&payload));
+    }
+
+    #[test]
+    fn test_is_not_match() {
+        let json = read_json_file("api_gateway_http_event.json");
+        let payload = serde_json::from_str(&json).expect("Failed to deserialize into Value");
+        assert!(!APIGatewayWebSocketEvent::is_match(&payload));
+
+        let json = read_json_file("api_gateway_proxy_event.json");
+        let payload = serde_json::from_str(&json).expect("Failed to deserialize into Value");
+        assert!(!APIGatewayWebSocketEvent::is_match(&payload));
+    }
 }

--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
@@ -15,7 +15,7 @@ use super::ServiceNameResolver;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct APIGatewayWebSocketEvent {
-    #[serde(deserialize_with = "lowercase_key")]
+    #[serde(deserialize_with = "lowercase_key", default)]
     pub headers: HashMap<String, String>,
     #[serde(rename = "requestContext")]
     pub request_context: RequestContext,

--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
@@ -76,7 +76,7 @@ impl Trigger for APIGatewayWebSocketEvent {
 
         span.name = "aws.apigateway".to_string();
         span.service = service_name;
-        span.resource.clone_from(&resource);
+        span.resource.clone_from(resource);
         span.r#type = "web".to_string();
         span.start = start_time;
         span.meta.extend(HashMap::from([
@@ -280,22 +280,31 @@ mod tests {
         event.enrich_span(&mut span, &service_mapping);
 
         assert_eq!(span.name, "aws.apigateway");
-        assert_eq!(span.service, "85fj5nw29d.execute-api.eu-west-1.amazonaws.com");
+        assert_eq!(
+            span.service,
+            "85fj5nw29d.execute-api.eu-west-1.amazonaws.com"
+        );
         assert_eq!(span.resource, "hello");
         assert_eq!(span.r#type, "web");
-        assert_eq!(span.meta, HashMap::from([
-            ("endpoint".to_string(), "hello".to_string()),
-            ("resource_names".to_string(), "hello".to_string()),
-            ("http.url".to_string(), "85fj5nw29d.execute-api.eu-west-1.amazonaws.comhello".to_string()),
-            ("operation_name".to_string(), "aws.apigateway".to_string()),
-            ("request_id".to_string(), "ahVmYGOMmjQFhyg=".to_string()),
-            ("apiid".to_string(), "85fj5nw29d".to_string()),
-            ("apiname".to_string(), "85fj5nw29d".to_string()),
-            ("stage".to_string(), "dev".to_string()),
-            ("connection_id".to_string(), "ahVWscZqmjQCI1w=".to_string()),
-            ("event_type".to_string(), "MESSAGE".to_string()),
-            ("message_direction".to_string(), "IN".to_string()),
-        ]));
+        assert_eq!(
+            span.meta,
+            HashMap::from([
+                ("endpoint".to_string(), "hello".to_string()),
+                ("resource_names".to_string(), "hello".to_string()),
+                (
+                    "http.url".to_string(),
+                    "85fj5nw29d.execute-api.eu-west-1.amazonaws.comhello".to_string()
+                ),
+                ("operation_name".to_string(), "aws.apigateway".to_string()),
+                ("request_id".to_string(), "ahVmYGOMmjQFhyg=".to_string()),
+                ("apiid".to_string(), "85fj5nw29d".to_string()),
+                ("apiname".to_string(), "85fj5nw29d".to_string()),
+                ("stage".to_string(), "dev".to_string()),
+                ("connection_id".to_string(), "ahVWscZqmjQCI1w=".to_string()),
+                ("event_type".to_string(), "MESSAGE".to_string()),
+                ("message_direction".to_string(), "IN".to_string()),
+            ])
+        );
     }
 
     #[test]
@@ -307,9 +316,15 @@ mod tests {
 
         let tags = event.get_tags();
         let expected = HashMap::from([
-            ("http.url".to_string(), "85fj5nw29d.execute-api.eu-west-1.amazonaws.comhello".to_string()),
+            (
+                "http.url".to_string(),
+                "85fj5nw29d.execute-api.eu-west-1.amazonaws.comhello".to_string(),
+            ),
             ("http.url_details.path".to_string(), "hello".to_string()),
-            ("function_trigger.event_source".to_string(), "api-gateway".to_string()),
+            (
+                "function_trigger.event_source".to_string(),
+                "api-gateway".to_string(),
+            ),
         ]);
 
         assert_eq!(tags, expected);
@@ -338,7 +353,10 @@ mod tests {
         // Priority is given to the specific key
         let specific_service_mapping = HashMap::from([
             ("85fj5nw29d".to_string(), "specific-service".to_string()),
-            ("lambda_api_gateway".to_string(), "generic-service".to_string()),
+            (
+                "lambda_api_gateway".to_string(),
+                "generic-service".to_string(),
+            ),
         ]);
 
         assert_eq!(
@@ -349,15 +367,14 @@ mod tests {
             "specific-service"
         );
 
-        let generic_service_mapping = HashMap::from([
-            ("lambda_api_gateway".to_string(), "generic-service".to_string()),
-        ]);
+        let generic_service_mapping = HashMap::from([(
+            "lambda_api_gateway".to_string(),
+            "generic-service".to_string(),
+        )]);
 
         assert_eq!(
-            event.resolve_service_name(
-                &generic_service_mapping,
-                &event.request_context.domain_name
-            ),
+            event
+                .resolve_service_name(&generic_service_mapping, &event.request_context.domain_name),
             "generic-service"
         );
     }

--- a/bottlecap/src/lifecycle/invocation/triggers/mod.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/mod.rs
@@ -6,6 +6,7 @@ use serde_json::Value;
 
 pub mod api_gateway_http_event;
 pub mod api_gateway_rest_event;
+pub mod api_gateway_websocket_event;
 pub mod dynamodb_event;
 pub mod event_bridge_event;
 pub mod kinesis_event;

--- a/bottlecap/tests/payloads/api_gateway_websocket_connect_event.json
+++ b/bottlecap/tests/payloads/api_gateway_websocket_connect_event.json
@@ -1,0 +1,27 @@
+{
+  "requestContext": {
+    "routeKey": "hello",
+    "authorizer": {
+      "_datadog": "eyJ4LWRhdGFkb2ctdHJhY2UtaWQiOiI2NTQ1NDA2NzQ3NDUzNjg0NjAwIiwieC1kYXRhZG9nLXBhcmVudC1pZCI6IjY1NDU0MDY3NDc0NTM2ODQ2MDAiLCJ4LWRhdGFkb2ctc2FtcGxpbmctcHJpb3JpdHkiOiIxIiwieC1kYXRhZG9nLXBhcmVudC1zcGFuLWZpbmlzaC10aW1lIjoxNjY2NjMzNTY2OTMxLCJ4LWRhdGFkb2ctYXV0aG9yaXppbmctcmVxdWVzdGlkIjoiYWhWV3NIVkFtalFGcTZnPSJ9",
+      "scope": "this is just a string",
+      "principalId": "foo"
+    },
+    "messageId": "ahVmYcavmjQCI1w=",
+    "eventType": "MESSAGE",
+    "extendedRequestId": "ahVmYGOMmjQFhyg=",
+    "requestTime": "24/Oct/2022:17:47:46 +0000",
+    "messageDirection": "IN",
+    "stage": "dev",
+    "connectedAt": 1666633565827,
+    "requestTimeEpoch": 1666633666203,
+    "identity": {
+      "sourceIp": "24.193.182.233"
+    },
+    "requestId": "ahVmYGOMmjQFhyg=",
+    "domainName": "85fj5nw29d.execute-api.eu-west-1.amazonaws.com",
+    "connectionId": "ahVWscZqmjQCI1w=",
+    "apiId": "85fj5nw29d"
+  },
+  "body": "{\"action\": \"hello\", \"message\":\"in\"}",
+  "isBase64Encoded": false
+}

--- a/bottlecap/tests/payloads/api_gateway_websocket_disconnect_event.json
+++ b/bottlecap/tests/payloads/api_gateway_websocket_disconnect_event.json
@@ -1,0 +1,27 @@
+{
+  "requestContext": {
+    "routeKey": "hello",
+    "authorizer": {
+      "_datadog": "eyJ4LWRhdGFkb2ctdHJhY2UtaWQiOiI2NTQ1NDA2NzQ3NDUzNjg0NjAwIiwieC1kYXRhZG9nLXBhcmVudC1pZCI6IjY1NDU0MDY3NDc0NTM2ODQ2MDAiLCJ4LWRhdGFkb2ctc2FtcGxpbmctcHJpb3JpdHkiOiIxIiwieC1kYXRhZG9nLXBhcmVudC1zcGFuLWZpbmlzaC10aW1lIjoxNjY2NjMzNTY2OTMxLCJ4LWRhdGFkb2ctYXV0aG9yaXppbmctcmVxdWVzdGlkIjoiYWhWV3NIVkFtalFGcTZnPSJ9",
+      "scope": "this is just a string",
+      "principalId": "foo"
+    },
+    "messageId": "ahVmYcavmjQCI1w=",
+    "eventType": "DISCONNECT",
+    "extendedRequestId": "ahVmYGOMmjQFhyg=",
+    "requestTime": "24/Oct/2022:17:47:46 +0000",
+    "messageDirection": "IN",
+    "stage": "production",
+    "connectedAt": 1666633565827,
+    "requestTimeEpoch": 1666633666203,
+    "identity": {
+      "sourceIp": "24.193.182.233"
+    },
+    "requestId": "ahVmYGOMmjQFhyg=",
+    "domainName": "85fj5nw29d.execute-api.eu-west-1.amazonaws.com",
+    "connectionId": "ahVWscZqmjQCI1w=",
+    "apiId": "85fj5nw29d"
+  },
+  "body": "{\"action\": \"hello\", \"message\":\"in\"}",
+  "isBase64Encoded": false
+}

--- a/bottlecap/tests/payloads/api_gateway_websocket_message_event.json
+++ b/bottlecap/tests/payloads/api_gateway_websocket_message_event.json
@@ -1,0 +1,27 @@
+{
+  "requestContext": {
+    "routeKey": "hello",
+    "authorizer": {
+      "_datadog": "eyJ4LWRhdGFkb2ctdHJhY2UtaWQiOiI2NTQ1NDA2NzQ3NDUzNjg0NjAwIiwieC1kYXRhZG9nLXBhcmVudC1pZCI6IjY1NDU0MDY3NDc0NTM2ODQ2MDAiLCJ4LWRhdGFkb2ctc2FtcGxpbmctcHJpb3JpdHkiOiIxIiwieC1kYXRhZG9nLXBhcmVudC1zcGFuLWZpbmlzaC10aW1lIjoxNjY2NjMzNTY2OTMxLCJ4LWRhdGFkb2ctYXV0aG9yaXppbmctcmVxdWVzdGlkIjoiYWhWV3NIVkFtalFGcTZnPSJ9",
+      "scope": "this is just a string",
+      "principalId": "foo"
+    },
+    "messageId": "ahVmYcavmjQCI1w=",
+    "eventType": "MESSAGE",
+    "extendedRequestId": "ahVmYGOMmjQFhyg=",
+    "requestTime": "24/Oct/2022:17:47:46 +0000",
+    "messageDirection": "IN",
+    "stage": "dev",
+    "connectedAt": 1666633565827,
+    "requestTimeEpoch": 1666633666203,
+    "identity": {
+      "sourceIp": "24.193.182.233"
+    },
+    "requestId": "ahVmYGOMmjQFhyg=",
+    "domainName": "85fj5nw29d.execute-api.eu-west-1.amazonaws.com",
+    "connectionId": "ahVWscZqmjQCI1w=",
+    "apiId": "85fj5nw29d"
+  },
+  "body": "{\"action\": \"hello\", \"message\":\"in\"}",
+  "isBase64Encoded": false
+}


### PR DESCRIPTION
Adds inferred spans for API Gateway Websocket Events (`connect`, `message`, and `disconnect`).

Copied a lot of logic (for tags, span name/resource name, etc.) from the websocket inferred spans in https://github.com/DataDog/datadog-lambda-js/blob/9e67be3a05100ba85d825ed84219cf0a8271f9ec/src/trace/span-inferrer.ts#L88

#### Connect event:
<img width="600" alt="Screenshot 2025-04-15 at 4 00 06 PM" src="https://github.com/user-attachments/assets/da5ac4c3-10ac-4852-938e-6743e9628493" />

_Full JSON of trace: https://pastebin.com/raw/1pdPqWh8_

#### Message event:
<img width="600" alt="Screenshot 2025-04-15 at 4 01 32 PM" src="https://github.com/user-attachments/assets/f814b3a2-5c8d-403a-bbd9-c4ba1734d65b" />

_Full JSON of trace: https://pastebin.com/raw/0c229ts7_

#### Disconnect event:
<img width="600" alt="Screenshot 2025-04-15 at 4 02 35 PM" src="https://github.com/user-attachments/assets/5a9a6ec0-b69d-493b-9f97-e6f836652db0" />

_Full JSON of trace: https://pastebin.com/raw/JryvzpwP_