### PR TITLE
fix: Add sns sqs binary tests

### DIFF
--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
@@ -187,7 +187,7 @@ mod tests {
             request_context: RequestContext {
                 route_key: "hello".to_string(),
                 domain_name: "85fj5nw29d.execute-api.eu-west-1.amazonaws.com".to_string(),
-                time_epoch: 1666633666203,
+                time_epoch: 1_666_633_666_203,
                 request_id: "ahVmYGOMmjQFhyg=".to_string(),
                 api_id: "85fj5nw29d".to_string(),
                 stage: "dev".to_string(),
@@ -212,7 +212,7 @@ mod tests {
             request_context: RequestContext {
                 route_key: "hello".to_string(),
                 domain_name: "85fj5nw29d.execute-api.eu-west-1.amazonaws.com".to_string(),
-                time_epoch: 1666633666203,
+                time_epoch: 1_666_633_666_203,
                 request_id: "ahVmYGOMmjQFhyg=".to_string(),
                 api_id: "85fj5nw29d".to_string(),
                 stage: "dev".to_string(),
@@ -237,7 +237,7 @@ mod tests {
             request_context: RequestContext {
                 route_key: "hello".to_string(),
                 domain_name: "85fj5nw29d.execute-api.eu-west-1.amazonaws.com".to_string(),
-                time_epoch: 1666633666203,
+                time_epoch: 1_666_633_666_203,
                 request_id: "ahVmYGOMmjQFhyg=".to_string(),
                 api_id: "85fj5nw29d".to_string(),
                 stage: "production".to_string(),

--- a/bottlecap/src/lifecycle/invocation/triggers/sqs_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/sqs_event.rs
@@ -445,6 +445,40 @@ mod tests {
     }
 
     #[test]
+    fn test_get_carrier_from_sns_binary() {
+        let json = read_json_file("sns_sqs_binary_event.json");
+        let payload = serde_json::from_str(&json).expect("Failed to deserialize into Value");
+        let event = SqsRecord::new(payload).expect("Failed to deserialize SqsRecord");
+        let carrier = event.get_carrier();
+
+        let expected = HashMap::from([
+            (
+                "x-datadog-trace-id".to_string(),
+                "5863834085596065348".to_string(),
+            ),
+            (
+                "x-datadog-parent-id".to_string(),
+                "2752725546543693249".to_string(),
+            ),
+            (
+                "tracestate".to_string(),
+                "dd=s:1;p:2633a54ccde13dc1;t.tid:6801584a00000000;t.dm:-1".to_string(),
+            ),
+            (
+                "traceparent".to_string(),
+                "00-6801584a00000000516086086dc7ee44-2633a54ccde13dc1-01".to_string(),
+            ),
+            (
+                "x-datadog-tags".to_string(),
+                "_dd.p.dm=-1,_dd.p.tid=6801584a00000000".to_string(),
+            ),
+            ("x-datadog-sampling-priority".to_string(), "1".to_string()),
+        ]);
+
+        assert_eq!(carrier, expected);
+    }
+
+    #[test]
     fn test_get_carrier_from_eventbridge() {
         let json = read_json_file("eventbridge_sqs_event.json");
         let payload = serde_json::from_str(&json).expect("Failed to deserialize into Value");

--- a/bottlecap/tests/payloads/sns_sqs_binary_event.json
+++ b/bottlecap/tests/payloads/sns_sqs_binary_event.json
@@ -1,0 +1,20 @@
+{
+  "Records": [
+    {
+      "messageId": "64812b68-4d9b-4dca-b3fb-9b18f255ee51",
+      "receiptHandle": "AQEBER6aRkfG8092GvkL7FRwCwbQ7LLDW9Tlk/CembqHe+suS2kfFxXiukomvaIN61QoyQMoRgWuV52SDkiQno2u+5hP64BDbmw+e/KR9ayvIfHJ3M6RfyQLaWNWm3hDFBCKTnBMVIxtdx0N9epZZewyokjKcrNYtmCghFgTCvZzsQkowi5rnoHAVHJ3je1c3bDnQ1KLrZFgajDnootYXDwEPuMq5FIxrf4EzTe0S7S+rnRm+GaQfeBLBVAY6dASL9usV3/AFRqDtaI7GKI+0F2NCgLlqj49VlPRz4ldhkGknYlKTZTluAqALWLJS62/J1GQo53Cs3nneJcmu5ajB2zzmhhRXoXINEkLhCD5ujZfcsw9H4xqW69Or4ECvlqx14bUU2rtMIW0QM2p7pEeXnyocymQv6m1te113eYWTVmaJ4I=",
+      "body": "{\n  \"Type\" : \"Notification\",\n  \"MessageId\" : \"0a0ab23e-4861-5447-82b7-e8094ff3e332\",\n  \"TopicArn\" : \"arn:aws:sns:eu-west-1:601427279990:js-library-test-dev-demoTopic-15WGUVRCBMPAA\",\n  \"Message\" : \"{\\\"hello\\\":\\\"harv\\\",\\\"nice of you to join us\\\":\\\"david\\\",\\\"anotherThing\\\":{\\\"foo\\\":\\\"bar\\\",\\\"blah\\\":null,\\\"harv\\\":123},\\\"vals\\\":[{\\\"thingOne\\\":1},{\\\"thingTwo\\\":2}],\\\"ajTimestamp\\\":1639777617957}\",\n  \"Timestamp\" : \"2021-12-17T21:46:58.040Z\",\n  \"SignatureVersion\" : \"1\",\n  \"Signature\" : \"FR35/7E8C3LHEVk/rC4XxXlXwV/5mNkFNPgDhHSnJ2I6hIoSrTROAm7h5xm1PuBkAeFDvq0zofw91ouk9zZyvhdrMLFIIgrjEyNayRmEffmoEAkzLFUsgtQX7MmTl644r4NuWiM0Oiz7jueRvIcKXcZr7Nc6GJcWV1ymec8oOmuHNMisnPMxI07LIQVYSyAfv6P9r2jEWMVIukRoCzwTnRk4bUUYhPSGHI7OC3AsxxXBbv8snqTrLM/4z2rXCf6jHCKNxWeLlm9/45PphCkEyx5BWS4/71KaoMWUWy8+6CCsy+uF3XTCVmvSEYLyEwTSzOY+vCUjazrRW93498i70g==\",\n  \"SigningCertUrl\" : \"https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-7ff5318490ec183fbaddaa2a969abfda.pem\",\n  \"UnsubscribeUrl\" : \"https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:601427279990:js-library-test-dev-demoTopic-15WGUVRCBMPAA:1290f550-9a8a-4e8f-a900-8f5f96dcddda\",\n  \"MessageAttributes\" : {\n    \"_datadog\" : {\"Type\":\"Binary\",\"Value\":\"eyJ0cmFjZXBhcmVudCI6IjAwLTY4MDE1ODRhMDAwMDAwMDA1MTYwODYwODZkYzdlZTQ0LTI2MzNhNTRjY2RlMTNkYzEtMDEiLCJ0cmFjZXN0YXRlIjoiZGQ9czoxO3A6MjYzM2E1NGNjZGUxM2RjMTt0LnRpZDo2ODAxNTg0YTAwMDAwMDAwO3QuZG06LTEiLCJ4LWRhdGFkb2ctcGFyZW50LWlkIjoiMjc1MjcyNTU0NjU0MzY5MzI0OSIsIngtZGF0YWRvZy1zYW1wbGluZy1wcmlvcml0eSI6IjEiLCJ4LWRhdGFkb2ctdGFncyI6Il9kZC5wLmRtPS0xLF9kZC5wLnRpZD02ODAxNTg0YTAwMDAwMDAwIiwieC1kYXRhZG9nLXRyYWNlLWlkIjoiNTg2MzgzNDA4NTU5NjA2NTM0OCJ9\"}\n  }\n}",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1639777618130",
+        "SenderId": "AIDAIOA2GYWSHW4E2VXIO",
+        "ApproximateFirstReceiveTimestamp": "1639777618132"
+      },
+      "messageAttributes": {},
+      "md5OfBody": "ee19d8b1377919239ad3fd5dabc33739",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:eu-west-1:601427279990:aj-js-library-test-dev-demo-queue",
+      "awsRegion": "eu-west-1"
+    }
+  ]
+}


### PR DESCRIPTION
While investigating a trade propagation issue we realized there was no test for binary-encoded sns-sqs payloads, so I've added one.