### PR TITLE
fix(appsec): remove conflicting appsec_enabled configuration

### DIFF
--- a/bottlecap/src/config/env.rs
+++ b/bottlecap/src/config/env.rs
@@ -132,13 +132,6 @@ pub struct EnvConfig {
     #[serde(deserialize_with = "deserialize_service_mapping")]
     pub service_mapping: HashMap<String, String>,
     //
-    // Appsec
-    /// @env `DD_APPSEC_ENABLED`
-    ///
-    /// Enable Application and API Protection (AAP), previously known as AppSec/ASM.
-    #[serde(deserialize_with = "deserialize_optional_bool_from_anything")]
-    pub appsec_enabled: Option<bool>,
-    //
     /// @env `DD_APM_DD_URL`
     ///
     /// Define the endpoint and port to hit when using a proxy for APM.
@@ -332,7 +325,6 @@ fn merge_config(config: &mut Config, env_config: &EnvConfig) {
 
     // APM
     merge_hashmap!(config, env_config, service_mapping);
-    merge_option_to_value!(config, env_config, appsec_enabled);
     merge_string!(config, env_config, apm_dd_url);
     merge_option!(config, env_config, apm_replace_tags);
     merge_option_to_value!(
@@ -652,7 +644,6 @@ mod tests {
                     "old-service".to_string(),
                     "new-service".to_string(),
                 )]),
-                appsec_enabled: true,
                 apm_dd_url: "https://apm.datadoghq.com".to_string(),
                 apm_replace_tags: Some(
                     datadog_trace_obfuscation::replacer::parse_rules_from_string(

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -427,7 +427,7 @@ fn fallback(config: &Config) -> Result<(), ConfigError> {
     }
 
     if config.serverless_appsec_enabled {
-        log_fallback_reason("serverless_appsec_enabled");
+        log_fallback_reason("appsec_enabled");
         return Err(ConfigError::UnsupportedField(
             "serverless_appsec_enabled".to_string(),
         ));

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -265,9 +265,6 @@ pub struct Config {
     //
     pub service_mapping: HashMap<String, String>,
     //
-    // AppSec
-    pub appsec_enabled: bool,
-    //
     pub apm_dd_url: String,
     pub apm_replace_tags: Option<Vec<ReplaceRule>>,
     pub apm_config_obfuscation_http_remove_query_string: bool,
@@ -359,7 +356,6 @@ impl Default for Config {
 
             // APM
             service_mapping: HashMap::new(),
-            appsec_enabled: false,
             apm_dd_url: String::default(),
             apm_replace_tags: None,
             apm_config_obfuscation_http_remove_query_string: false,
@@ -430,9 +426,11 @@ fn fallback(config: &Config) -> Result<(), ConfigError> {
         ));
     }
 
-    if config.serverless_appsec_enabled || config.appsec_enabled {
-        log_fallback_reason("appsec_enabled");
-        return Err(ConfigError::UnsupportedField("appsec_enabled".to_string()));
+    if config.serverless_appsec_enabled {
+        log_fallback_reason("serverless_appsec_enabled");
+        return Err(ConfigError::UnsupportedField(
+            "serverless_appsec_enabled".to_string(),
+        ));
     }
 
     // OTLP
@@ -749,7 +747,7 @@ pub mod tests {
             let config = get_config(Path::new("")).expect_err("should reject unknown fields");
             assert_eq!(
                 config,
-                ConfigError::UnsupportedField("appsec_enabled".to_string())
+                ConfigError::UnsupportedField("serverless_appsec_enabled".to_string())
             );
             Ok(())
         });

--- a/bottlecap/src/config/yaml.rs
+++ b/bottlecap/src/config/yaml.rs
@@ -63,11 +63,6 @@ pub struct YamlConfig {
     pub apm_config: ApmConfig,
     #[serde(deserialize_with = "deserialize_service_mapping")]
     pub service_mapping: HashMap<String, String>,
-    //
-    // Appsec
-    #[serde(deserialize_with = "deserialize_optional_bool_from_anything")]
-    pub appsec_enabled: Option<bool>,
-    //
     // Trace Propagation
     #[serde(deserialize_with = "deserialize_trace_propagation_style")]
     pub trace_propagation_style: Vec<TracePropagationStyle>,
@@ -400,7 +395,6 @@ fn merge_config(config: &mut Config, yaml_config: &YamlConfig) {
 
     // APM
     merge_hashmap!(config, yaml_config, service_mapping);
-    merge_option_to_value!(config, yaml_config, appsec_enabled);
     merge_string!(config, apm_dd_url, yaml_config.apm_config, apm_dd_url);
     merge_option!(
         config,
@@ -676,8 +670,6 @@ apm_config:
 
 service_mapping: old-service:new-service
 
-appsec_enabled: true
-
 # Trace Propagation
 trace_propagation_style: "datadog"
 trace_propagation_style_extract: "b3"
@@ -782,7 +774,6 @@ extension_version: "compatibility"
                     "old-service".to_string(),
                     "new-service".to_string(),
                 )]),
-                appsec_enabled: true,
                 apm_dd_url: "https://apm.datadoghq.com".to_string(),
                 apm_replace_tags: Some(vec![]),
                 apm_config_obfuscation_http_remove_query_string: true,

--- a/bottlecap/src/proxy/mod.rs
+++ b/bottlecap/src/proxy/mod.rs
@@ -17,9 +17,8 @@ pub fn should_start_proxy(config: &Arc<Config>, aws_config: &AwsConfig) -> bool 
         .exec_wrapper
         .as_ref()
         .is_some_and(|s| s.eq("/opt/datadog_wrapper"));
-    let appsec_enabled = config.appsec_enabled || config.serverless_appsec_enabled;
 
-    lwa_proxy_set || (datadog_wrapper_set && appsec_enabled)
+    lwa_proxy_set || (datadog_wrapper_set && config.serverless_appsec_enabled)
 }
 
 #[cfg(test)]
@@ -32,7 +31,7 @@ mod tests {
     fn test_should_start_proxy_everything_set() {
         let config = Arc::new(Config {
             // Appsec is enabled, so we should start the proxy
-            appsec_enabled: true,
+            serverless_appsec_enabled: true,
             ..Default::default()
         });
         let aws_config = AwsConfig {
@@ -74,7 +73,7 @@ mod tests {
     fn test_should_start_proxy_appsec_enabled_and_datadog_wrapper_set() {
         let config = Arc::new(Config {
             // Appsec is enabled, so we should start the proxy
-            appsec_enabled: true,
+            serverless_appsec_enabled: true,
             ..Default::default()
         });
         let aws_config = AwsConfig {
@@ -97,7 +96,7 @@ mod tests {
     fn test_should_start_proxy_appsec_disabled_and_datadog_wrapper_set() {
         let config = Arc::new(Config {
             // Appsec is disabled, so we should not start the proxy
-            appsec_enabled: false,
+            serverless_appsec_enabled: false,
             ..Default::default()
         });
         let aws_config = AwsConfig {
@@ -120,7 +119,7 @@ mod tests {
     fn test_should_start_proxy_appsec_enabled_datadog_wrapper_not_set() {
         let config = Arc::new(Config {
             // Appsec is enabled, so we should not start the proxy
-            appsec_enabled: true,
+            serverless_appsec_enabled: true,
             ..Default::default()
         });
         let aws_config = AwsConfig {


### PR DESCRIPTION
## Background

i am currently working on Appsec enablement inside the `datadog-lambda-python` tracer and I have noticed that the extension unnecessarily falls back to the go extension when Appsec is enabled at the tracer level.

Appsec inside the extension should only be managed by the `DD_SERVERLESS_APPSEC_ENABLED` env var. 
The `DD_APPSEC_ENABLED` one is reserved for tracer enablement.

## Changes
Remove the conflicting `appsec_enabled` configuration option.

CC @Julio-Guerra 