### PR TITLE
chore: upgrade rust version for toolchain to 1.84.1

### DIFF
--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -197,7 +197,7 @@ impl ConfigBuilder {
         // or in the `proxy_no_proxy` config field.
         if self.config.proxy_https.is_some() {
             let site_in_no_proxy = std::env::var("NO_PROXY")
-                .map_or(false, |no_proxy| no_proxy.contains(&self.config.site))
+                .is_ok_and(|no_proxy| no_proxy.contains(&self.config.site))
                 || self
                     .config
                     .proxy_no_proxy
@@ -543,7 +543,7 @@ where
 {
     struct KeyValueVisitor;
 
-    impl<'de> serde::de::Visitor<'de> for KeyValueVisitor {
+    impl serde::de::Visitor<'_> for KeyValueVisitor {
         type Value = HashMap<String, String>;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/bottlecap/src/lifecycle/invocation/mod.rs
+++ b/bottlecap/src/lifecycle/invocation/mod.rs
@@ -43,7 +43,7 @@ fn create_empty_span(name: String, resource: &str, service: &str) -> Span {
 
 #[must_use]
 pub fn generate_span_id() -> u64 {
-    if std::env::var(INIT_TYPE).map_or(false, |it| it == SNAP_START_VALUE) {
+    if std::env::var(INIT_TYPE).is_ok_and(|it| it == SNAP_START_VALUE) {
         return OsRng.next_u64();
     }
 

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -898,7 +898,7 @@ impl Processor {
 
         let is_error = headers
             .get(DATADOG_INVOCATION_ERROR_KEY)
-            .map_or(false, |v| v.to_lowercase() == "true")
+            .is_some_and(|v| v.to_lowercase() == "true")
             || message.is_some()
             || stack.is_some()
             || r#type.is_some()

--- a/bottlecap/src/lifecycle/invocation/triggers/event_bridge_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/event_bridge_event.rs
@@ -47,7 +47,7 @@ impl Trigger for EventBridgeEvent {
             && payload
                 .get("source")
                 .and_then(Value::as_str)
-                .map_or(false, |s| s != "aws.events")
+                .is_some_and(|s| s != "aws.events")
     }
 
     #[allow(clippy::cast_possible_truncation)]

--- a/bottlecap/src/lifecycle/invocation/triggers/lambda_function_url_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/lambda_function_url_event.rs
@@ -59,7 +59,7 @@ impl Trigger for LambdaFunctionUrlEvent {
             .get("requestContext")
             .and_then(|rc| rc.get("domainName"))
             .and_then(Value::as_str)
-            .map_or(false, |dn| dn.contains("lambda-url"))
+            .is_some_and(|dn| dn.contains("lambda-url"))
     }
 
     #[allow(clippy::cast_possible_truncation)]

--- a/bottlecap/src/lifecycle/invocation/triggers/msk_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/msk_event.rs
@@ -55,7 +55,7 @@ impl Trigger for MSKEvent {
             .and_then(|map| map.values().next())
             .and_then(Value::as_array)
             .and_then(|arr| arr.first())
-            .map_or(false, |rec| rec.get("topic").is_some())
+            .is_some_and(|rec| rec.get("topic").is_some())
     }
 
     #[allow(clippy::cast_possible_truncation)]

--- a/bottlecap/src/lifecycle/invocation/triggers/sqs_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/sqs_event.rs
@@ -93,7 +93,7 @@ impl Trigger for SqsRecord {
             first_record
                 .get("eventSource")
                 .and_then(Value::as_str)
-                .map_or(false, |s| s == "aws:sqs")
+                .is_some_and(|s| s == "aws:sqs")
         } else {
             false
         }

--- a/bottlecap/src/otlp/agent.rs
+++ b/bottlecap/src/otlp/agent.rs
@@ -71,6 +71,8 @@ impl Agent {
         self.cancel_token.clone()
     }
 
+    // TODO (Yiming): Fix this lint
+    #[allow(clippy::ref_option)]
     fn parse_port(endpoint: &Option<String>, default_port: u16) -> u16 {
         if let Some(endpoint) = endpoint {
             let port = endpoint.split(':').nth(1);

--- a/bottlecap/src/proc/mod.rs
+++ b/bottlecap/src/proc/mod.rs
@@ -60,7 +60,7 @@ fn get_network_data_from_path(path: &str) -> Result<NetworkData, io::Error> {
         let line = line?;
         let mut values = line.split_whitespace();
 
-        if values.next().map_or(false, |interface_name| {
+        if values.next().is_some_and(|interface_name| {
             interface_name.starts_with(LAMBDA_NETWORK_INTERFACE)
                 || interface_name.starts_with(LAMBDA_RUNTIME_NETWORK_INTERFACE)
         }) {

--- a/bottlecap/src/proxy/interceptor.rs
+++ b/bottlecap/src/proxy/interceptor.rs
@@ -110,6 +110,8 @@ async fn graceful_shutdown(tasks: Arc<Mutex<JoinSet<()>>>, shutdown_token: Cance
 /// If the LWA proxy lambda runtime API is not provided, the default Extension
 /// host and port will be used.
 ///
+// TODO (Yiming): Fix this lint
+#[allow(clippy::ref_option)]
 fn get_proxy_socket_address(aws_lwa_proxy_lambda_runtime_api: &Option<String>) -> SocketAddr {
     if let Some(socket_addr) = aws_lwa_proxy_lambda_runtime_api
         .as_ref()

--- a/bottlecap/src/traces/propagation/text_map_propagator.rs
+++ b/bottlecap/src/traces/propagation/text_map_propagator.rs
@@ -96,7 +96,7 @@ impl DatadogHeaderPropagator {
     fn validate_sampling_decision(tags: &mut HashMap<String, String>) {
         let should_remove =
             tags.get(DATADOG_SAMPLING_DECISION_KEY)
-                .map_or(false, |sampling_decision| {
+                .is_some_and(|sampling_decision| {
                     let is_invalid = !VALID_SAMPLING_DECISION_REGEX.is_match(sampling_decision);
                     if is_invalid {
                         warn!("Failed to decode `_dd.p.dm`: {}", sampling_decision);

--- a/bottlecap/src/traces/stats_aggregator.rs
+++ b/bottlecap/src/traces/stats_aggregator.rs
@@ -1,6 +1,7 @@
 use datadog_trace_protobuf::pb::ClientStatsPayload;
 use std::collections::VecDeque;
 
+#[allow(clippy::empty_line_after_doc_comments)]
 /// Maximum number of entries in a stat payload.
 ///
 /// <https://github.com/DataDog/datadog-agent/blob/996dd54337908a6511948fabd2a41420ba919a8b/pkg/trace/writer/stats.go#L35-L41>

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.84.1"
 components = [ "rustfmt", "clippy" ]
 profile = "minimal"


### PR DESCRIPTION
# This PR
1. In `rust-toolchain.toml`, upgrade Rust version from `1.81.0` to `1.84.1`.
2. Fix/mute clippy errors caused by the upgrade
  - some errors require non-trivial code changes, so I muted them for now and added a TODO to fix them in separate PRs.

# Motivation
`libdatadog` now uses `1.84.1` https://github.com/DataDog/libdatadog/blame/main/Cargo.toml#L62

To test changes on `libdatadog`, I need to change the Rust version in `datadog-lambda-extension` to 1.84.1 as well.

Making this a separate PR:
1. so it's easier to test multiple PRs that depend on changes on `libdatadog` in parallel after I merge this PR to main.
4. because this PR also involves lots of code changes needed to make clippy happy