### PR TITLE
chore(cargo): use `dd-rust-license-tool` instead of `bundle-licenses`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,4 @@
 [alias]
-license = "bundle-licenses --format yaml --output LICENSE-3rdparty.yml"
+license = "dd-rust-license-tool check"
 format = "fmt --all && clippy --workspace --all-features --fix"
 


### PR DESCRIPTION
Self descriptive