### PR TITLE
feat: use skip missed tick behavior

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -489,6 +489,7 @@ async fn extension_loop_active(
         FlushControl::new(config.serverless_flush_strategy, config.flush_timeout);
 
     let mut race_flush_interval = flush_control.get_flush_interval();
+    race_flush_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     race_flush_interval.tick().await; // discard first tick, which is instantaneous
 
     debug!(


### PR DESCRIPTION
By default, tokio uses the `burst` behavior which will fire ticks instantly in the case that a task blocks the main thread and the tick is missed. In our case I believe if there is a long/erroneous flush, this may cause the race interval to fire even when we'd reset it.
[docs](https://docs.rs/tokio/latest/tokio/time/enum.MissedTickBehavior.html)
