### PR TITLE
chore: Add workflow_dispatch trigger for rs_ci.yml

### DIFF
--- a/.github/workflows/rs_ci.yml
+++ b/.github/workflows/rs_ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 env:
   PB_VERSION: 25.3
@@ -146,7 +147,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-22.04, macos-latest ]
+        os: [ubuntu-22.04, macos-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1.13.0


### PR DESCRIPTION
# This PR
Allows the workflow `rs_ci.yml` to be triggered manually.

# Motivation
Right now `rs_ci.yml` can only use the workflow from the main branch, making it hard to test https://github.com/DataDog/datadog-lambda-extension/pull/741.