### PR TITLE
feat: parallelize batch flusher

### DIFF
--- a/bottlecap/src/traces/trace_flusher.rs
+++ b/bottlecap/src/traces/trace_flusher.rs
@@ -94,14 +94,13 @@ impl TraceFlusher for ServerlessTraceFlusher {
 
         for task in tasks {
             match task.await {
-                Ok(result) => match result {
-                    Ok(_) => {}
-                    Err(e) => {
+                Ok(result) => {
+                    if let Err(e) = result {
                         error!("Error sending trace: {e:?}");
                         // Return the original traces for retry
                         return Some(traces_clone);
                     }
-                },
+                }
                 Err(e) => {
                     error!("Task join error: {e:?}");
                     // Return the original traces for retry if a task panics


### PR DESCRIPTION
Parallelizes the trace flusher for cases where we send lots of spans. Tested on a function sending 100k spans
