### PR TITLE
feat: Add function_version tag to metrics/traces

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -712,9 +712,11 @@ async fn handle_event_bus_event(
         Event::Telemetry(event) => {
             debug!("Telemetry event received: {:?}", event);
             match event.record {
-                TelemetryRecord::PlatformInitStart { .. } => {
+                TelemetryRecord::PlatformInitStart {
+                    function_version, ..
+                } => {
                     let mut p = invocation_processor.lock().await;
-                    p.on_platform_init_start(event.time);
+                    p.on_platform_init_start(function_version, event.time);
                     drop(p);
                 }
                 TelemetryRecord::PlatformInitReport {

--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -451,6 +451,7 @@ mod tests {
                 record: TelemetryRecord::PlatformInitStart {
                     runtime_version: Some("test-runtime-version".to_string()),
                     runtime_version_arn: Some("test-runtime-version-arn".to_string()),
+                    function_version: Some("$LATEST".to_string()),
                     initialization_type: InitType::OnDemand,
                     phase: InitPhase::Init,
                 }

--- a/bottlecap/src/metrics/enhanced/lambda.rs
+++ b/bottlecap/src/metrics/enhanced/lambda.rs
@@ -58,6 +58,11 @@ impl Lambda {
             .insert(String::from("runtime"), runtime.to_string());
     }
 
+    pub fn set_version_tag(&mut self, function_version: String) {
+        self.dynamic_value_tags
+            .insert(String::from("function_version"), function_version);
+    }
+
     fn get_dynamic_value_tags(&self) -> Option<SortedTags> {
         let vec_tags: Vec<String> = self
             .dynamic_value_tags

--- a/bottlecap/src/telemetry/events.rs
+++ b/bottlecap/src/telemetry/events.rs
@@ -35,6 +35,7 @@ pub enum TelemetryRecord {
         runtime_version: Option<String>,
         /// Lambda runtime version ARN
         runtime_version_arn: Option<String>,
+        function_version: Option<String>,
     },
 
     /// Platform init runtime done record
@@ -280,6 +281,7 @@ mod tests {
                 phase: InitPhase::Init,
                 runtime_version: None,
                 runtime_version_arn: None,
+                function_version: Some("$LATEST".to_string()),
             },
         ),
 

--- a/bottlecap/src/telemetry/listener.rs
+++ b/bottlecap/src/telemetry/listener.rs
@@ -146,6 +146,7 @@ mod tests {
             DateTime::parse_from_rfc3339("2024-04-25T17:35:59.944Z").expect("failed to parse time");
         assert_eq!(telemetry_event.time, expected_time);
         assert_eq!(telemetry_event.record, TelemetryRecord::PlatformInitStart {
+            function_version: Some("$LATEST".to_string()),
             initialization_type: InitType::OnDemand,
             phase: InitPhase::Init,
             runtime_version: Some("nodejs:20.v22".to_string()),


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/SVLS-6993

Adds the function_version tag to spans/metrics. `executedversion` was always only the version number, but `function_version` will use the `function_version` metadata from the initStart event which also includes the alias if it's latest.

<img width="683" alt="image" src="https://github.com/user-attachments/assets/5a92170d-ce12-4efd-94d9-804a9a3ff1f8" />
