### PR TITLE
fix: Extract trace context from inferred span when AWS Xray is enabled

### DIFF
--- a/bottlecap/src/lifecycle/invocation/span_inferrer.rs
+++ b/bottlecap/src/lifecycle/invocation/span_inferrer.rs
@@ -312,6 +312,9 @@ impl SpanInferrer {
     /// otherwise it will return `None`.
     ///
     pub fn get_span_context(&self, propagator: &impl Propagator) -> Option<SpanContext> {
+        // Order matters here: check inferred span for trace context first, then fallback to generated span context.
+        // If the order is flipped, trace propagation will be broken when AWS Xray is enabled.
+        // https://github.com/DataDog/datadog-lambda-extension/pull/655
         if let Some(sc) = self.carrier.as_ref().and_then(|c| propagator.extract(c)) {
             debug!("Extracted trace context from inferred span");
             return Some(sc);

--- a/bottlecap/src/lifecycle/invocation/span_inferrer.rs
+++ b/bottlecap/src/lifecycle/invocation/span_inferrer.rs
@@ -319,6 +319,7 @@ impl SpanInferrer {
 
         // Step Functions `SpanContext` is deterministically generated
         if self.generated_span_context.is_some() {
+            debug!("Returning generated span context");
             return self.generated_span_context.clone();
         }
 

--- a/bottlecap/src/lifecycle/invocation/span_inferrer.rs
+++ b/bottlecap/src/lifecycle/invocation/span_inferrer.rs
@@ -333,3 +333,167 @@ impl SpanInferrer {
         self.trigger_tags.clone()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::traces::context::{Sampling, SpanContext};
+    use crate::traces::propagation::text_map_propagator::DatadogHeaderPropagator;
+    use serde_json::json;
+    use std::collections::HashMap;
+    use std::time::Instant;
+
+    use super::*;
+
+    fn test_context_source(
+        carrier: Option<HashMap<String, String>>,
+        generated_context: Option<SpanContext>,
+        expected_source: &str,
+    ) {
+        let mut inferrer = SpanInferrer::default();
+        inferrer.carrier = carrier;
+        inferrer.generated_span_context = generated_context;
+
+        let propagator = DatadogHeaderPropagator;
+        let context = inferrer.get_span_context(&propagator);
+
+        assert!(context.is_some(), "Should return a span context");
+        let context = context.unwrap();
+        match expected_source {
+            "inferred" => {
+                assert_eq!(
+                    context.trace_id, 123456789,
+                    "Should have trace_id from inferred span"
+                );
+                assert_eq!(
+                    context.span_id, 987654321,
+                    "Should have span_id from inferred span"
+                );
+            }
+            "generated" => {
+                assert_eq!(
+                    context.trace_id, 111111111,
+                    "Should have trace_id from generated context"
+                );
+                assert_eq!(
+                    context.span_id, 222222222,
+                    "Should have span_id from generated context"
+                );
+            }
+            "aws_trace_header" => {
+                assert_eq!(
+                    context.trace_id, 0x35578e774943fd9d,
+                    "Should have trace_id from AWSTraceHeader"
+                );
+                assert_eq!(
+                    context.span_id, 0x76c040bdc454a7ac,
+                    "Should have span_id from AWSTraceHeader"
+                );
+            }
+            _ => panic!("Unknown expected source: {}", expected_source),
+        }
+    }
+
+    #[test]
+    fn test_get_span_context_from_inferred_span() {
+        let carrier = HashMap::from([
+            ("x-datadog-trace-id".to_string(), "123456789".to_string()),
+            ("x-datadog-parent-id".to_string(), "987654321".to_string()),
+            ("x-datadog-sampling-priority".to_string(), "1".to_string()),
+        ]);
+
+        let generated_context = SpanContext {
+            trace_id: 111111111,
+            span_id: 222222222,
+            sampling: Some(Sampling {
+                priority: Some(1),
+                mechanism: None,
+            }),
+            origin: None,
+            tags: HashMap::new(),
+            links: Vec::new(),
+        };
+
+        // Should prefer inferred span context from carrier over generated context
+        test_context_source(Some(carrier), Some(generated_context), "inferred");
+    }
+
+    #[test]
+    fn test_get_span_context_fallback_to_generated() {
+        let generated_context = SpanContext {
+            trace_id: 111111111,
+            span_id: 222222222,
+            sampling: Some(Sampling {
+                priority: Some(1),
+                mechanism: None,
+            }),
+            origin: None,
+            tags: HashMap::new(),
+            links: Vec::new(),
+        };
+
+        // Should fallback to generated context when no carrier exists
+        test_context_source(None, Some(generated_context), "generated");
+    }
+
+    #[test]
+    fn test_java_sqs_aws_trace_header() {
+        let mut inferrer = SpanInferrer::default();
+
+        // Create a payload with AWSTraceHeader from Java->SQS->Java
+        let payload = json!({
+            "Records": [{
+                "messageId": "fde33907-bdf2-4e37-bb5b-f19c4f0e5ec2",
+                "receiptHandle": "test-receipt-handle",
+                "body": "Hello World",
+                "attributes": {
+                    "ApproximateReceiveCount": "1",
+                    "AWSTraceHeader": "Root=1-68029e8a-0000000035578e774943fd9d;Parent=76c040bdc454a7ac;Sampled=1",
+                    "SentTimestamp": "1745002122577",
+                    "SenderId": "AROAWGCM4HXUTNAMSZ533:nhulston-java-test-dev-main",
+                    "ApproximateFirstReceiveTimestamp": "1745002122578"
+                },
+                "messageAttributes": {},
+                "md5OfBody": "b10a8db164e0754105b7a99be72e3fe5",
+                "eventSource": "aws:sqs",
+                "eventSourceARN": "arn:aws:sqs:us-east-1:425362996713:nhulston-java",
+                "awsRegion": "us-east-1"
+            }]
+        });
+
+        let aws_config = AwsConfig {
+            region: "us-east-1".to_string(),
+            aws_access_key_id: "".to_string(),
+            aws_secret_access_key: "".to_string(),
+            aws_session_token: "".to_string(),
+            function_name: "".to_string(),
+            sandbox_init_time: Instant::now(),
+            aws_container_credentials_full_uri: "".to_string(),
+            aws_container_authorization_token: "".to_string(),
+        };
+        inferrer.infer_span(&payload, &aws_config);
+
+        assert!(
+            inferrer.generated_span_context.is_some(),
+            "Should generate span context from AWSTraceHeader"
+        );
+        assert!(
+            inferrer.carrier.is_some(),
+            "Should have carrier from SQS event"
+        );
+        let propagator = DatadogHeaderPropagator;
+        let inferred_context = inferrer
+            .carrier
+            .as_ref()
+            .and_then(|c| propagator.extract(c));
+        assert!(
+            inferred_context.is_none(),
+            "Carrier should not have trace context for Java->SQS->Java case"
+        );
+
+        test_context_source(
+            inferrer.carrier,
+            inferrer.generated_span_context,
+            "aws_trace_header",
+        );
+    }
+}

--- a/bottlecap/src/lifecycle/invocation/span_inferrer.rs
+++ b/bottlecap/src/lifecycle/invocation/span_inferrer.rs
@@ -312,14 +312,14 @@ impl SpanInferrer {
     /// otherwise it will return `None`.
     ///
     pub fn get_span_context(&self, propagator: &impl Propagator) -> Option<SpanContext> {
-        // Step Functions `SpanContext` is deterministically generated
-        if self.generated_span_context.is_some() {
-            return self.generated_span_context.clone();
-        }
-
         if let Some(sc) = self.carrier.as_ref().and_then(|c| propagator.extract(c)) {
             debug!("Extracted trace context from inferred span");
             return Some(sc);
+        }
+
+        // Step Functions `SpanContext` is deterministically generated
+        if self.generated_span_context.is_some() {
+            return self.generated_span_context.clone();
         }
 
         None


### PR DESCRIPTION
### What
- In `span_inferrer.rs`, we were looking for `generated_span_context` first before looking for the inferred span's trace context.
- AWS Xray's trace context is extracted from the AWSTraceHeader in `extract_trace_context_from_aws_trace_header`. 
- Therefore, if the user has AWS Xray enabled, we would use that trace context rather than the inferred span's trace context, breaking trace propagation.
- The fix is simply swapping the order of the if statements: first look for inferred span's trace context, then look for trace context in the AWS trace header.

### Testing
Before this change, trace propagation was broken when Xray was enabled:
<img width="400" alt="Screenshot 2025-04-18 at 4 28 28 PM" src="https://github.com/user-attachments/assets/2a822270-7d52-42ea-ba4e-6dee33b4c9a5" />

After this change, trace propagation works as expected with Xray enabled:
<img width="400" alt="Screenshot 2025-04-18 at 4 29 30 PM" src="https://github.com/user-attachments/assets/26577101-2d47-4914-a514-cf564efb50a2" />

The Datadog Java tracer injects trace context in the AWSTraceHeader for SQS, so I also manually verifed that this change does not break Java->SQS->Java trace propagation:
<img width="400" alt="Screenshot 2025-04-18 at 4 31 53 PM" src="https://github.com/user-attachments/assets/872aa469-fdd0-4035-a39a-56e8cf80a5a6" />

Lastly, the `generated_span_context` is also used by Step Functions, but there is no inferred span for step functions so this change should not affect Step Functions.
https://github.com/DataDog/datadog-lambda-extension/blob/56e6cc11b74eace24a8621d058d9b6d13d708a2b/bottlecap/src/lifecycle/invocation/span_inferrer.rs#L231-L236
