### PR TITLE
fix(fips): ignore test and build deps

### DIFF
--- a/bottlecap/build.rs
+++ b/bottlecap/build.rs
@@ -8,6 +8,7 @@ fn check_forbidden_dependency(dependency_name: &str) -> Result<(), String> {
     );
 
     // First run cargo tree to get dependency with detailed info
+    // Use --edges normal to exclude build and test dependencies
     let output = Command::new("cargo")
         .args([
             "tree",
@@ -17,6 +18,7 @@ fn check_forbidden_dependency(dependency_name: &str) -> Result<(), String> {
             "--prefix-depth",
             "--features=fips",
             "--no-default-features",
+            "--edges=normal",
         ])
         .output()
         .map_err(|e| {
@@ -27,6 +29,7 @@ fn check_forbidden_dependency(dependency_name: &str) -> Result<(), String> {
         })?;
 
     // Also get the complete dependency path to help debugging
+    // Use --edges normal to exclude build and test dependencies
     let path_output = Command::new("cargo")
         .args([
             "tree",
@@ -34,6 +37,7 @@ fn check_forbidden_dependency(dependency_name: &str) -> Result<(), String> {
             dependency_name,
             "--features=fips",
             "--no-default-features",
+            "--edges=normal",
         ])
         .output()
         .map_err(|e| {


### PR DESCRIPTION
# What?

Sets `--edges=normal` to ignore build and test dependencies

# Why?

Unblock #695, since it uses `reqwest` when downloading the `libddwaf` binary