### PR TITLE
fix: Parse DD_APM_REPLACE_TAGS env var

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -722,7 +722,7 @@ fn start_trace_agent(
     });
 
     let obfuscation_config = obfuscation_config::ObfuscationConfig {
-        tag_replace_rules: config.apm_config_replace_tags.clone(),
+        tag_replace_rules: config.apm_replace_tags.clone(),
         http_remove_path_digits: config.apm_config_obfuscation_http_remove_paths_with_digits,
         http_remove_query_string: config.apm_config_obfuscation_http_remove_query_string,
         obfuscate_memcached: false,

--- a/bottlecap/src/config/env.rs
+++ b/bottlecap/src/config/env.rs
@@ -56,6 +56,8 @@ pub struct Config {
     // APM
     pub apm_config_apm_dd_url: String,
     #[serde(deserialize_with = "deserialize_apm_replace_rules")]
+    pub apm_replace_tags: Option<Vec<ReplaceRule>>,
+    #[serde(deserialize_with = "deserialize_apm_replace_rules")]
     pub apm_config_replace_tags: Option<Vec<ReplaceRule>>,
     pub apm_config_obfuscation_http_remove_query_string: bool,
     pub apm_config_obfuscation_http_remove_paths_with_digits: bool,
@@ -142,6 +144,7 @@ impl Default for Config {
             trace_propagation_http_baggage_enabled: false,
             // APM
             apm_config_apm_dd_url: String::default(),
+            apm_replace_tags: None,
             apm_config_replace_tags: None,
             apm_config_obfuscation_http_remove_query_string: false,
             apm_config_obfuscation_http_remove_paths_with_digits: false,

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -775,6 +775,37 @@ pub mod tests {
     }
 
     #[test]
+    fn test_apm_tags_env_overrides_yaml() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+            jail.set_env(
+                "DD_APM_REPLACE_TAGS",
+                r#"[{"name":"*","pattern":"foo","repl":"REDACTED-ENV"}]"#,
+            );
+            jail.create_file(
+                "datadog.yaml",
+                r"
+                site: datadoghq.com
+                apm_config:
+                  replace_tags:
+                    - name: '*'
+                      pattern: 'foo'
+                      repl: 'REDACTED-YAML'
+            ",
+            )?;
+            let config = get_config(Path::new(""), MOCK_REGION).expect("should parse config");
+            let rule = parse_rules_from_string(
+                r#"[
+                        {"name": "*", "pattern": "foo", "repl": "REDACTED-ENV"}
+                    ]"#,
+            )
+            .expect("can't parse rules");
+            assert_eq!(config.apm_replace_tags, Some(rule),);
+            Ok(())
+        });
+    }
+
+    #[test]
     fn test_parse_apm_http_obfuscation_from_yaml() {
         figment::Jail::expect_with(|jail| {
             jail.clear_env();

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -191,9 +191,9 @@ fn merge_config(config: &mut EnvConfig, yaml_config: &YamlConfig) {
             trace_intake_url_prefixed(config.apm_config_apm_dd_url.as_str());
     }
 
-    if config.apm_config_replace_tags.is_none() {
+    if config.apm_replace_tags.is_none() {
         if let Some(rules) = yaml_config.apm_config.replace_tags.as_ref() {
-            config.apm_config_replace_tags = Some(rules.clone());
+            config.apm_replace_tags = Some(rules.clone());
         }
     }
 
@@ -769,7 +769,7 @@ pub mod tests {
                     ]"#,
             )
             .expect("can't parse rules");
-            assert_eq!(config.apm_config_replace_tags, Some(rule),);
+            assert_eq!(config.apm_replace_tags, Some(rule),);
             Ok(())
         });
     }


### PR DESCRIPTION
Fixes an issue where we didn't parse `DD_APM_REPLACE_TAGS` because the yaml block includes an additional `config` word after APM, which is not present in the env var.

As usual, env vars override config file settings
