### PR TITLE
Enhance Synthetic Span Service Representation

### DIFF
--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -89,11 +89,11 @@ impl Processor {
         aws_config: Arc<AwsConfig>,
         metrics_aggregator: Arc<Mutex<MetricsAggregator>>,
     ) -> Self {
-        let service = config.service.clone().unwrap_or(String::from("aws.lambda"));
         let resource = tags_provider
             .get_canonical_resource_name()
             .unwrap_or(String::from("aws.lambda"));
 
+        let service = config.service.clone().unwrap_or(resource.clone());
         let propagator = DatadogCompositePropagator::new(Arc::clone(&config));
 
         Processor {

--- a/bottlecap/src/lifecycle/invocation/triggers/alb_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/alb_event.rs
@@ -230,7 +230,8 @@ mod tests {
         assert_eq!(
             event.resolve_service_name(
                 &specific_service_mapping,
-                &event.request_context.elb.target_group_arn
+                &event.request_context.elb.target_group_arn,
+                None
             ),
             "specific-service"
         );
@@ -242,7 +243,8 @@ mod tests {
         assert_eq!(
             event.resolve_service_name(
                 &generic_service_mapping,
-                &event.request_context.elb.target_group_arn
+                &event.request_context.elb.target_group_arn,
+                None
             ),
             "generic-service"
         );

--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_http_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_http_event.rs
@@ -79,7 +79,7 @@ impl Trigger for APIGatewayHttpEvent {
         let start_time = (self.request_context.time_epoch as f64 * MS_TO_NS) as i64;
 
         let service_name =
-            self.resolve_service_name(service_mapping, &self.request_context.domain_name);
+            self.resolve_service_name(service_mapping, &self.request_context.domain_name, None);
 
         span.name = "aws.httpapi".to_string();
         span.service = service_name;
@@ -421,7 +421,8 @@ mod tests {
         assert_eq!(
             event.resolve_service_name(
                 &specific_service_mapping,
-                &event.request_context.domain_name
+                &event.request_context.domain_name,
+                None
             ),
             "specific-service"
         );
@@ -432,7 +433,7 @@ mod tests {
         )]);
         assert_eq!(
             event
-                .resolve_service_name(&generic_service_mapping, &event.request_context.domain_name),
+                .resolve_service_name(&generic_service_mapping, &event.request_context.domain_name, None),
             "generic-service"
         );
     }

--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_rest_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_rest_event.rs
@@ -82,7 +82,7 @@ impl Trigger for APIGatewayRestEvent {
         let start_time = (self.request_context.time_epoch as f64 * MS_TO_NS) as i64;
 
         let service_name =
-            self.resolve_service_name(service_mapping, &self.request_context.domain_name);
+            self.resolve_service_name(service_mapping, &self.request_context.domain_name, None);
 
         span.name = "aws.apigateway".to_string();
         span.service = service_name;
@@ -437,7 +437,8 @@ mod tests {
         assert_eq!(
             event.resolve_service_name(
                 &specific_service_mapping,
-                &event.request_context.domain_name
+                &event.request_context.domain_name,
+                None
             ),
             "specific-service"
         );
@@ -448,7 +449,7 @@ mod tests {
         )]);
         assert_eq!(
             event
-                .resolve_service_name(&generic_service_mapping, &event.request_context.domain_name),
+                .resolve_service_name(&generic_service_mapping, &event.request_context.domain_name, None),
             "generic-service"
         );
     }

--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
@@ -72,7 +72,7 @@ impl Trigger for APIGatewayWebSocketEvent {
         let start_time = (self.request_context.time_epoch as f64 * MS_TO_NS) as i64;
 
         let service_name =
-            self.resolve_service_name(service_mapping, &self.request_context.domain_name);
+            self.resolve_service_name(service_mapping, &self.request_context.domain_name, None);
 
         span.name = "aws.apigateway".to_string();
         span.service = service_name;
@@ -362,7 +362,8 @@ mod tests {
         assert_eq!(
             event.resolve_service_name(
                 &specific_service_mapping,
-                &event.request_context.domain_name
+                &event.request_context.domain_name,
+                None
             ),
             "specific-service"
         );
@@ -374,7 +375,7 @@ mod tests {
 
         assert_eq!(
             event
-                .resolve_service_name(&generic_service_mapping, &event.request_context.domain_name),
+                .resolve_service_name(&generic_service_mapping, &event.request_context.domain_name, None),
             "generic-service"
         );
     }

--- a/bottlecap/src/lifecycle/invocation/triggers/dynamodb_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/dynamodb_event.rs
@@ -108,7 +108,7 @@ impl Trigger for DynamoDbRecord {
 
         let start_time = (self.dynamodb.approximate_creation_date_time * S_TO_NS) as i64;
 
-        let service_name = self.resolve_service_name(service_mapping, "dynamodb");
+        let service_name = self.resolve_service_name(service_mapping, &table_name, "dynamodb");
 
         span.name = String::from("aws.dynamodb");
         span.service = service_name.to_string();
@@ -355,14 +355,14 @@ mod tests {
         ]);
 
         assert_eq!(
-            event.resolve_service_name(&specific_service_mapping, "dynamodb"),
+            event.resolve_service_name(&specific_service_mapping, &event.get_specific_identifier(), "dynamodb"),
             "specific-service"
         );
 
         let generic_service_mapping =
             HashMap::from([("lambda_dynamodb".to_string(), "generic-service".to_string())]);
         assert_eq!(
-            event.resolve_service_name(&generic_service_mapping, "dynamodb"),
+            event.resolve_service_name(&generic_service_mapping, &event.get_specific_identifier(), "dynamodb"),
             "generic-service"
         );
     }

--- a/bottlecap/src/lifecycle/invocation/triggers/event_bridge_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/event_bridge_event.rs
@@ -65,7 +65,7 @@ impl Trigger for EventBridgeEvent {
             .and_then(|s| s.parse::<f64>().ok())
             .map_or(start_time_seconds, |s| (s * MS_TO_NS) as i64);
 
-        let service_name = self.resolve_service_name(service_mapping, &resource_name, "eventbridge");
+        let service_name = self.resolve_service_name(service_mapping, &self.get_specific_identifier(), "eventbridge");
 
         span.name = String::from("aws.eventbridge");
         span.service = service_name.to_string();

--- a/bottlecap/src/lifecycle/invocation/triggers/event_bridge_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/event_bridge_event.rs
@@ -65,7 +65,7 @@ impl Trigger for EventBridgeEvent {
             .and_then(|s| s.parse::<f64>().ok())
             .map_or(start_time_seconds, |s| (s * MS_TO_NS) as i64);
 
-        let service_name = self.resolve_service_name(service_mapping, "eventbridge");
+        let service_name = self.resolve_service_name(service_mapping, &resource_name, "eventbridge");
 
         span.name = String::from("aws.eventbridge");
         span.service = service_name.to_string();
@@ -271,7 +271,7 @@ mod tests {
         ]);
 
         assert_eq!(
-            event.resolve_service_name(&specific_service_mapping, "eventbridge"),
+            event.resolve_service_name(&specific_service_mapping, &event.get_specific_identifier(), "eventbridge"),
             "specific-service"
         );
 
@@ -280,7 +280,7 @@ mod tests {
             "generic-service".to_string(),
         )]);
         assert_eq!(
-            event.resolve_service_name(&generic_service_mapping, "eventbridge"),
+            event.resolve_service_name(&generic_service_mapping, &event.get_specific_identifier(), "eventbridge"),
             "generic-service"
         );
     }

--- a/bottlecap/src/lifecycle/invocation/triggers/kinesis_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/kinesis_event.rs
@@ -74,7 +74,7 @@ impl Trigger for KinesisRecord {
     fn enrich_span(&self, span: &mut Span, service_mapping: &HashMap<String, String>) {
         let stream_name = self.get_specific_identifier();
         let shard_id = self.event_id.split(':').next().unwrap_or_default();
-        let service_name = self.resolve_service_name(service_mapping, "kinesis");
+        let service_name = self.resolve_service_name(service_mapping, &stream_name, "kinesis");
 
         span.name = String::from("aws.kinesis");
         span.service = service_name;
@@ -280,14 +280,14 @@ mod tests {
         ]);
 
         assert_eq!(
-            event.resolve_service_name(&specific_service_mapping, "kinesis"),
+            event.resolve_service_name(&specific_service_mapping, &event.get_specific_identifier(), "kinesis"),
             "specific-service"
         );
 
         let generic_service_mapping =
             HashMap::from([("lambda_kinesis".to_string(), "generic-service".to_string())]);
         assert_eq!(
-            event.resolve_service_name(&generic_service_mapping, "kinesis"),
+            event.resolve_service_name(&generic_service_mapping, &event.get_specific_identifier(), "kinesis"),
             "generic-service"
         );
     }

--- a/bottlecap/src/lifecycle/invocation/triggers/lambda_function_url_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/lambda_function_url_event.rs
@@ -78,7 +78,7 @@ impl Trigger for LambdaFunctionUrlEvent {
         let start_time = (self.request_context.time_epoch as f64 * MS_TO_NS) as i64;
 
         let service_name =
-            self.resolve_service_name(service_mapping, &self.request_context.domain_name);
+            self.resolve_service_name(service_mapping, &self.request_context.domain_name, None);
 
         span.name = String::from("aws.lambda.url");
         span.service = service_name;
@@ -336,14 +336,14 @@ mod tests {
         ]);
 
         assert_eq!(
-            event.resolve_service_name(&specific_service_mapping, "domain-name"),
+            event.resolve_service_name(&specific_service_mapping, "domain-name", None),
             "specific-service"
         );
 
         let generic_service_mapping =
             HashMap::from([("lambda_url".to_string(), "generic-service".to_string())]);
         assert_eq!(
-            event.resolve_service_name(&generic_service_mapping, "domain-name"),
+            event.resolve_service_name(&generic_service_mapping, "domain-name", None),
             "generic-service"
         );
     }

