### PR TITLE
Aj/fix shutdown deadlock

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -679,20 +679,11 @@ async fn extension_loop_active(
             'shutdown: loop {
                 tokio::select! {
                     Some(event) = event_bus.rx.recv() => {
-                        match event {
-                            Event::Telemetry(telemetry_event) => {
-                                if let TelemetryRecord::PlatformTombstone = telemetry_event.record {
-                                    debug!("Received tombstone event, proceeding with shutdown");
-                                    break 'shutdown;
-                                }
-                                // Process other telemetry events normally
-                                handle_event_bus_event(Event::Telemetry(telemetry_event), invocation_processor.clone(), tags_provider.clone(), trace_processor.clone(), trace_agent_channel.clone()).await;
-                            }
-                            other_event => {
-                                // Process non-telemetry events
-                                handle_event_bus_event(other_event, invocation_processor.clone(), tags_provider.clone(), trace_processor.clone(), trace_agent_channel.clone()).await;
-                            }
+                    if let Event::Telemetry(TelemetryEvent { record: TelemetryRecord::PlatformTombstone, .. }) = event {
+                            debug!("Received tombstone event, proceeding with shutdown");
+                            break 'shutdown;
                         }
+                    handle_event_bus_event(event, invocation_processor.clone(), tags_provider.clone(), trace_processor.clone(), trace_agent_channel.clone()).await;
                     }
                     // Add timeout to prevent hanging indefinitely
                     () = tokio::time::sleep(tokio::time::Duration::from_millis(300)) => {

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -695,7 +695,7 @@ async fn extension_loop_active(
                         }
                     }
                     // Add timeout to prevent hanging indefinitely
-                    _ = tokio::time::sleep(tokio::time::Duration::from_millis(300)) => {
+                    () = tokio::time::sleep(tokio::time::Duration::from_millis(300)) => {
                         debug!("Timeout waiting for tombstone event, proceeding with shutdown");
                         break 'shutdown;
                     }

--- a/bottlecap/src/telemetry/events.rs
+++ b/bottlecap/src/telemetry/events.rs
@@ -150,6 +150,10 @@ pub enum TelemetryRecord {
         /// When unsuccessful, the `error_type` describes what kind of error occurred
         error_type: Option<String>,
     },
+
+    /// Tombstone event to signal shutdown
+    #[serde(rename = "platform.tombstone")]
+    PlatformTombstone,
 }
 
 /// Type of Initialization

--- a/bottlecap/src/telemetry/listener.rs
+++ b/bottlecap/src/telemetry/listener.rs
@@ -1,6 +1,6 @@
 use crate::{
     http::{extract_request_body, handler_not_found},
-    telemetry::events::TelemetryEvent,
+    telemetry::events::{TelemetryEvent, TelemetryRecord},
 };
 
 use axum::{
@@ -10,6 +10,7 @@ use axum::{
     routing::post,
     Router,
 };
+use chrono::Utc;
 use std::net::SocketAddr;
 use tokio::{net::TcpListener, sync::mpsc::Sender};
 use tokio_util::sync::CancellationToken;
@@ -46,13 +47,17 @@ impl TelemetryListener {
         let router = self.make_router();
 
         let cancel_token_clone = self.cancel_token();
+        let event_bus_clone = self.event_bus.clone();
         tokio::spawn(async move {
             let listener = TcpListener::bind(&socket)
                 .await
                 .expect("Failed to bind socket");
             debug!("Telemetry API | Starting listener on {}", socket);
             axum::serve(listener, router)
-                .with_graceful_shutdown(Self::graceful_shutdown(cancel_token_clone))
+                .with_graceful_shutdown(Self::graceful_shutdown(
+                    cancel_token_clone,
+                    event_bus_clone,
+                ))
                 .await
                 .expect("Failed to start telemetry listener");
         });
@@ -69,9 +74,21 @@ impl TelemetryListener {
             .with_state(event_bus)
     }
 
-    async fn graceful_shutdown(cancel_token: CancellationToken) {
+    async fn graceful_shutdown(cancel_token: CancellationToken, event_bus: Sender<TelemetryEvent>) {
         cancel_token.cancelled().await;
-        debug!("Telemetry API | Shutdown signal received, shutting down");
+        debug!("Telemetry API | Shutdown signal received, sending tombstone event");
+
+        // Send tombstone event to signal shutdown
+        let tombstone_event = TelemetryEvent {
+            time: Utc::now(),
+            record: TelemetryRecord::PlatformTombstone,
+        };
+
+        if let Err(e) = event_bus.send(tombstone_event).await {
+            debug!("Failed to send tombstone event: {:?}", e);
+        }
+
+        debug!("Telemetry API | Shutting down");
     }
 
     async fn handle(State(event_bus): State<Sender<TelemetryEvent>>, request: Request) -> Response {


### PR DESCRIPTION
We added this check for the platform.Report item because we'd occasionally race past it when shutting down, leading to missing metrics (namely post-runtime duration for the last request). This predominantly affected hourly/infrequent functions.

But that change introduced a race condition where sometimes Lambda would respond to /next with the shutdown event at the same time we'd receive the last invocation's report event. In some cases, Tokio would run the report event first followed by the response to /next, where then we'd hit the shutdown event bus loop and wait for a report event that was never coming.

This change also adds a 300ms timeout in case of a deadlock.

Jira: https://datadoghq.atlassian.net/browse/SLES-2151