### PR TITLE
chore: Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can opt out of the next-generation Lambda Extension by setting the environme
 Today, all workloads using Logs and Metrics are supported.
 
 APM Tracing is supported for Python, NodeJS, Go, Java, and .NET runtimes.
-Profiling and ASM are not yet supported, and will fallback to compatibility mode.
+ASM is not yet supported, and will fallback to compatibility mode.
 
 ### Feedback
 


### PR DESCRIPTION
1. Fix some typos and grammatical errors:
    1. `setting the the environment` -> `setting the environment`
    2. `compatability` -> `compatibility`
    3. `Datadog ... recommend` -> `Datadog ... recommends`
    4. `can observe` -> `you can observe`
2. Apply some automatic format changes