### PR TITLE
feat: use GITHUB_TOKEN if available in Serverless-Init .NET install script

### DIFF
--- a/scripts/serverless_init_dotnet.sh
+++ b/scripts/serverless_init_dotnet.sh
@@ -15,7 +15,17 @@ TRACER_VERSION=${TRACER_VERSION#v} # remove the 'v' prefix
 
 # Download the tracer to the dd_tracer folder
 echo Downloading version "${TRACER_VERSION}" of the .NET tracer into /tmp/datadog-dotnet-apm.tar.gz
-curl -L "https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm-${TRACER_VERSION}.tar.gz" -o /tmp/datadog-dotnet-apm.tar.gz
+
+# Use Github authentication token if provided
+if [ -n "$GITHUB_TOKEN" ]; then
+    curl -L -H "Authorization: Bearer $GITHUB_TOKEN" \
+        "https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm-${TRACER_VERSION}.tar.gz" \
+        -o /tmp/datadog-dotnet-apm.tar.gz
+else
+    curl -L \
+        "https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm-${TRACER_VERSION}.tar.gz" \
+        -o /tmp/datadog-dotnet-apm.tar.gz
+fi
 
 # Unarchive the tracer and remove the tmp
 mkdir -p /dd_tracer/dotnet

--- a/scripts/serverless_init_dotnet.sh
+++ b/scripts/serverless_init_dotnet.sh
@@ -15,17 +15,9 @@ TRACER_VERSION=${TRACER_VERSION#v} # remove the 'v' prefix
 
 # Download the tracer to the dd_tracer folder
 echo Downloading version "${TRACER_VERSION}" of the .NET tracer into /tmp/datadog-dotnet-apm.tar.gz
-
-# Use Github authentication token if provided
-if [ -n "$GITHUB_TOKEN" ]; then
-    curl -L -H "Authorization: Bearer $GITHUB_TOKEN" \
-        "https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm-${TRACER_VERSION}.tar.gz" \
-        -o /tmp/datadog-dotnet-apm.tar.gz
-else
-    curl -L \
-        "https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm-${TRACER_VERSION}.tar.gz" \
-        -o /tmp/datadog-dotnet-apm.tar.gz
-fi
+curl -L -H "Authorization: Bearer $GITHUB_TOKEN" \
+    "https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm-${TRACER_VERSION}.tar.gz" \
+    -o /tmp/datadog-dotnet-apm.tar.gz
 
 # Unarchive the tracer and remove the tmp
 mkdir -p /dd_tracer/dotnet


### PR DESCRIPTION
Currently the .NET install script for Serverless-Init makes unauthenticated requests to the Github API, sometimes resulting in rate limiting. This PR adds a `GITHUB_TOKEN` to be passed as a Docker secret to the .NET install script to allow for an increased rate limit. If no `GITHUB_TOKEN` is passed then requests will be unauthenticated as they were before this change.

## Additional Notes

Pass value in `GITHUB_TOKEN` environment variable to the Docker secret `github-token`.
```
docker build -t <image> --secret id=github-token,env=GITHUB_TOKEN .
```

In the Dockerfile read the value of the `github-token` secret into the `GITHUB_TOKEN` environment variable so it can be passed in the authentication header of the Github API request.
```
RUN --mount=type=secret,id=github-token,env=GITHUB_TOKEN \
    chmod +x /app/test.sh && /app/test.sh
```