### PR TITLE
fix: Correctly get oldest invocation in `should_adapt_to_periodic` 

### DIFF
--- a/bottlecap/src/lifecycle/invocation_times.rs
+++ b/bottlecap/src/lifecycle/invocation_times.rs
@@ -86,4 +86,38 @@ mod tests {
         assert_eq!(invocation_times.head, 1);
         assert!(!invocation_times.should_adapt_to_periodic(10000));
     }
+
+    #[test]
+    fn should_adapt_to_periodic_when_fast_invokes() {
+        let mut invocation_times = invocation_times::InvocationTimes::new();
+        for i in 0..=(invocation_times::LOOKBACK_COUNT + 5) {
+            invocation_times.add((i * 100 + 1) as u64);
+        }
+
+        assert_eq!(invocation_times.times[0], 2001);
+        assert_eq!(invocation_times.times[5], 2501);
+        assert_eq!(invocation_times.times[6], 601);
+        assert_eq!(
+            invocation_times.times[invocation_times::LOOKBACK_COUNT - 1],
+            1901
+        );
+        assert!(invocation_times.should_adapt_to_periodic(2501));
+    }
+
+    #[test]
+    fn should_not_adapt_to_periodic_when_slow_invokes() {
+        let mut invocation_times = invocation_times::InvocationTimes::new();
+        for i in 0..=(invocation_times::LOOKBACK_COUNT + 5) {
+            invocation_times.add((i * 130 + 1) as u64);
+        }
+
+        assert_eq!(invocation_times.times[0], 2601);
+        assert_eq!(invocation_times.times[5], 3251);
+        assert_eq!(invocation_times.times[6], 781);
+        assert_eq!(
+            invocation_times.times[invocation_times::LOOKBACK_COUNT - 1],
+            2471
+        );
+        assert!(!invocation_times.should_adapt_to_periodic(3251));
+    }
 }


### PR DESCRIPTION
### What
We switch to periodic flushing if there are at least 20 invocations and the average time between each invocation is less than 120 seconds. (see [datadog-agent implementation](https://github.com/DataDog/datadog-agent/blob/main/pkg/serverless/daemon/interval.go#L47-L76))

In `should_adapt_to_periodic`, we calculate the average time between invocations (for the last 20 invocations) by taking the time between the oldest and newest invocations in the buffer, then dividing by 20.

Prior to this, we were assuming the oldest invocation in the buffer was the last item in the array. This is incorrect because the buffer is a circular buffer; we can instead use `buffer[head]` to get the oldest item in the array.

I also added a small improvement where we exit early if the buffer is not full (meaning <20 invocations have occurred so far).

### Motivation
https://github.com/DataDog/datadog-lambda-extension/issues/652
https://datadoghq.atlassian.net/browse/SVLS-6684
