### PR TITLE
fix(config): remove `apm_ignore_resources` check in OTEL

### DIFF
--- a/bottlecap/src/config/env.rs
+++ b/bottlecap/src/config/env.rs
@@ -72,7 +72,6 @@ pub struct Config {
     #[serde(deserialize_with = "deserialize_bool_from_anything")]
     pub apm_config_obfuscation_http_remove_paths_with_digits: bool,
     pub apm_features: Vec<String>,
-    pub apm_ignore_resources: Vec<String>,
     // Metrics overrides
     pub dd_url: String,
     pub url: String,
@@ -171,7 +170,6 @@ impl Default for Config {
             apm_config_obfuscation_http_remove_query_string: false,
             apm_config_obfuscation_http_remove_paths_with_digits: false,
             apm_features: vec![],
-            apm_ignore_resources: vec![],
             dd_url: String::default(),
             url: String::default(),
             // OTLP

--- a/bottlecap/src/otlp/transform.rs
+++ b/bottlecap/src/otlp/transform.rs
@@ -1057,22 +1057,6 @@ pub fn otel_resource_spans_to_dd_spans(
         };
 
         for otel_span in otel_spans {
-            let mut resource_name = get_otel_attribute_value_as_string_from_resource_or_span(
-                otel_res,
-                otel_span,
-                KEY_DATADOG_RESOURCE,
-                true,
-            );
-
-            if resource_name.is_empty() && !config.otlp_config_ignore_missing_datadog_fields {
-                resource_name = get_otel_resource(otel_span, otel_res);
-            }
-
-            // TODO(duncanista): verify if type is correct for ignore resources
-            if config.apm_ignore_resources.contains(&resource_name) {
-                continue;
-            }
-
             let (trace_id_lower, _) = otel_trace_id_to_dd_id(&otel_span.trace_id);
             let dd_span = otel_span_to_dd_span(otel_span, otel_res, lib, config.clone());
             traces_by_id.entry(trace_id_lower).or_default();


### PR DESCRIPTION
# What?

Removes usage of `DD_APM_IGNORE_RESOURCES` in the OTEL span transform.

# Why?

1. The implementation was incorrect and shouldn't check for resources to ignore in the transformation step.
2. It was not properly used in the `apm_config` for YAML files.

# Notes:

- Follow up PR to implement `APM_IGNORE_RESOURCES` properly in the Trace Agent.

# More

Learn about ignoring resources: https://docs.datadoghq.com/tracing/guide/ignoring_apm_resources/?tab=datadogyaml#ignoring-based-on-resources

`DD_APM_IGNORE_RESOURCES` is specified as:

```
A list of regular expressions can be provided to exclude certain traces based on their resource name.
All entries must be surrounded by double quotes and separated by commas.
```

A correct usage would be:

```env
DD_APM_IGNORE_RESOURCES="(GET|POST) /healthcheck,API::NotesController#index"
```

or in yaml
```yaml
apm_config:
  ignore_resources: ["(GET|POST) /healthcheck","API::NotesController#index"]
```