--- a/bottlecap/src/lifecycle/invocation/triggers/mod.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/mod.rs
@@ -113,12 +113,19 @@ pub trait Trigger: ServiceNameResolver {
     fn resolve_service_name(
         &self,
         service_mapping: &HashMap<String, String>,
-        fallback: &str,
+        instance_name: &str,
+        fallback: Option<&str>,
     ) -> String {
         service_mapping
             .get(&self.get_specific_identifier())
             .or_else(|| service_mapping.get(self.get_generic_identifier()))
-            .unwrap_or(&fallback.to_string())
+            .unwrap_or_else(|| {
+                if !instance_name.is_empty() {
+                    instance_name.to_string()
+                } else {
+                    fallback.unwrap_or_default().to_string()
+                }
+            })
             .to_string()
     }
 }

--- a/bottlecap/src/lifecycle/invocation/triggers/msk_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/msk_event.rs
@@ -63,7 +63,7 @@ impl Trigger for MSKEvent {
         debug!("Enriching an Inferred Span for an MSK event");
 
         span.name = String::from("aws.msk");
-        span.service = self.resolve_service_name(service_mapping, "msk");
+        span.service = self.resolve_service_name(service_mapping, &self.get_specific_identifier(), "msk");
         span.r#type = String::from("web");
 
         let first_value = self.records.values().find_map(|arr| arr.first());
@@ -241,14 +241,14 @@ mod tests {
         ]);
 
         assert_eq!(
-            event.resolve_service_name(&specific_service_mapping, "msk"),
+            event.resolve_service_name(&specific_service_mapping, &event.get_specific_identifier(), "msk"),
             "specific-service"
         );
 
         let generic_service_mapping =
             HashMap::from([("lambda_msk".to_string(), "generic-service".to_string())]);
         assert_eq!(
-            event.resolve_service_name(&generic_service_mapping, "msk"),
+            event.resolve_service_name(&generic_service_mapping, &event.get_specific_identifier(), "msk"),
             "generic-service"
         );
     }

