### PR TITLE
fix: use debug log level for connection errors

### DIFF
--- a/bottlecap/src/lifecycle/listener.rs
+++ b/bottlecap/src/lifecycle/listener.rs
@@ -84,7 +84,7 @@ impl Listener {
             let service = service.clone();
             joinset.spawn(async move {
                 if let Err(e) = server.serve_connection(conn, service).await {
-                    error!("Connection error: {e}");
+                    debug!("Lifecycle connection error: {e}");
                 }
             });
         }

--- a/bottlecap/src/otlp/agent.rs
+++ b/bottlecap/src/otlp/agent.rs
@@ -124,7 +124,7 @@ impl Agent {
             let service = service.clone();
             joinset.spawn(async move {
                 if let Err(e) = server.serve_connection(conn, service).await {
-                    error!("OTLP Receiver connection error: {e}");
+                    debug!("OTLP Receiver connection error: {e}");
                 }
             });
         }

--- a/bottlecap/src/telemetry/listener.rs
+++ b/bottlecap/src/telemetry/listener.rs
@@ -72,7 +72,7 @@ impl TelemetryListener {
             let service = service.clone();
             joinset.spawn(async move {
                 if let Err(e) = server.serve_connection(conn, service).await {
-                    error!("Connection error: {e}");
+                    debug!("Telemetry Connection error: {e}");
                 }
             });
         }

--- a/bottlecap/src/traces/trace_agent.rs
+++ b/bottlecap/src/traces/trace_agent.rs
@@ -202,7 +202,7 @@ impl TraceAgent {
             let service = service.clone();
             joinset.spawn(async move {
                 if let Err(e) = server.serve_connection(conn, service).await {
-                    error!("Connection error: {e}");
+                    debug!("Trace agent connection error: {e}");
                 }
             });
         }


### PR DESCRIPTION
Hyper v1 migration added these logs but it's a bit noisy when clients go away without sending FIN.

This moves these to debug (which is what we'd need for support anyway)
