### PR TITLE
feat(apm): aggregate and flush data accordingly for DSM, Profiling, LLMObs, and Live Debugger

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -46,6 +46,8 @@ use bottlecap::{
         listener::TelemetryListener,
     },
     traces::{
+        proxy_aggregator,
+        proxy_flusher::Flusher as ProxyFlusher,
         stats_aggregator::StatsAggregator,
         stats_flusher::{self, StatsFlusher},
         stats_processor, trace_agent, trace_aggregator,
@@ -95,6 +97,7 @@ struct PendingFlushHandles {
     trace_flush_handles: FuturesOrdered<JoinHandle<Vec<SendData>>>,
     log_flush_handles: FuturesOrdered<JoinHandle<Vec<reqwest::RequestBuilder>>>,
     metric_flush_handles: FuturesOrdered<JoinHandle<MetricsRetryBatch>>,
+    proxy_flush_handles: FuturesOrdered<JoinHandle<Vec<reqwest::RequestBuilder>>>,
 }
 
 struct MetricsRetryBatch {
@@ -109,6 +112,7 @@ impl PendingFlushHandles {
             trace_flush_handles: FuturesOrdered::new(),
             log_flush_handles: FuturesOrdered::new(),
             metric_flush_handles: FuturesOrdered::new(),
+            proxy_flush_handles: FuturesOrdered::new(),
         }
     }
 
@@ -117,6 +121,7 @@ impl PendingFlushHandles {
         logs_flusher: &LogsFlusher,
         trace_flusher: &ServerlessTraceFlusher,
         metrics_flushers: &Arc<TokioMutex<Vec<MetricsFlusher>>>,
+        proxy_flusher: &Arc<ProxyFlusher>,
     ) -> bool {
         let mut joinset = tokio::task::JoinSet::new();
         let mut flush_error = false;
@@ -186,6 +191,24 @@ impl PendingFlushHandles {
                 }
                 Err(e) => {
                     error!("redrive metrics error {e:?}");
+                }
+            }
+        }
+
+        while let Some(retries) = self.proxy_flush_handles.next().await {
+            match retries {
+                Ok(batch) => {
+                    if !batch.is_empty() {
+                        debug!("Redriving {:?} APM proxy payloads", batch.len());
+                    }
+
+                    let pf = proxy_flusher.clone();
+                    joinset.spawn(async move {
+                        pf.flush(Some(batch)).await;
+                    });
+                }
+                Err(e) => {
+                    error!("Redrive error in APM proxy: {e:?}");
                 }
             }
         }
