### PR TITLE
fix: cold start tag

### DIFF
--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -115,6 +115,8 @@ impl Processor {
     pub fn on_invoke_event(&mut self, request_id: String) {
         let invocation_span =
             create_empty_span(String::from("aws.lambda"), &self.resource, &self.service);
+        // Important! Call set_init_tags() before additing the invocation to the context buffer
+        self.set_init_tags();
         self.context_buffer
             .start_context(&request_id, invocation_span);
 
@@ -124,7 +126,6 @@ impl Processor {
             .as_secs()
             .try_into()
             .unwrap_or_default();
-        self.set_init_tags();
 
         if self.config.lambda_proc_enhanced_metrics {
             // Collect offsets for network and cpu metrics


### PR DESCRIPTION
Fixes #682

In #636 we changed this method and inserted the invocation into the context buffer before setting the init tags: [link](https://github.com/DataDog/datadog-lambda-extension/commit/94cebb9037c28b17c086c049adb04d77db250a5b#diff-689befe07a6fb7b65e3a7ed5c8949970e0fbbc74e0356f56ea8d829159ae5f14R119).

Fix:
![image](https://github.com/user-attachments/assets/443c6776-b221-4247-b08e-70eefd802625)

This caused the cold start logic to always return false, as it's looking for that buffer to be empty. A safer implementation could be to check if the length is 1 and the current request ID matches the item in the buffer, but this works.