--- a/bottlecap/src/lifecycle/invocation/triggers/s3_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/s3_event.rs
@@ -86,7 +86,7 @@ impl Trigger for S3Record {
             .timestamp_nanos_opt()
             .unwrap_or((self.event_time.timestamp_millis() as f64 * MS_TO_NS) as i64);
 
-        let service_name = self.resolve_service_name(service_mapping, "s3");
+        let service_name = self.resolve_service_name(service_mapping, &bucket_name, "s3");
 
         span.name = String::from("aws.s3");
         span.service = service_name.to_string();
@@ -286,14 +286,14 @@ mod tests {
         ]);
 
         assert_eq!(
-            event.resolve_service_name(&specific_service_mapping, "s3"),
+            event.resolve_service_name(&specific_service_mapping, &event.get_specific_identifier(), "s3"),
             "specific-service"
         );
 
         let generic_service_mapping =
             HashMap::from([("lambda_s3".to_string(), "generic-service".to_string())]);
         assert_eq!(
-            event.resolve_service_name(&generic_service_mapping, "s3"),
+            event.resolve_service_name(&generic_service_mapping, &event.get_specific_identifier(), "s3"),
             "generic-service"
         );
     }

--- a/bottlecap/src/lifecycle/invocation/triggers/sns_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/sns_event.rs
@@ -93,7 +93,7 @@ impl Trigger for SnsRecord {
             .timestamp_nanos_opt()
             .unwrap_or((self.sns.timestamp.timestamp_millis() as f64 * MS_TO_NS) as i64);
 
-        let service_name = self.resolve_service_name(service_mapping, &resource_name, "sns");
+        let service_name = self.resolve_service_name(service_mapping, &self.get_specific_identifier(), "sns");
 
         span.name = "aws.sns".to_string();
         span.service = service_name.to_string();

--- a/bottlecap/src/lifecycle/invocation/triggers/sns_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/sns_event.rs
@@ -93,7 +93,7 @@ impl Trigger for SnsRecord {
             .timestamp_nanos_opt()
             .unwrap_or((self.sns.timestamp.timestamp_millis() as f64 * MS_TO_NS) as i64);
 
-        let service_name = self.resolve_service_name(service_mapping, "sns");
+        let service_name = self.resolve_service_name(service_mapping, &resource_name, "sns");
 
         span.name = "aws.sns".to_string();
         span.service = service_name.to_string();
@@ -369,14 +369,14 @@ mod tests {
         ]);
 
         assert_eq!(
-            event.resolve_service_name(&specific_service_mapping, "sns"),
+            event.resolve_service_name(&specific_service_mapping, &event.get_specific_identifier(), "sns"),
             "specific-service"
         );
 
         let generic_service_mapping =
             HashMap::from([("lambda_sns".to_string(), "generic-service".to_string())]);
         assert_eq!(
-            event.resolve_service_name(&generic_service_mapping, "sns"),
+            event.resolve_service_name(&generic_service_mapping, &event.get_specific_identifier(), "sns"),
             "generic-service"
         );
     }

