### PR TITLE
fix: move env mapping from ignore_missing_datadog_fields=true to false block

### DIFF
--- a/bottlecap/src/otlp/transform.rs
+++ b/bottlecap/src/otlp/transform.rs
@@ -13,11 +13,12 @@ use opentelemetry_proto::tonic::trace::v1::{
     Span as OtelSpan,
 };
 use opentelemetry_semantic_conventions::attribute::{
-    DB_QUERY_TEXT, DB_STATEMENT, DB_SYSTEM_NAME, DEPLOYMENT_ENVIRONMENT, FAAS_INVOKED_NAME,
-    FAAS_INVOKED_PROVIDER, FAAS_TRIGGER, GRAPHQL_OPERATION_NAME, GRAPHQL_OPERATION_TYPE,
-    HTTP_ROUTE, HTTP_STATUS_CODE, MESSAGING_DESTINATION_NAME, MESSAGING_OPERATION,
-    MESSAGING_SYSTEM, OTEL_LIBRARY_NAME, OTEL_LIBRARY_VERSION, OTEL_STATUS_CODE,
-    OTEL_STATUS_DESCRIPTION, RPC_METHOD, RPC_SERVICE, RPC_SYSTEM,
+    DB_QUERY_TEXT, DB_STATEMENT, DB_SYSTEM_NAME, DEPLOYMENT_ENVIRONMENT,
+    DEPLOYMENT_ENVIRONMENT_NAME, FAAS_INVOKED_NAME, FAAS_INVOKED_PROVIDER, FAAS_TRIGGER,
+    GRAPHQL_OPERATION_NAME, GRAPHQL_OPERATION_TYPE, HTTP_ROUTE, HTTP_STATUS_CODE,
+    MESSAGING_DESTINATION_NAME, MESSAGING_OPERATION, MESSAGING_SYSTEM, OTEL_LIBRARY_NAME,
+    OTEL_LIBRARY_VERSION, OTEL_STATUS_CODE, OTEL_STATUS_DESCRIPTION, RPC_METHOD, RPC_SERVICE,
+    RPC_SYSTEM,
 };
 use opentelemetry_semantic_conventions::resource::{SERVICE_NAME, SERVICE_VERSION}; // CONTAINER_ID, SERVICE_VERSION, TELEMETRY_SDK_LANGUAGE, TELEMETRY_SDK_VERSION,
 use opentelemetry_semantic_conventions::trace::{
@@ -873,13 +874,24 @@ pub fn otel_span_to_dd_span(
                 .insert("http.status_code".to_string(), f64::from(http_status_code));
         }
 
-        // Map OTEL deployment.environment to Datadog env field
+        // Map OTEL deployment.environment to Datadog env field with fallback
         if !dd_span.meta.contains_key("env") {
-            let env = get_otel_attribute_value_as_string(
+            // Try new standard first: deployment.environment.name
+            let mut env = get_otel_attribute_value_as_string(
                 &otel_res.attributes,
-                DEPLOYMENT_ENVIRONMENT,
+                DEPLOYMENT_ENVIRONMENT_NAME,
                 true,
             );
+
+            // Fallback to deprecated deployment.environment if new standard not found
+            if env.is_empty() {
+                env = get_otel_attribute_value_as_string(
+                    &otel_res.attributes,
+                    DEPLOYMENT_ENVIRONMENT,
+                    true,
+                );
+            }
+
             if !env.is_empty() {
                 dd_span.meta.insert("env".to_string(), env);
             }

--- a/bottlecap/src/otlp/transform.rs
+++ b/bottlecap/src/otlp/transform.rs
@@ -872,6 +872,18 @@ pub fn otel_span_to_dd_span(
                 .metrics
                 .insert("http.status_code".to_string(), f64::from(http_status_code));
         }
+
+        // Map OTEL deployment.environment to Datadog env field
+        if !dd_span.meta.contains_key("env") {
+            let env = get_otel_attribute_value_as_string(
+                &otel_res.attributes,
+                DEPLOYMENT_ENVIRONMENT,
+                true,
+            );
+            if !env.is_empty() {
+                dd_span.meta.insert("env".to_string(), env);
+            }
+        }
     }
 
     let top_level_by_kind = config
@@ -1014,24 +1026,12 @@ pub fn otel_span_to_dd_span(
             .insert(OTEL_STATUS_DESCRIPTION.to_string(), status.message.clone());
     }
 
-    if config.otlp_config_ignore_missing_datadog_fields {
-        if !dd_span.meta.contains_key("error.msg")
+    if config.otlp_config_ignore_missing_datadog_fields
+        && (!dd_span.meta.contains_key("error.msg")
             || !dd_span.meta.contains_key("error.type")
-            || !dd_span.meta.contains_key("error.stack")
-        {
-            set_span_error_from_otel_span(&mut dd_span, otel_span);
-        }
-
-        if !dd_span.meta.contains_key("env") {
-            let env = get_otel_attribute_value_as_string(
-                &otel_res.attributes,
-                DEPLOYMENT_ENVIRONMENT,
-                true,
-            );
-            if !env.is_empty() {
-                dd_span.meta.insert("env".to_string(), env);
-            }
-        }
+            || !dd_span.meta.contains_key("error.stack"))
+    {
+        set_span_error_from_otel_span(&mut dd_span, otel_span);
     }
 
     dd_span


### PR DESCRIPTION
## Summary
- Fixes environment mapping logic that created a false choice between env field mapping and service/operation name mapping
- Moves OTEL deployment.environment → Datadog env field mapping to work alongside service/operation name mapping when DD_OTLP_CONFIG_IGNORE_MISSING_DATADOG_FIELDS=false (default)
- Resolves issue where spans show env="none" despite correct OTEL resource attributes

## Background
Previously, environment mapping from OTEL `deployment.environment` to Datadog `env` field only worked when `DD_OTLP_CONFIG_IGNORE_MISSING_DATADOG_FIELDS=true`, but service/operation name mapping only worked when this flag was false (default). This created a false choice where users had to choose between environment mapping OR service/operation name mapping.

## Changes
- Moved environment mapping logic from the `config.otlp_config_ignore_missing_datadog_fields = true` block to the `= false` block in `bottlecap/src/otlp/transform.rs`
- Now all OTEL semantic convention mappings work together when the flag is false (default behavior)

## Test Plan
- [x] All existing tests pass (341 tests via cargo nextest)
- [x] Clippy linting passes
- [x] Code formatting verified

Fixes #723