### PR TITLE
fix(config): fix otlp trace agent to start when right configuration is set

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -25,7 +25,7 @@ use bottlecap::{
     },
     logger,
     logs::{agent::LogsAgent, flusher::Flusher as LogsFlusher},
-    otlp::agent::Agent as OtlpAgent,
+    otlp::{agent::Agent as OtlpAgent, should_enable_otlp_agent},
     proxy::{interceptor, should_start_proxy},
     secrets::decrypt,
     tags::{
@@ -821,11 +821,7 @@ fn start_otlp_agent(
     trace_processor: Arc<dyn trace_processor::TraceProcessor + Send + Sync>,
     trace_tx: Sender<SendData>,
 ) {
-    if !config.otlp_config_traces_enabled
-        && config
-            .otlp_config_receiver_protocols_http_endpoint
-            .is_none()
-    {
+    if !should_enable_otlp_agent(config) {
         return;
     }
 

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -821,7 +821,11 @@ fn start_otlp_agent(
     trace_processor: Arc<dyn trace_processor::TraceProcessor + Send + Sync>,
     trace_tx: Sender<SendData>,
 ) {
-    if !config.otlp_config_traces_enabled {
+    if !config.otlp_config_traces_enabled
+        && config
+            .otlp_config_receiver_protocols_http_endpoint
+            .is_none()
+    {
         return;
     }
 

--- a/bottlecap/src/config/yaml.rs
+++ b/bottlecap/src/config/yaml.rs
@@ -35,6 +35,18 @@ impl Config {
     }
 
     #[must_use]
+    pub fn otlp_config_receiver_protocols_grpc(&self) -> Option<&Value> {
+        self.otlp_config
+            .as_ref()?
+            .receiver
+            .as_ref()?
+            .protocols
+            .as_ref()?
+            .grpc
+            .as_ref()
+    }
+
+    #[must_use]
     pub fn otlp_config_traces_enabled(&self) -> bool {
         self.otlp_config.as_ref().is_some_and(|otlp_config| {
             otlp_config
@@ -71,6 +83,19 @@ impl Config {
             .and_then(|otlp_config| otlp_config.traces.as_ref())
             .map(|traces| traces.span_name_remappings.clone())
             .unwrap_or_default()
+    }
+
+    #[must_use]
+    pub fn otlp_config_traces_probabilistic_sampler(&self) -> Option<&Value> {
+        self.otlp_config
+            .as_ref()
+            .and_then(|otlp_config| otlp_config.traces.as_ref())
+            .and_then(|traces| traces.probabilistic_sampler.as_ref())
+    }
+
+    #[must_use]
+    pub fn otlp_config_logs(&self) -> Option<&Value> {
+        self.otlp_config.as_ref().and_then(|otlp_config| otlp_config.logs.as_ref())
     }
 }
 

--- a/bottlecap/src/config/yaml.rs
+++ b/bottlecap/src/config/yaml.rs
@@ -95,7 +95,9 @@ impl Config {
 
     #[must_use]
     pub fn otlp_config_logs(&self) -> Option<&Value> {
-        self.otlp_config.as_ref().and_then(|otlp_config| otlp_config.logs.as_ref())
+        self.otlp_config
+            .as_ref()
+            .and_then(|otlp_config| otlp_config.logs.as_ref())
     }
 }
 

--- a/bottlecap/src/config/yaml.rs
+++ b/bottlecap/src/config/yaml.rs
@@ -16,7 +16,62 @@ pub struct Config {
     pub logs_config: LogsConfig,
     pub apm_config: ApmConfig,
     pub proxy: ProxyConfig,
-    pub otlp_config: OtlpConfig,
+    pub otlp_config: Option<OtlpConfig>,
+}
+
+impl Config {
+    #[must_use]
+    pub fn otlp_config_receiver_protocols_http_endpoint(&self) -> Option<&str> {
+        self.otlp_config
+            .as_ref()?
+            .receiver
+            .as_ref()?
+            .protocols
+            .as_ref()?
+            .http
+            .as_ref()?
+            .endpoint
+            .as_deref()
+    }
+
+    #[must_use]
+    pub fn otlp_config_traces_enabled(&self) -> bool {
+        self.otlp_config.as_ref().is_some_and(|otlp_config| {
+            otlp_config
+                .traces
+                .as_ref()
+                .is_some_and(|traces| traces.enabled)
+        })
+    }
+
+    #[must_use]
+    pub fn otlp_config_traces_ignore_missing_datadog_fields(&self) -> bool {
+        self.otlp_config.as_ref().is_some_and(|otlp_config| {
+            otlp_config
+                .traces
+                .as_ref()
+                .is_some_and(|traces| traces.ignore_missing_datadog_fields)
+        })
+    }
+
+    #[must_use]
+    pub fn otlp_config_traces_span_name_as_resource_name(&self) -> bool {
+        self.otlp_config.as_ref().is_some_and(|otlp_config| {
+            otlp_config
+                .traces
+                .as_ref()
+                .is_some_and(|traces| traces.span_name_as_resource_name)
+        })
+    }
+
+    #[must_use]
+    pub fn otlp_config_traces_span_name_remappings(&self) -> HashMap<String, String> {
+        self.otlp_config
+            .as_ref()
+            .and_then(|otlp_config| otlp_config.traces.as_ref())
+            .map(|traces| traces.span_name_remappings.clone())
+            .unwrap_or_default()
+    }
 }
 
 /// Logs Config
@@ -77,8 +132,8 @@ pub struct ProxyConfig {
 #[serde(default)]
 #[allow(clippy::module_name_repetitions)]
 pub struct OtlpConfig {
-    pub receiver: OtlpReceiverConfig,
-    pub traces: OtlpTracesConfig,
+    pub receiver: Option<OtlpReceiverConfig>,
+    pub traces: Option<OtlpTracesConfig>,
 
     // NOT SUPPORTED
     pub metrics: Option<Value>,
@@ -89,14 +144,14 @@ pub struct OtlpConfig {
 #[serde(default)]
 #[allow(clippy::module_name_repetitions)]
 pub struct OtlpReceiverConfig {
-    pub protocols: OtlpReceiverProtocolsConfig,
+    pub protocols: Option<OtlpReceiverProtocolsConfig>,
 }
 
 #[derive(Debug, PartialEq, Deserialize, Clone, Default)]
 #[serde(default)]
 #[allow(clippy::module_name_repetitions)]
 pub struct OtlpReceiverProtocolsConfig {
-    pub http: OtlpReceiverHttpConfig,
+    pub http: Option<OtlpReceiverHttpConfig>,
 
     // NOT SUPPORTED
     pub grpc: Option<Value>,
@@ -106,10 +161,22 @@ pub struct OtlpReceiverProtocolsConfig {
 #[serde(default)]
 #[allow(clippy::module_name_repetitions)]
 pub struct OtlpReceiverHttpConfig {
-    pub endpoint: String,
+    pub endpoint: Option<String>,
 }
 
-#[derive(Debug, PartialEq, Deserialize, Clone, Default)]
+impl Default for OtlpTracesConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true, // Default this to true
+            span_name_as_resource_name: false,
+            span_name_remappings: HashMap::new(),
+            ignore_missing_datadog_fields: false,
+            probabilistic_sampler: None,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Deserialize, Clone)]
 #[serde(default)]
 #[allow(clippy::module_name_repetitions)]
 pub struct OtlpTracesConfig {
@@ -123,4 +190,37 @@ pub struct OtlpTracesConfig {
 
     // NOT SUPORTED
     pub probabilistic_sampler: Option<Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use crate::config::get_config;
+
+    #[test]
+    fn test_otlp_config_receiver_protocols_http_endpoint() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+            jail.create_file(
+                "datadog.yaml",
+                r"
+                otlp_config:
+                  receiver:
+                    protocols:
+                      http:
+                        endpoint: 0.0.0.0:4318
+            ",
+            )?;
+
+            let config = get_config(Path::new("")).expect("should parse config");
+
+            assert_eq!(
+                config.otlp_config_receiver_protocols_http_endpoint,
+                Some("0.0.0.0:4318".to_string())
+            );
+
+            Ok(())
+        });
+    }
 }

--- a/bottlecap/src/otlp/mod.rs
+++ b/bottlecap/src/otlp/mod.rs
@@ -1,3 +1,84 @@
+use std::sync::Arc;
+
+use crate::config::Config;
+
 pub mod agent;
 pub mod processor;
 pub mod transform;
+
+#[must_use]
+pub fn should_enable_otlp_agent(config: &Arc<Config>) -> bool {
+    config.otlp_config_traces_enabled
+        && config
+            .otlp_config_receiver_protocols_http_endpoint
+            .is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::path::Path;
+
+    use crate::config::get_config;
+
+    #[test]
+    fn test_should_enable_otlp_agent_from_yaml() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+            jail.create_file(
+                "datadog.yaml",
+                r"
+                otlp_config:
+                  receiver:
+                    protocols:
+                      http:
+                        endpoint: 0.0.0.0:4318
+            ",
+            )?;
+
+            let config = get_config(Path::new("")).expect("should parse config");
+
+            // Since the default for traces is `true`, we don't need to set it.
+            assert_eq!(should_enable_otlp_agent(&Arc::new(config)), true);
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_should_enable_otlp_agent_from_env_vars() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+            jail.set_env(
+                "DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT",
+                "0.0.0.0:4318",
+            );
+
+            let config = get_config(Path::new("")).expect("should parse config");
+
+            // Since the default for traces is `true`, we don't need to set it.
+            assert_eq!(should_enable_otlp_agent(&Arc::new(config)), true);
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_should_not_enable_otlp_agent_if_traces_are_disabled() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+            jail.set_env("DD_OTLP_CONFIG_TRACES_ENABLED", "false");
+            jail.set_env(
+                "DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT",
+                "0.0.0.0:4318",
+            );
+
+            let config = get_config(Path::new("")).expect("should parse config");
+
+            assert_eq!(should_enable_otlp_agent(&Arc::new(config)), false);
+
+            Ok(())
+        });
+    }
+}


### PR DESCRIPTION
# What?

Ensures that OTLP agent is only enabled when the `otlp_config_receiver_protocols_http_endpoint` is set, and when `otlp_config_traces_enabled` is `true`

 # Motivation

#678 

# Notes

OTEL agent should only spin up when receiver protocols endpoint is set, so this was a miss on my side.