--- a/bottlecap/src/lifecycle/invocation/triggers/sqs_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/sqs_event.rs
@@ -110,7 +110,7 @@ impl Trigger for SqsRecord {
             .unwrap_or_default() as f64
             * MS_TO_NS) as i64;
 
-        let service_name = self.resolve_service_name(service_mapping, &resource, "sqs");
+        let service_name = self.resolve_service_name(service_mapping, &self.get_specific_identifier(), "sqs");
 
         span.name = "aws.sqs".to_string();
         span.service = service_name.to_string();

--- a/bottlecap/src/lifecycle/invocation/triggers/sqs_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/sqs_event.rs
@@ -110,7 +110,7 @@ impl Trigger for SqsRecord {
             .unwrap_or_default() as f64
             * MS_TO_NS) as i64;
 
-        let service_name = self.resolve_service_name(service_mapping, "sqs");
+        let service_name = self.resolve_service_name(service_mapping, &resource, "sqs");
 
         span.name = "aws.sqs".to_string();
         span.service = service_name.to_string();
@@ -506,14 +506,14 @@ mod tests {
         ]);
 
         assert_eq!(
-            event.resolve_service_name(&specific_service_mapping, "sqs"),
+            event.resolve_service_name(&specific_service_mapping, &event.get_specific_identifier(), "sqs"),
             "specific-service"
         );
 
         let generic_service_mapping =
             HashMap::from([("lambda_sqs".to_string(), "generic-service".to_string())]);
         assert_eq!(
-            event.resolve_service_name(&generic_service_mapping, "sqs"),
+            event.resolve_service_name(&generic_service_mapping, &event.get_specific_identifier(), "sqs"),
             "generic-service"
         );
     }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-python/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
<!--- A brief description of the change being made with this pull request. --->

Rollout of span naming changes to align serverless product with tracer to create streamlined Service Representation for Serverless

Key Changes:

- Change service name to match instance name for all managed services (aws.lambda -> lambda name, etc) (breaking)

- Add `span.kind:server` on synthetic spans made via span-inferrer

### Motivation

<!--- What inspired you to submit this pull request? --->

Improve Service Map for Serverless. This allows for synthetic spans to have their own service on the map which connects with the inferred spans from the tracer side.