@@ -472,6 +495,7 @@ async fn extension_loop_active(
         trace_flusher,
         trace_processor,
         stats_flusher,
+        proxy_flusher,
         trace_agent_shutdown_token,
     ) = start_trace_agent(
         config,
@@ -548,6 +572,7 @@ async fn extension_loop_active(
                             &mut locked_metrics,
                             &*trace_flusher,
                             &*stats_flusher,
+                            &proxy_flusher,
                             &mut race_flush_interval,
                             &metrics_aggr,
                         )
@@ -562,6 +587,7 @@ async fn extension_loop_active(
                 &mut locked_metrics,
                 &*trace_flusher,
                 &*stats_flusher,
+                &proxy_flusher,
                 &mut race_flush_interval,
                 &metrics_aggr,
             )
@@ -575,18 +601,23 @@ async fn extension_loop_active(
                 let tf = trace_flusher.clone();
                 // Await any previous flush handles. This
                 last_continuous_flush_error = pending_flush_handles
-                    .await_flush_handles(&logs_flusher.clone(), &tf, &metrics_flushers)
+                    .await_flush_handles(
+                        &logs_flusher.clone(),
+                        &tf,
+                        &metrics_flushers,
+                        &proxy_flusher,
+                    )
                     .await;
 
-                let val = logs_flusher.clone();
+                let lf = logs_flusher.clone();
                 pending_flush_handles
                     .log_flush_handles
-                    .push_back(tokio::spawn(async move { val.flush(None).await }));
-                let traces_val = trace_flusher.clone();
+                    .push_back(tokio::spawn(async move { lf.flush(None).await }));
+                let tf = trace_flusher.clone();
                 pending_flush_handles
                     .trace_flush_handles
                     .push_back(tokio::spawn(async move {
-                        traces_val.flush(None).await.unwrap_or_default()
+                        tf.flush(None).await.unwrap_or_default()
                     }));
                 let (metrics_flushers_copy, series, sketches) = {
                     let locked_metrics = metrics_flushers.lock().await;
@@ -613,6 +644,14 @@ async fn extension_loop_active(
                     });
                     pending_flush_handles.metric_flush_handles.push_back(handle);
                 }
+
+                let pf = proxy_flusher.clone();
+                pending_flush_handles
+                    .proxy_flush_handles
+                    .push_back(tokio::spawn(async move {
+                        pf.flush(None).await.unwrap_or_default()
+                    }));
+
                 race_flush_interval.reset();
             } else if current_flush_decision == FlushDecision::Periodic {
                 let mut locked_metrics = metrics_flushers.lock().await;
@@ -621,6 +660,7 @@ async fn extension_loop_active(
                     &mut locked_metrics,
                     &*trace_flusher,
                     &*stats_flusher,
+                    &proxy_flusher,
                     &mut race_flush_interval,
                     &metrics_aggr,
                 )
@@ -660,6 +700,7 @@ async fn extension_loop_active(
                             &mut locked_metrics,
                             &*trace_flusher,
                             &*stats_flusher,
+                            &proxy_flusher,
                             &mut race_flush_interval,
                             &metrics_aggr,
                         )
@@ -676,7 +717,12 @@ async fn extension_loop_active(
             // Redrive/block on any failed payloads
             let tf = trace_flusher.clone();
             pending_flush_handles
-                .await_flush_handles(&logs_flusher.clone(), &tf, &metrics_flushers)
+                .await_flush_handles(
+                    &logs_flusher.clone(),
+                    &tf,
+                    &metrics_flushers,
+                    &proxy_flusher,
+                )
                 .await;
             // The Shutdown event we get during a timeout will
             // never include a report log
@@ -712,6 +758,7 @@ async fn extension_loop_active(
                 &mut locked_metrics,
                 &*trace_flusher,
                 &*stats_flusher,
+                &proxy_flusher,
                 &mut race_flush_interval,
                 &metrics_aggr,
             )
@@ -726,6 +773,7 @@ async fn blocking_flush_all(
     metrics_flushers: &mut [MetricsFlusher],
     trace_flusher: &impl TraceFlusher,
     stats_flusher: &impl StatsFlusher,
+    proxy_flusher: &ProxyFlusher,
     race_flush_interval: &mut tokio::time::Interval,
     metrics_aggr: &Arc<Mutex<MetricsAggregator>>,
 ) {
@@ -745,7 +793,8 @@ async fn blocking_flush_all(
         logs_flusher.flush(None),
         futures::future::join_all(metrics_futures),
         trace_flusher.flush(None),
-        stats_flusher.flush()
+        stats_flusher.flush(),
+        proxy_flusher.flush(None),
     );
     race_flush_interval.reset();
 }
@@ -969,6 +1018,7 @@ fn start_metrics_flushers(
     flushers
 }
 
+#[allow(clippy::type_complexity)]
 fn start_trace_agent(
     config: &Arc<Config>,
     resolved_api_key: String,
@@ -980,6 +1030,7 @@ fn start_trace_agent(
     Arc<trace_flusher::ServerlessTraceFlusher>,
     Arc<trace_processor::ServerlessTraceProcessor>,
     Arc<stats_flusher::ServerlessStatsFlusher>,
+    Arc<ProxyFlusher>,
     tokio_util::sync::CancellationToken,
 ) {
     // Stats
@@ -1012,15 +1063,24 @@ fn start_trace_agent(
         resolved_api_key: resolved_api_key.clone(),
     });
 
+    // Proxy
+    let proxy_aggregator = Arc::new(TokioMutex::new(proxy_aggregator::Aggregator::default()));
+    let proxy_flusher = Arc::new(ProxyFlusher::new(
+        resolved_api_key,
+        Arc::clone(&proxy_aggregator),
+        Arc::clone(tags_provider),
+        Arc::clone(config),
+    ));
+
     let trace_agent = trace_agent::TraceAgent::new(
         Arc::clone(config),
         trace_aggregator,
         trace_processor.clone(),
         stats_aggregator,
         stats_processor,
+        proxy_aggregator,
         invocation_processor,
         Arc::clone(tags_provider),
-        resolved_api_key,
     );
     let trace_agent_channel = trace_agent.get_sender_copy();
     let shutdown_token = trace_agent.shutdown_token();
@@ -1037,6 +1097,7 @@ fn start_trace_agent(
         trace_flusher,
         trace_processor,
         stats_flusher,
+        proxy_flusher,
         shutdown_token,
     )
 }

--- a/bottlecap/src/http.rs
+++ b/bottlecap/src/http.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use tracing::error;
 
 #[must_use]
-pub fn get_client(config: Arc<config::Config>) -> reqwest::Client {
+pub fn get_client(config: &Arc<config::Config>) -> reqwest::Client {
     build_client(config).unwrap_or_else(|e| {
         error!(
             "Unable to parse proxy configuration: {}, no proxy will be used",
@@ -23,7 +23,7 @@ pub fn get_client(config: Arc<config::Config>) -> reqwest::Client {
     })
 }
 
-fn build_client(config: Arc<config::Config>) -> Result<reqwest::Client, Box<dyn Error>> {
+fn build_client(config: &Arc<config::Config>) -> Result<reqwest::Client, Box<dyn Error>> {
     let mut client = create_reqwest_client_builder()?
         .timeout(Duration::from_secs(config.flush_timeout))
         .pool_idle_timeout(Some(Duration::from_secs(270)))

--- a/bottlecap/src/logs/flusher.rs
+++ b/bottlecap/src/logs/flusher.rs
@@ -38,7 +38,7 @@ impl Flusher {
         aggregator: Arc<Mutex<Aggregator>>,
         config: Arc<config::Config>,
     ) -> Self {
-        let client = get_client(config.clone());
+        let client = get_client(&config);
         let mut headers = HeaderMap::new();
         headers.insert(
             "DD-API-KEY",

--- a/bottlecap/src/traces/mod.rs
+++ b/bottlecap/src/traces/mod.rs
@@ -3,6 +3,8 @@
 
 pub mod context;
 pub mod propagation;
+pub mod proxy_aggregator;
+pub mod proxy_flusher;
 pub mod span_pointers;
 pub mod stats_aggregator;
 pub mod stats_flusher;
@@ -32,3 +34,10 @@ const AWS_XRAY_DAEMON_ADDRESS_URL_PREFIX: &str = "169.254.79.129";
 
 // Name of the placeholder invocation span set by Java and Go tracers
 const INVOCATION_SPAN_RESOURCE: &str = "dd-tracer-serverless-span";
+
+#[allow(clippy::doc_markdown)]
+/// Header used for additional tags when sending APM data to the Datadog intake
+///
+/// Used when we are appending Lambda specific tags to incoming APM data from
+/// products like DSM, Profiling, LLMObs, Live Debugger, and more.
+const DD_ADDITIONAL_TAGS_HEADER: &str = "X-Datadog-Additional-Tags";

--- a/bottlecap/src/traces/proxy_aggregator.rs
+++ b/bottlecap/src/traces/proxy_aggregator.rs
@@ -14,7 +14,7 @@ pub struct Aggregator {
 impl Default for Aggregator {
     fn default() -> Self {
         Aggregator {
-            queue: Vec::with_capacity(128), // arbritrary capacity for request queue
+            queue: Vec::with_capacity(128), // arbitrary capacity for request queue
         }
     }
 }

--- a/bottlecap/src/traces/proxy_aggregator.rs
+++ b/bottlecap/src/traces/proxy_aggregator.rs
@@ -1,0 +1,30 @@
+use bytes::Bytes;
+use reqwest::header::HeaderMap;
+
+pub struct ProxyRequest {
+    pub headers: HeaderMap,
+    pub body: Bytes,
+    pub target_url: String,
+}
+
+pub struct Aggregator {
+    queue: Vec<ProxyRequest>,
+}
+
+impl Default for Aggregator {
+    fn default() -> Self {
+        Aggregator {
+            queue: Vec::with_capacity(128), // arbritrary capacity for request queue
+        }
+    }
+}
+
+impl Aggregator {
+    pub fn add(&mut self, request: ProxyRequest) {
+        self.queue.push(request);
+    }
+
+    pub fn get_batch(&mut self) -> Vec<ProxyRequest> {
+        std::mem::take(&mut self.queue)
+    }
+}

--- a/bottlecap/src/traces/proxy_flusher.rs
+++ b/bottlecap/src/traces/proxy_flusher.rs
@@ -93,17 +93,17 @@ impl Flusher {
     }
 
     fn create_request(&self, request: ProxyRequest) -> reqwest::RequestBuilder {
-        let mut incoming_headers = request.headers.clone();
+        let mut headers = request.headers.clone();
 
         // Remove headers that are not needed for the proxy request
-        incoming_headers.remove("host");
-        incoming_headers.remove("content-length");
+        headers.remove("host");
+        headers.remove("content-length");
 
-        incoming_headers.extend(self.headers.clone());
+        headers.extend(self.headers.clone());
 
         self.client
             .post(&request.target_url)
-            .headers(request.headers)
+            .headers(headers)
             .timeout(std::time::Duration::from_secs(self.config.flush_timeout))
             .body(request.body)
     }

--- a/bottlecap/src/traces/proxy_flusher.rs
+++ b/bottlecap/src/traces/proxy_flusher.rs
@@ -136,9 +136,7 @@ impl Flusher {
                             elapsed.as_millis()
                         );
                     } else {
-                        error!(
-                            "Proxy Flusher | Request failed with status {status}: {body:?}"
-                        );
+                        error!("Proxy Flusher | Request failed with status {status}: {body:?}");
                     }
 
                     return Ok(());

--- a/bottlecap/src/traces/proxy_flusher.rs
+++ b/bottlecap/src/traces/proxy_flusher.rs
@@ -1,0 +1,188 @@
+use std::{error::Error, sync::Arc};
+use thiserror::Error as ThisError;
+use tokio::{sync::Mutex, task::JoinSet};
+
+use reqwest::header::HeaderMap;
+use tracing::{debug, error};
+
+use crate::{
+    config,
+    http::get_client,
+    tags::provider,
+    traces::{
+        proxy_aggregator::{Aggregator, ProxyRequest},
+        DD_ADDITIONAL_TAGS_HEADER,
+    },
+    FLUSH_RETRY_COUNT,
+};
+
+#[derive(ThisError, Debug)]
+#[error("{message}")]
+pub struct FailedProxyRequestError {
+    pub request: reqwest::RequestBuilder,
+    pub message: String,
+}
+
+pub struct Flusher {
+    client: reqwest::Client,
+    aggregator: Arc<Mutex<Aggregator>>,
+    config: Arc<config::Config>,
+    headers: HeaderMap,
+}
+
+impl Flusher {
+    pub fn new(
+        api_key: String,
+        aggregator: Arc<Mutex<Aggregator>>,
+        tags_provider: Arc<provider::Provider>,
+        config: Arc<config::Config>,
+    ) -> Self {
+        let client = get_client(&config);
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "DD-API-KEY",
+            api_key.parse().expect("Failed to parse API key header"),
+        );
+        let additional_tags = format!(
+            "_dd.origin:lambda;functionname:{}",
+            tags_provider
+                .get_canonical_resource_name()
+                .unwrap_or_default()
+        );
+        headers.insert(
+            DD_ADDITIONAL_TAGS_HEADER,
+            additional_tags
+                .parse()
+                .expect("Failed to parse additional tags header"),
+        );
+
+        Flusher {
+            client,
+            aggregator,
+            config,
+            headers,
+        }
+    }
+
+    pub async fn flush(
+        &self,
+        retry_requests: Option<Vec<reqwest::RequestBuilder>>,
+    ) -> Option<Vec<reqwest::RequestBuilder>> {
+        let mut join_set = JoinSet::new();
+        let mut requests = Vec::<reqwest::RequestBuilder>::new();
+
+        // If there are any requests to retry, start with those
+        if retry_requests.as_ref().is_some_and(|r| !r.is_empty()) {
+            let retries = retry_requests.unwrap_or_default();
+            debug!("Proxy Flusher | Retrying {} failed requests", retries.len());
+            requests = retries;
+        } else {
+            let mut aggregator = self.aggregator.lock().await;
+            for pr in aggregator.get_batch() {
+                requests.push(self.create_request(pr));
+            }
+        }
+
+        for request in requests {
+            join_set.spawn(async move { Self::send(request).await });
+        }
+
+        let send_results = join_set.join_all().await;
+
+        Self::get_failed_requests(send_results)
+    }
+
+    fn create_request(&self, request: ProxyRequest) -> reqwest::RequestBuilder {
+        let mut incoming_headers = request.headers.clone();
+
+        // Remove headers that are not needed for the proxy request
+        incoming_headers.remove("host");
+        incoming_headers.remove("content-length");
+
+        incoming_headers.extend(self.headers.clone());
+
+        self.client
+            .post(&request.target_url)
+            .headers(request.headers)
+            .timeout(std::time::Duration::from_secs(self.config.flush_timeout))
+            .body(request.body)
+    }
+
+    async fn send(request: reqwest::RequestBuilder) -> Result<(), Box<dyn Error + Send>> {
+        debug!("Proxy Flusher | Attempting to send request");
+        let mut attempts = 0;
+
+        loop {
+            attempts += 1;
+
+            let Some(cloned_request) = request.try_clone() else {
+                return Err(Box::new(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "can't clone proxy request",
+                )));
+            };
+
+            let time = std::time::Instant::now();
+            let response = cloned_request.send().await;
+            let elapsed = time.elapsed();
+
+            match response {
+                Ok(r) => {
+                    let status = r.status();
+                    let body = r.text().await;
+                    if status == 202 || status == 200 {
+                        debug!(
+                            "Proxy Flusher | Successfully sent request in {} ms",
+                            elapsed.as_millis()
+                        );
+                    } else {
+                        error!(
+                            "Proxy Flusher | Request failed with status {status}: {body:?}"
+                        );
+                    }
+
+                    return Ok(());
+                }
+                Err(e) => {
+                    if attempts >= FLUSH_RETRY_COUNT {
+                        error!(
+                            "Proxy Flusher | Failed to send request after {} attempts: {:?}",
+                            attempts, e
+                        );
+
+                        return Err(Box::new(FailedProxyRequestError {
+                            request,
+                            message: e.to_string(),
+                        }));
+                    }
+                }
+            }
+        }
+    }
+
+    /// Given a vector of results from the `send` method, return a vector of failed requests
+    /// if there are any.
+    ///
+    /// Failed requests should be retried later.
+    fn get_failed_requests(
+        results: Vec<Result<(), Box<dyn Error + Send>>>,
+    ) -> Option<Vec<reqwest::RequestBuilder>> {
+        let mut failed_requests: Vec<reqwest::RequestBuilder> = Vec::new();
+        for result in results {
+            // There is no cleaner way to do this, so it's deeply nested.
+            if let Err(e) = result {
+                if let Some(fpre) = e.downcast_ref::<FailedProxyRequestError>() {
+                    if let Some(request) = fpre.request.try_clone() {
+                        failed_requests.push(request);
+                    }
+                }
+            }
+        }
+
+        if failed_requests.is_empty() {
+            return None;
+        }
+
+        Some(failed_requests)
+    }
+}

--- a/bottlecap/src/traces/proxy_flusher.rs
+++ b/bottlecap/src/traces/proxy_flusher.rs
@@ -128,11 +128,12 @@ impl Flusher {
 
             match response {
                 Ok(r) => {
+                    let url = r.url().to_string();
                     let status = r.status();
                     let body = r.text().await;
                     if status == 202 || status == 200 {
                         debug!(
-                            "Proxy Flusher | Successfully sent request in {} ms",
+                            "Proxy Flusher | Successfully sent request in {} ms to {url}",
                             elapsed.as_millis()
                         );
                     } else {


### PR DESCRIPTION
# What?

Creates an aggregator and flusher for APM proxy data.

# Motivation

With the introduction of #684, the Extension is way faster to continue invocations, I think this could have affected how data is aggregated for this various APM products in which we were just sending the request to intake as soon as it arrives.

Now, we aggregate it and respect the flushing pattern and algorithm.

# Testing

1. Profiling:
<img width="1497" height="741" alt="Screenshot 2025-07-11 at 11 13 55 AM" src="https://github.com/user-attachments/assets/f11c3536-f7e9-4f92-b853-2c7fd5d71720" />

2. LLMObs:
<img width="1342" height="855" alt="Screenshot 2025-07-15 at 3 12 01 PM" src="https://github.com/user-attachments/assets/19703ffa-ef45-4b79-ba61-28673edafa05" />

3. DSM:
tbd


4. Live Debugger:
<img width="2122" height="1806" alt="image" src="https://github.com/user-attachments/assets/8bb638a8-6b1d-43d3-a1da-cc54e649dcac" />


