### PR TITLE
feat: Optionally disable proc enhanced metrics

### DIFF
--- a/bottlecap/src/config/env.rs
+++ b/bottlecap/src/config/env.rs
@@ -38,6 +38,7 @@ pub struct Config {
     pub logs_config_logs_dd_url: String,
     pub serverless_flush_strategy: FlushStrategy,
     pub enhanced_metrics: bool,
+    pub proc_enhanced_metrics: bool,
     /// Flush timeout in seconds
     pub flush_timeout: u64, //TODO go agent adds jitter too
     pub https_proxy: Option<String>,
@@ -129,6 +130,7 @@ impl Default for Config {
             logs_config_logs_dd_url: String::default(),
             // Metrics
             enhanced_metrics: true,
+            proc_enhanced_metrics: true,
             https_proxy: None,
             capture_lambda_payload: false,
             capture_lambda_payload_max_depth: 10,

--- a/bottlecap/src/config/env.rs
+++ b/bottlecap/src/config/env.rs
@@ -38,7 +38,7 @@ pub struct Config {
     pub logs_config_logs_dd_url: String,
     pub serverless_flush_strategy: FlushStrategy,
     pub enhanced_metrics: bool,
-    pub proc_enhanced_metrics: bool,
+    pub lambda_proc_enhanced_metrics: bool,
     /// Flush timeout in seconds
     pub flush_timeout: u64, //TODO go agent adds jitter too
     pub https_proxy: Option<String>,
@@ -130,7 +130,7 @@ impl Default for Config {
             logs_config_logs_dd_url: String::default(),
             // Metrics
             enhanced_metrics: true,
-            proc_enhanced_metrics: true,
+            lambda_proc_enhanced_metrics: true,
             https_proxy: None,
             capture_lambda_payload: false,
             capture_lambda_payload_max_depth: 10,

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -126,7 +126,7 @@ impl Processor {
             .unwrap_or_default();
         self.set_init_tags();
 
-        if self.config.enhanced_metrics {
+        if self.config.proc_enhanced_metrics {
             // Collect offsets for network and cpu metrics
             let network_offset: Option<NetworkData> = proc::get_network_data().ok();
             let cpu_offset: Option<CPUData> = proc::get_cpu_data().ok();

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -126,7 +126,7 @@ impl Processor {
             .unwrap_or_default();
         self.set_init_tags();
 
-        if self.config.proc_enhanced_metrics {
+        if self.config.lambda_proc_enhanced_metrics {
             // Collect offsets for network and cpu metrics
             let network_offset: Option<NetworkData> = proc::get_network_data().ok();
             let cpu_offset: Option<CPUData> = proc::get_cpu_data().ok();


### PR DESCRIPTION
Fixes #648

For customers using very very fast/small lambda functions (usually just rust), there can be a small 1-2ms increase in runtime duration when collecing metrics like open file descriptors or tmp file usage.

We still enable these by default, but customers can now optionally disable them
