### PR TITLE
feat(bottlecap): add MSK inferred spans

### DIFF
--- a/bottlecap/src/lifecycle/invocation/span_inferrer.rs
+++ b/bottlecap/src/lifecycle/invocation/span_inferrer.rs
@@ -18,6 +18,7 @@ use crate::{
             event_bridge_event::EventBridgeEvent,
             kinesis_event::KinesisRecord,
             lambda_function_url_event::LambdaFunctionUrlEvent,
+            msk_event::MSKEvent,
             s3_event::S3Record,
             sns_event::{SnsEntity, SnsRecord},
             sqs_event::{extract_trace_context_from_aws_trace_header, SqsRecord},
@@ -102,6 +103,12 @@ impl SpanInferrer {
             }
         } else if LambdaFunctionUrlEvent::is_match(payload_value) {
             if let Some(t) = LambdaFunctionUrlEvent::new(payload_value.clone()) {
+                t.enrich_span(&mut inferred_span, &self.service_mapping);
+
+                trigger = Some(Box::new(t));
+            }
+        } else if MSKEvent::is_match(payload_value) {
+            if let Some(t) = MSKEvent::new(payload_value.clone()) {
                 t.enrich_span(&mut inferred_span, &self.service_mapping);
 
                 trigger = Some(Box::new(t));

--- a/bottlecap/src/lifecycle/invocation/triggers/mod.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/mod.rs
@@ -11,6 +11,7 @@ pub mod dynamodb_event;
 pub mod event_bridge_event;
 pub mod kinesis_event;
 pub mod lambda_function_url_event;
+pub mod msk_event;
 pub mod s3_event;
 pub mod sns_event;
 pub mod sqs_event;

--- a/bottlecap/src/lifecycle/invocation/triggers/msk_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/msk_event.rs
@@ -42,7 +42,6 @@ impl Trigger for MSKEvent {
         match serde_json::from_value::<Self>(payload) {
             Ok(event) => Some(event),
             Err(e) => {
-                println!("[bottlecap] Failed to deserialize modified MSKEvent: {e}");
                 debug!("Failed to deserialize modified MSKEvent: {e}");
                 None
             }

--- a/bottlecap/src/lifecycle/invocation/triggers/msk_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/msk_event.rs
@@ -1,0 +1,103 @@
+use crate::lifecycle::invocation::triggers::{
+    ServiceNameResolver, Trigger, FUNCTION_TRIGGER_EVENT_SOURCE_TAG,
+};
+use datadog_trace_protobuf::pb::Span;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use tracing::debug;
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct MSKEvent {
+    pub event_source: String,
+    pub event_source_arn: String,
+    pub records: HashMap<String, Vec<MSKRecord>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct MSKRecord {
+    pub topic: String,
+    pub partition: i32,
+    pub timestamp: f64,
+}
+
+impl Trigger for MSKEvent {
+    fn new(mut payload: Value) -> Option<Self> {
+        // We only care about the first item in the first record, so drop the others before deserializing.
+        let mut key_to_keep: Option<String> = None;
+
+        if let Some(records_map) = payload.get_mut("records").and_then(Value::as_object_mut) {
+            if let Some((first_key, first_value_ref)) = records_map.iter_mut().next() {
+                let key_copy = first_key.clone();
+                if let Some(arr) = first_value_ref.as_array_mut() {
+                    arr.truncate(1);
+                    key_to_keep = Some(key_copy);
+                }
+            }
+
+            if let Some(ref key) = key_to_keep {
+                records_map.retain(|k, _| k == key);
+            } else {
+                records_map.clear();
+            }
+        }
+
+        match serde_json::from_value::<Self>(payload) {
+            Ok(event) => Some(event),
+            Err(e) => {
+                println!("[bottlecap] Failed to deserialize modified MSKEvent: {e}");
+                debug!("Failed to deserialize modified MSKEvent: {e}");
+                None
+            }
+        }
+    }
+
+    fn is_match(payload: &Value) -> bool {
+        payload
+            .get("records")
+            .and_then(Value::as_object)
+            .and_then(|map| map.values().next())
+            .and_then(Value::as_array)
+            .and_then(|arr| arr.first())
+            .map_or(false, |rec| rec.get("topic").is_some())
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    fn enrich_span(&self, span: &mut Span, service_mapping: &HashMap<String, String>) {
+        // TODO
+    }
+
+    fn get_tags(&self) -> HashMap<String, String> {
+        HashMap::from([(
+            FUNCTION_TRIGGER_EVENT_SOURCE_TAG.to_string(),
+            "msk".to_string(),
+        )])
+    }
+
+    fn get_arn(&self, _region: &str) -> String {
+        self.event_source_arn.to_string()
+    }
+
+    fn get_carrier(&self) -> HashMap<String, String> {
+        HashMap::new()
+    }
+
+    fn is_async(&self) -> bool {
+        true
+    }
+}
+
+impl ServiceNameResolver for MSKEvent {
+    fn get_specific_identifier(&self) -> String {
+        self.event_source_arn
+            .split('/')
+            .nth(1)
+            .unwrap_or_default()
+            .to_string()
+    }
+
+    fn get_generic_identifier(&self) -> &'static str {
+        "lambda_msk"
+    }
+}

--- a/bottlecap/tests/payloads/msk_event.json
+++ b/bottlecap/tests/payloads/msk_event.json
@@ -1,0 +1,41 @@
+{
+  "eventSource": "aws:kafka",
+  "eventSourceArn": "arn:aws:kafka:us-east-1:123456789012:cluster/demo-cluster/751d2973-a626-431c-9d4e-d7975eb44dd7-2",
+  "bootstrapServers": "b-1.demo-cluster.a1bcde.c1.kafka.us-east-1.amazonaws.com:9092,b-2.demo-cluster.a1bcde.c1.kafka.us-east-1.amazonaws.com:9092",
+  "records": {
+    "topic1": [
+      {
+        "topic":        "topic1",
+        "partition":    0,
+        "offset":       101,
+        "timestamp":    1745846213022,
+        "timestampType":"CREATE_TIME",
+        "key":   "b3JkZXJJZA==",
+        "value": "eyJvcmRlcklkIjoiMTIzNCIsImFtb3VudCI6MTAwLjAxfQ==",
+        "headers": []
+      },
+      {
+        "topic":        "topic1",
+        "partition":    0,
+        "offset":       102,
+        "timestamp":    1745746213022,
+        "timestampType":"CREATE_TIME",
+        "key":   "b3JkZXJJZA==",
+        "value": "eyJvcmRlcklkIjoiNTY3OCIsImFtb3VudCI6NTAuMDB9",
+        "headers": []
+      }
+    ],
+    "topic2": [
+      {
+        "topic":        "topic2",
+        "partition":    1,
+        "offset":       7,
+        "timestamp":    1745646213022,
+        "timestampType":"CREATE_TIME",
+        "key":   "cmVmdW5kSWQ=",
+        "value": "eyJyZWZ1bmRJZCI6Ijk4NzYiLCJvcmRlcklkIjoiMTIzNCIsImFtb3VudCI6MTAwLjAxfQ==",
+        "headers": []
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add inferred spans for MSK events. Since there are multiple records, possibly from multiple different topics, we just get the first item from the first topic and use that information to create the inferred span.

<img width="600" alt="Screenshot 2025-04-28 at 10 09 23 AM" src="https://github.com/user-attachments/assets/af7bdcdc-b137-4bad-b5dd-5252414121b1" />

https://datadoghq.atlassian.net/browse/SVLS-6711