### PR TITLE
feat: set init_type on init duration metric

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -717,9 +717,17 @@ async fn handle_event_bus_event(
                     p.on_platform_init_start(event.time);
                     drop(p);
                 }
-                TelemetryRecord::PlatformInitReport { metrics, .. } => {
+                TelemetryRecord::PlatformInitReport {
+                    metrics,
+                    initialization_type,
+                    ..
+                } => {
                     let mut p = invocation_processor.lock().await;
-                    p.on_platform_init_report(metrics.duration_ms, event.time.timestamp());
+                    p.on_platform_init_report(
+                        initialization_type,
+                        metrics.duration_ms,
+                        event.time.timestamp(),
+                    );
                     drop(p);
                 }
                 TelemetryRecord::PlatformStart { request_id, .. } => {

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -25,7 +25,7 @@ use crate::{
         CPUData, NetworkData,
     },
     tags::{lambda::tags::resolve_runtime_from_proc, provider},
-    telemetry::events::{ReportMetrics, RuntimeDoneMetrics, Status},
+    telemetry::events::{InitType, ReportMetrics, RuntimeDoneMetrics, Status},
     traces::{
         context::SpanContext,
         propagation::{
@@ -243,9 +243,14 @@ impl Processor {
     /// Given the duration of the platform init report, set the init duration metric.
     ///
     #[allow(clippy::cast_possible_truncation)]
-    pub fn on_platform_init_report(&mut self, duration_ms: f64, timestamp: i64) {
+    pub fn on_platform_init_report(
+        &mut self,
+        init_type: InitType,
+        duration_ms: f64,
+        timestamp: i64,
+    ) {
         self.enhanced_metrics
-            .set_init_duration_metric(duration_ms, timestamp);
+            .set_init_duration_metric(init_type, duration_ms, timestamp);
 
         let Some(context) = self.context_buffer.get_closest_mut(timestamp) else {
             debug!("Cannot process on platform init report, no invocation context found");

--- a/bottlecap/src/telemetry/events.rs
+++ b/bottlecap/src/telemetry/events.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Utc};
 
 use serde::Deserialize;
 use serde_json::Value;
+use std::fmt::Display;
 
 /// Payload received from the Telemetry API
 #[derive(Clone, Debug, Deserialize, PartialEq)]
@@ -161,6 +162,17 @@ pub enum InitType {
     ProvisionedConcurrency,
     /// `SnapStart`
     SnapStart,
+}
+
+impl Display for InitType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let style = match self {
+            InitType::OnDemand => "on-demand",
+            InitType::ProvisionedConcurrency => "provisioned-concurrency",
+            InitType::SnapStart => "SnapStart",
+        };
+        write!(f, "{style}")
+    }
 }
 
 /// Phase in which initialization occurs


### PR DESCRIPTION
Lambda has been well-known to boost vCPU for on-demand invocations, decreasing the init_duration time because the CPU is not throttled like it is during normal invocations. This has lead to issues like the [Doom Loop](https://aaronstuyvenberg.com/posts/lambda-timeout-doom-loop).

One thing to know is that initializations occurring under `provisioned concurrency` do *not* receive this CPU boost, which leads to longer than expected reported `initialization_duration` latencies. This PR adds the `init_type` tag so users can see the difference. `SnapStart` is never going to be sent, but it's required to satisfy the enum.

Here are the tags being sent for a 128mb function. Note the 11s init duration! (it had to retry during the invoke phase!):
![image](https://github.com/user-attachments/assets/cb358db2-60a0-4432-b924-6092cb57a692)

Now, note they are equal at 1769mb RAM:
![image](https://github.com/user-attachments/assets/41ad0735-4c3c-4c00-b48c-e1c381c1ccfb)

As per the Lambda [docs](https://docs.aws.amazon.com/lambda/latest/dg/configuration-memory.html), at 1769mb RAM your function receives the equivalent of 1vCPU.

This PR will help prevent customers from being confused as they may experience longer or shorter initialization durations when using provisioned concurrency, indicating that a faster initialization was likely `on-demand`, vs the much slower `provisioned-concurrency` initialization.

https://datadoghq.atlassian.net/browse/SVLS-6991