### PR TITLE
fix: bump flush_timeout default

### DIFF
--- a/bottlecap/src/config/env.rs
+++ b/bottlecap/src/config/env.rs
@@ -135,7 +135,7 @@ impl Default for Config {
             api_key_secret_arn: String::default(),
             kms_api_key: String::default(),
             serverless_flush_strategy: FlushStrategy::Default,
-            flush_timeout: 10,
+            flush_timeout: 30,
             // Unified Tagging
             env: None,
             service: None,


### PR DESCRIPTION
A little goofy because we use this to determine when/how to move over to continuous flushing, but the gist is that our invocation context tracks the start time of each invocation. Because it's all local to a single sandbox, this means that the time diff between invocations includes post runtime duration, so it's very common to have 20 invocations greater than 10s if there are even a couple of periodic/end flushes in there.

This customizable with `DD_FLUSH_TIMEOUT` so if people want to set it to a very short timeout, they are able to.