### PR TITLE
chore: upgrade to edition 2024 and fix all linter warnings

### DIFF
--- a/.github/workflows/rs_ci.yml
+++ b/.github/workflows/rs_ci.yml
@@ -79,9 +79,9 @@ jobs:
       - uses: mozilla-actions/sccache-action@v0.0.9
       # We need to do these separately because the fips feature is incompatible with the default feature.
       - working-directory: bottlecap
-        run: cargo clippy --workspace --features default
+        run: cargo clippy --workspace --all-targets --features default
       - working-directory: bottlecap
-        run: cargo clippy --workspace --no-default-features --features fips
+        run: cargo clippy --workspace --all-targets --no-default-features --features fips
 
   build-all:
     name: Build All

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bottlecap"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]
@@ -16,7 +16,7 @@ hyper-util = { version = "0.1.10", features = [
     "client-legacy",
 ] }
 http-body = "0.1"
-http-body-util = "0.1" 
+http-body-util = "0.1"
 lazy_static = { version = "1.5", default-features = false }
 log = { version = "0.4", default-features = false }
 nix = { version = "0.26", default-features = false, features = ["feature", "fs"] }

--- a/bottlecap/build.rs
+++ b/bottlecap/build.rs
@@ -84,7 +84,10 @@ fn check_forbidden_dependency(dependency_name: &str) -> Result<(), String> {
 
         Err(error_msg)
     } else {
-        println!("cargo:warning=No {} dependency found. FIPS compliance check passed for this dependency!", dependency_name);
+        println!(
+            "cargo:warning=No {} dependency found. FIPS compliance check passed for this dependency!",
+            dependency_name
+        );
         Ok(())
     }
 }

--- a/bottlecap/src/config/additional_endpoints.rs
+++ b/bottlecap/src/config/additional_endpoints.rs
@@ -26,7 +26,10 @@ where
                         result.insert(key, urls);
                     }
                     _ => {
-                        error!("Failed to deserialize additional endpoints - Invalid YAML format: expected array for key {}", key);
+                        error!(
+                            "Failed to deserialize additional endpoints - Invalid YAML format: expected array for key {}",
+                            key
+                        );
                     }
                 }
             }
@@ -58,7 +61,8 @@ mod tests {
             "https://app.datadoghq.eu": ["key3"]
         });
 
-        let result = deserialize_additional_endpoints(input).unwrap();
+        let result = deserialize_additional_endpoints(input)
+            .expect("Failed to deserialize additional endpoints");
 
         let mut expected = HashMap::new();
         expected.insert(
@@ -76,9 +80,12 @@ mod tests {
     #[test]
     fn test_deserialize_additional_endpoints_json() {
         // Test JSON string format
-        let input = json!("{\"https://app.datadoghq.com\":[\"key1\",\"key2\"],\"https://app.datadoghq.eu\":[\"key3\"]}");
+        let input = json!(
+            "{\"https://app.datadoghq.com\":[\"key1\",\"key2\"],\"https://app.datadoghq.eu\":[\"key3\"]}"
+        );
 
-        let result = deserialize_additional_endpoints(input).unwrap();
+        let result = deserialize_additional_endpoints(input)
+            .expect("Failed to deserialize additional endpoints");
 
         let mut expected = HashMap::new();
         expected.insert(
@@ -97,22 +104,26 @@ mod tests {
     fn test_deserialize_additional_endpoints_invalid_or_empty() {
         // Test empty YAML
         let input = json!({});
-        let result = deserialize_additional_endpoints(input).unwrap();
+        let result = deserialize_additional_endpoints(input)
+            .expect("Failed to deserialize additional endpoints");
         assert!(result.is_empty());
 
         // Test empty JSON
         let input = json!("");
-        let result = deserialize_additional_endpoints(input).unwrap();
+        let result = deserialize_additional_endpoints(input)
+            .expect("Failed to deserialize additional endpoints");
         assert!(result.is_empty());
 
         let input = json!({
             "https://app.datadoghq.com": "invalid-yaml"
         });
-        let result = deserialize_additional_endpoints(input).unwrap();
+        let result = deserialize_additional_endpoints(input)
+            .expect("Failed to deserialize additional endpoints");
         assert!(result.is_empty());
 
         let input = json!("invalid-json");
-        let result = deserialize_additional_endpoints(input).unwrap();
+        let result = deserialize_additional_endpoints(input)
+            .expect("Failed to deserialize additional endpoints");
         assert!(result.is_empty());
     }
 }

--- a/bottlecap/src/config/apm_replace_rule.rs
+++ b/bottlecap/src/config/apm_replace_rule.rs
@@ -1,4 +1,4 @@
-use datadog_trace_obfuscation::replacer::{parse_rules_from_string, ReplaceRule};
+use datadog_trace_obfuscation::replacer::{ReplaceRule, parse_rules_from_string};
 use serde::de::{Deserializer, SeqAccess, Visitor};
 use serde::{Deserialize, Serialize};
 use serde_json;

--- a/bottlecap/src/config/env.rs
+++ b/bottlecap/src/config/env.rs
@@ -1,4 +1,4 @@
-use figment::{providers::Env, Figment};
+use figment::{Figment, providers::Env};
 use serde::Deserialize;
 use std::collections::HashMap;
 
@@ -6,6 +6,7 @@ use datadog_trace_obfuscation::replacer::ReplaceRule;
 
 use crate::{
     config::{
+        Config, ConfigError, ConfigSource,
         additional_endpoints::deserialize_additional_endpoints,
         apm_replace_rule::deserialize_apm_replace_rules,
         deserialize_array_from_comma_separated_string, deserialize_key_value_pairs,
@@ -13,12 +14,11 @@ use crate::{
         flush_strategy::FlushStrategy,
         log_level::LogLevel,
         logs_additional_endpoints::{
-            deserialize_logs_additional_endpoints, LogsAdditionalEndpoint,
+            LogsAdditionalEndpoint, deserialize_logs_additional_endpoints,
         },
-        processing_rule::{deserialize_processing_rules, ProcessingRule},
+        processing_rule::{ProcessingRule, deserialize_processing_rules},
         service_mapping::deserialize_service_mapping,
-        trace_propagation_style::{deserialize_trace_propagation_style, TracePropagationStyle},
-        Config, ConfigError, ConfigSource,
+        trace_propagation_style::{TracePropagationStyle, deserialize_trace_propagation_style},
     },
     merge_hashmap, merge_option, merge_option_to_value, merge_string, merge_vec,
 };
@@ -484,14 +484,15 @@ impl ConfigSource for EnvConfigSource {
 mod tests {
     use super::*;
     use crate::config::{
+        Config,
         flush_strategy::{FlushStrategy, PeriodicStrategy},
         log_level::LogLevel,
         processing_rule::{Kind, ProcessingRule},
         trace_propagation_style::TracePropagationStyle,
-        Config,
     };
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn test_merge_config_overrides_with_environment_variables() {
         figment::Jail::expect_with(|jail| {
             jail.clear_env();

--- a/bottlecap/src/config/logs_additional_endpoints.rs
+++ b/bottlecap/src/config/logs_additional_endpoints.rs
@@ -40,16 +40,18 @@ mod tests {
 
     #[test]
     fn test_deserialize_logs_additional_endpoints_valid() {
-        let input = json!("[{\"api_key\": \"apiKey2\", \"Host\": \"agent-http-intake.logs.datadoghq.com\", \"Port\": 443, \"is_reliable\": true}]");
+        let input = json!(
+            "[{\"api_key\": \"apiKey2\", \"Host\": \"agent-http-intake.logs.datadoghq.com\", \"Port\": 443, \"is_reliable\": true}]"
+        );
 
-        let result = deserialize_logs_additional_endpoints(input).unwrap();
-        let mut expected = Vec::new();
-        expected.push(LogsAdditionalEndpoint {
+        let result = deserialize_logs_additional_endpoints(input)
+            .expect("Failed to deserialize logs additional endpoints");
+        let expected = vec![LogsAdditionalEndpoint {
             api_key: "apiKey2".to_string(),
             host: "agent-http-intake.logs.datadoghq.com".to_string(),
             port: 443,
             is_reliable: true,
-        });
+        }];
 
         assert_eq!(result, expected);
     }
@@ -57,9 +59,12 @@ mod tests {
     #[test]
     fn test_deserialize_logs_additional_endpoints_invalid() {
         // input missing "Port" field
-        let input = json!("[{\"api_key\": \"apiKey2\", \"Host\": \"agent-http-intake.logs.datadoghq.com\", \"is_reliable\": true}]");
+        let input = json!(
+            "[{\"api_key\": \"apiKey2\", \"Host\": \"agent-http-intake.logs.datadoghq.com\", \"is_reliable\": true}]"
+        );
 
-        let result = deserialize_logs_additional_endpoints(input).unwrap();
+        let result = deserialize_logs_additional_endpoints(input)
+            .expect("Failed to deserialize logs additional endpoints");
         let expected = Vec::new(); // expect empty list due to invalid input
 
         assert_eq!(result, expected);

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -27,7 +27,7 @@ use crate::config::{
     flush_strategy::FlushStrategy,
     log_level::LogLevel,
     logs_additional_endpoints::LogsAdditionalEndpoint,
-    processing_rule::{deserialize_processing_rules, ProcessingRule},
+    processing_rule::{ProcessingRule, deserialize_processing_rules},
     trace_propagation_style::TracePropagationStyle,
     yaml::YamlConfigSource,
 };
@@ -1186,10 +1186,10 @@ pub mod tests {
             jail.set_env("DD_LOGS_CONFIG_USE_COMPRESSION", "TRUE");
             jail.set_env("DD_CAPTURE_LAMBDA_PAYLOAD", "0");
             let config = get_config(Path::new("")).expect("should parse config");
-            assert_eq!(config.serverless_logs_enabled, true);
-            assert_eq!(config.enhanced_metrics, true);
-            assert_eq!(config.logs_config_use_compression, true);
-            assert_eq!(config.capture_lambda_payload, false);
+            assert!(config.serverless_logs_enabled);
+            assert!(config.enhanced_metrics);
+            assert!(config.logs_config_use_compression);
+            assert!(!config.capture_lambda_payload);
             Ok(())
         });
     }

--- a/bottlecap/src/config/yaml.rs
+++ b/bottlecap/src/config/yaml.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, path::PathBuf};
 
 use crate::{
     config::{
+        Config, ConfigError, ConfigSource, ProcessingRule,
         additional_endpoints::deserialize_additional_endpoints,
         deserialize_apm_replace_rules, deserialize_key_value_pair_array_to_hashmap,
         deserialize_optional_bool_from_anything, deserialize_processing_rules,
@@ -10,15 +11,14 @@ use crate::{
         log_level::LogLevel,
         logs_additional_endpoints::LogsAdditionalEndpoint,
         service_mapping::deserialize_service_mapping,
-        trace_propagation_style::{deserialize_trace_propagation_style, TracePropagationStyle},
-        Config, ConfigError, ConfigSource, ProcessingRule,
+        trace_propagation_style::{TracePropagationStyle, deserialize_trace_propagation_style},
     },
     merge_hashmap, merge_option, merge_option_to_value, merge_string, merge_vec,
 };
 use datadog_trace_obfuscation::replacer::ReplaceRule;
 use figment::{
-    providers::{Format, Yaml},
     Figment,
+    providers::{Format, Yaml},
 };
 use serde::Deserialize;
 
@@ -634,6 +634,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn test_merge_config_overrides_with_yaml_file() {
         figment::Jail::expect_with(|jail| {
             jail.clear_env();
@@ -778,7 +779,7 @@ extension_version: "compatibility"
                 proxy_no_proxy: vec!["localhost".to_string(), "127.0.0.1".to_string()],
                 http_protocol: Some("http1".to_string()),
                 dd_url: "https://metrics.datadoghq.com".to_string(),
-                url: "".to_string(), // doesnt exist in yaml
+                url: String::new(), // doesnt exist in yaml
                 additional_endpoints: HashMap::from([
                     (
                         "https://app.datadoghq.com".to_string(),

--- a/bottlecap/src/fips/mod.rs
+++ b/bottlecap/src/fips/mod.rs
@@ -26,10 +26,14 @@ pub fn runtime_layer_would_enable_fips_mode(region: &str) -> bool {
 pub fn check_fips_mode_mismatch(region: &str) {
     if runtime_layer_would_enable_fips_mode(region) {
         #[cfg(not(feature = "fips"))]
-        debug!("FIPS mode is disabled in this Extension layer but would be enabled in the runtime layer based on region and environment settings. Deploy the FIPS version of the Extension layer or set DD_LAMBDA_FIPS_MODE=false to ensure consistent FIPS behavior.");
+        debug!(
+            "FIPS mode is disabled in this Extension layer but would be enabled in the runtime layer based on region and environment settings. Deploy the FIPS version of the Extension layer or set DD_LAMBDA_FIPS_MODE=false to ensure consistent FIPS behavior."
+        );
     } else {
         #[cfg(feature = "fips")]
-        debug!("FIPS mode is enabled in this Extension layer but would be disabled in the runtime layer based on region and environment settings. Set DD_LAMBDA_FIPS_MODE=true or deploy the standard (non-FIPS) version of the Extension layer to ensure consistent FIPS behavior.");
+        debug!(
+            "FIPS mode is enabled in this Extension layer but would be disabled in the runtime layer based on region and environment settings. Set DD_LAMBDA_FIPS_MODE=true or deploy the standard (non-FIPS) version of the Extension layer to ensure consistent FIPS behavior."
+        );
     }
 }
 

--- a/bottlecap/src/lifecycle/invocation/context.rs
+++ b/bottlecap/src/lifecycle/invocation/context.rs
@@ -592,9 +592,11 @@ mod tests {
         // Create a context with a cold start span
         let request_id_2 = String::from("2");
         let mut context_2 = Context::from_request_id(&request_id_2);
-        let mut cold_start_span = Span::default();
-        cold_start_span.name = "aws.lambda.cold_start".to_string();
-        cold_start_span.span_id = 12345;
+        let cold_start_span = Span {
+            name: "aws.lambda.cold_start".to_string(),
+            span_id: 12345,
+            ..Span::default()
+        };
         context_2.cold_start_span = Some(cold_start_span);
         buffer.insert(context_2);
 

--- a/bottlecap/src/lifecycle/invocation/mod.rs
+++ b/bottlecap/src/lifecycle/invocation/mod.rs
@@ -1,6 +1,6 @@
-use base64::{engine::general_purpose, DecodeError, Engine};
+use base64::{DecodeError, Engine, engine::general_purpose};
 use datadog_trace_protobuf::pb::Span;
-use rand::{rngs::OsRng, Rng, RngCore};
+use rand::{Rng, RngCore, rngs::OsRng};
 use std::collections::HashMap;
 
 use crate::tags::lambda::tags::{INIT_TYPE, SNAP_START_VALUE};
@@ -48,7 +48,7 @@ pub fn generate_span_id() -> u64 {
     }
 
     let mut rng = rand::thread_rng();
-    rng.gen()
+    rng.r#gen()
 }
 
 fn redact_value(key: &str, value: String) -> String {

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -8,7 +8,7 @@ use chrono::{DateTime, Utc};
 use datadog_trace_protobuf::pb::Span;
 use datadog_trace_utils::tracer_header_tags;
 use dogstatsd::aggregator::Aggregator as MetricsAggregator;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tokio::sync::{mpsc::Sender, watch};
 use tracing::{debug, warn};
 
@@ -20,20 +20,19 @@ use crate::{
     },
     metrics::enhanced::lambda::{EnhancedMetricData, Lambda as EnhancedMetrics},
     proc::{
-        self,
+        self, CPUData, NetworkData,
         constants::{ETC_PATH, PROC_PATH},
-        CPUData, NetworkData,
     },
     tags::{lambda::tags::resolve_runtime_from_proc, provider},
     telemetry::events::{InitType, ReportMetrics, RuntimeDoneMetrics, Status},
     traces::{
         context::SpanContext,
         propagation::{
-            text_map_propagator::{
-                DatadogHeaderPropagator, DATADOG_PARENT_ID_KEY, DATADOG_SAMPLING_PRIORITY_KEY,
-                DATADOG_SPAN_ID_KEY, DATADOG_TRACE_ID_KEY,
-            },
             DatadogCompositePropagator, Propagator,
+            text_map_propagator::{
+                DATADOG_PARENT_ID_KEY, DATADOG_SAMPLING_PRIORITY_KEY, DATADOG_SPAN_ID_KEY,
+                DATADOG_TRACE_ID_KEY, DatadogHeaderPropagator,
+            },
         },
         trace_aggregator::SendDataBuilderInfo,
         trace_processor::{self, TraceProcessor},
@@ -353,7 +352,9 @@ impl Processor {
         status: Status,
     ) -> Option<Context> {
         let Some(context) = self.context_buffer.get_mut(request_id) else {
-            debug!("Cannot process on platform runtime done, no invocation context found for request_id: {request_id}");
+            debug!(
+                "Cannot process on platform runtime done, no invocation context found for request_id: {request_id}"
+            );
             return None;
         };
         context.runtime_done_received = true;
@@ -963,7 +964,7 @@ impl Processor {
 mod tests {
     use super::*;
     use crate::LAMBDA_RUNTIME_SLUG;
-    use base64::{engine::general_purpose::STANDARD, Engine};
+    use base64::{Engine, engine::general_purpose::STANDARD};
     use dogstatsd::aggregator::Aggregator;
     use dogstatsd::metric::EMPTY_TAGS;
 
@@ -1103,10 +1104,12 @@ mod tests {
 
         let context = p.context_buffer.get(&request_id).unwrap();
 
-        assert!(!context
-            .invocation_span
-            .metrics
-            .contains_key(TAG_SAMPLING_PRIORITY));
+        assert!(
+            !context
+                .invocation_span
+                .metrics
+                .contains_key(TAG_SAMPLING_PRIORITY)
+        );
         assert_eq!(context.invocation_span.trace_id, 888);
         assert_eq!(context.invocation_span.parent_id, 999);
     }
@@ -1126,10 +1129,12 @@ mod tests {
 
         let context = p.context_buffer.get(&request_id).unwrap();
 
-        assert!(!context
-            .invocation_span
-            .metrics
-            .contains_key(TAG_SAMPLING_PRIORITY));
+        assert!(
+            !context
+                .invocation_span
+                .metrics
+                .contains_key(TAG_SAMPLING_PRIORITY)
+        );
         assert_eq!(context.invocation_span.trace_id, 111);
         assert_eq!(context.invocation_span.parent_id, 222);
     }

--- a/bottlecap/src/lifecycle/invocation/span_inferrer.rs
+++ b/bottlecap/src/lifecycle/invocation/span_inferrer.rs
@@ -12,6 +12,7 @@ use crate::{
     lifecycle::invocation::{
         generate_span_id,
         triggers::{
+            FUNCTION_TRIGGER_EVENT_SOURCE_ARN_TAG, Trigger,
             api_gateway_http_event::APIGatewayHttpEvent,
             api_gateway_rest_event::APIGatewayRestEvent,
             api_gateway_websocket_event::APIGatewayWebSocketEvent,
@@ -22,9 +23,8 @@ use crate::{
             msk_event::MSKEvent,
             s3_event::S3Record,
             sns_event::{SnsEntity, SnsRecord},
-            sqs_event::{extract_trace_context_from_aws_trace_header, SqsRecord},
+            sqs_event::{SqsRecord, extract_trace_context_from_aws_trace_header},
             step_function_event::StepFunctionEvent,
-            Trigger, FUNCTION_TRIGGER_EVENT_SOURCE_ARN_TAG,
         },
     },
 };
@@ -368,47 +368,48 @@ mod tests {
         generated_context: Option<SpanContext>,
         expected_source: &str,
     ) {
-        let mut inferrer = SpanInferrer::default();
-        inferrer.carrier = carrier;
-        inferrer.generated_span_context = generated_context;
+        let inferrer = SpanInferrer {
+            carrier,
+            generated_span_context: generated_context,
+            ..SpanInferrer::default()
+        };
 
         let propagator = DatadogHeaderPropagator;
         let context = inferrer.get_span_context(&propagator);
 
-        assert!(context.is_some(), "Should return a span context");
-        let context = context.unwrap();
+        let context = context.expect("Should return a span context");
         match expected_source {
             "inferred" => {
                 assert_eq!(
-                    context.trace_id, 123456789,
+                    context.trace_id, 123_456_789,
                     "Should have trace_id from inferred span"
                 );
                 assert_eq!(
-                    context.span_id, 987654321,
+                    context.span_id, 987_654_321,
                     "Should have span_id from inferred span"
                 );
             }
             "generated" => {
                 assert_eq!(
-                    context.trace_id, 111111111,
+                    context.trace_id, 111_111_111,
                     "Should have trace_id from generated context"
                 );
                 assert_eq!(
-                    context.span_id, 222222222,
+                    context.span_id, 222_222_222,
                     "Should have span_id from generated context"
                 );
             }
             "aws_trace_header" => {
                 assert_eq!(
-                    context.trace_id, 0x35578e774943fd9d,
+                    context.trace_id, 0x3557_8e77_4943_fd9d,
                     "Should have trace_id from AWSTraceHeader"
                 );
                 assert_eq!(
-                    context.span_id, 0x76c040bdc454a7ac,
+                    context.span_id, 0x76c0_40bd_c454_a7ac,
                     "Should have span_id from AWSTraceHeader"
                 );
             }
-            _ => panic!("Unknown expected source: {}", expected_source),
+            _ => panic!("Unknown expected source: {expected_source}"),
         }
     }
 
@@ -421,8 +422,8 @@ mod tests {
         ]);
 
         let generated_context = SpanContext {
-            trace_id: 111111111,
-            span_id: 222222222,
+            trace_id: 111_111_111,
+            span_id: 222_222_222,
             sampling: Some(Sampling {
                 priority: Some(1),
                 mechanism: None,
@@ -439,8 +440,8 @@ mod tests {
     #[test]
     fn test_get_span_context_fallback_to_generated() {
         let generated_context = SpanContext {
-            trace_id: 111111111,
-            span_id: 222222222,
+            trace_id: 111_111_111,
+            span_id: 222_222_222,
             sampling: Some(Sampling {
                 priority: Some(1),
                 mechanism: None,
@@ -481,9 +482,9 @@ mod tests {
 
         let aws_config = Arc::new(AwsConfig {
             region: "us-east-1".to_string(),
-            aws_lwa_proxy_lambda_runtime_api: Some("".to_string()),
-            runtime_api: "".to_string(),
-            function_name: "".to_string(),
+            aws_lwa_proxy_lambda_runtime_api: Some(String::new()),
+            runtime_api: String::new(),
+            function_name: String::new(),
             sandbox_init_time: Instant::now(),
             exec_wrapper: None,
         });

--- a/bottlecap/src/lifecycle/invocation/triggers/alb_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/alb_event.rs
@@ -1,5 +1,5 @@
 use super::ServiceNameResolver;
-use crate::lifecycle::invocation::triggers::{Trigger, FUNCTION_TRIGGER_EVENT_SOURCE_TAG};
+use crate::lifecycle::invocation::triggers::{FUNCTION_TRIGGER_EVENT_SOURCE_TAG, Trigger};
 use datadog_trace_protobuf::pb::Span;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -133,7 +133,7 @@ mod tests {
                 ("x-forwarded-port".to_string(), "80".to_string()),
                 ("x-forwarded-proto".to_string(), "http".to_string()),
             ]),
-            multi_value_headers: Default::default(),
+            multi_value_headers: HashMap::default(),
         };
 
         assert_eq!(result, expected);

--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_http_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_http_event.rs
@@ -2,8 +2,8 @@ use crate::config::aws::get_aws_partition_by_region;
 use crate::lifecycle::invocation::{
     processor::MS_TO_NS,
     triggers::{
-        lowercase_key, parameterize_api_resource, ServiceNameResolver, Trigger,
-        FUNCTION_TRIGGER_EVENT_SOURCE_TAG,
+        FUNCTION_TRIGGER_EVENT_SOURCE_TAG, ServiceNameResolver, Trigger, lowercase_key,
+        parameterize_api_resource,
     },
 };
 use datadog_trace_protobuf::pb::Span;
@@ -60,7 +60,7 @@ impl Trigger for APIGatewayHttpEvent {
 
         version.is_some_and(|v| v == "2.0")
             && payload.get("rawQueryString").is_some()
-            && domain_name.is_some_and(|d| d.as_str().map_or(true, |s| !s.contains("lambda-url")))
+            && domain_name.is_some_and(|d| d.as_str().is_none_or(|s| !s.contains("lambda-url")))
     }
 
     #[allow(clippy::cast_possible_truncation)]

--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_rest_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_rest_event.rs
@@ -2,8 +2,8 @@ use crate::config::aws::get_aws_partition_by_region;
 use crate::lifecycle::invocation::{
     processor::MS_TO_NS,
     triggers::{
-        lowercase_key, parameterize_api_resource, ServiceNameResolver, Trigger,
-        FUNCTION_TRIGGER_EVENT_SOURCE_TAG,
+        FUNCTION_TRIGGER_EVENT_SOURCE_TAG, ServiceNameResolver, Trigger, lowercase_key,
+        parameterize_api_resource,
     },
 };
 use datadog_trace_protobuf::pb::Span;

--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
@@ -2,7 +2,7 @@ use crate::{
     config::aws::get_aws_partition_by_region,
     lifecycle::invocation::{
         processor::MS_TO_NS,
-        triggers::{lowercase_key, Trigger, FUNCTION_TRIGGER_EVENT_SOURCE_TAG},
+        triggers::{FUNCTION_TRIGGER_EVENT_SOURCE_TAG, Trigger, lowercase_key},
     },
 };
 use datadog_trace_protobuf::pb::Span;

--- a/bottlecap/src/lifecycle/invocation/triggers/dynamodb_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/dynamodb_event.rs
@@ -1,4 +1,4 @@
-use base64::{engine::general_purpose::STANDARD, Engine};
+use base64::{Engine, engine::general_purpose::STANDARD};
 use datadog_trace_protobuf::pb::Span;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -7,9 +7,9 @@ use tracing::debug;
 
 use crate::lifecycle::invocation::{
     processor::S_TO_NS,
-    triggers::{ServiceNameResolver, Trigger, FUNCTION_TRIGGER_EVENT_SOURCE_TAG},
+    triggers::{FUNCTION_TRIGGER_EVENT_SOURCE_TAG, ServiceNameResolver, Trigger},
 };
-use crate::traces::span_pointers::{generate_span_pointer_hash, SpanPointer};
+use crate::traces::span_pointers::{SpanPointer, generate_span_pointer_hash};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct DynamoDbEvent {
@@ -92,7 +92,6 @@ impl Trigger for DynamoDbRecord {
             .get("Records")
             .and_then(Value::as_array)
             .and_then(|r| r.first())
-            .take()
         {
             first_record.get("dynamodb").is_some()
         } else {
@@ -249,7 +248,9 @@ mod tests {
             event_id: String::from("c4ca4238a0b923820dcc509a6f75849b"),
             event_name: String::from("INSERT"),
             event_version: String::from("1.1"),
-            event_source_arn: String::from("arn:aws:dynamodb:us-east-1:123456789012:table/ExampleTableWithStream/stream/2015-06-27T00:48:05.899"),
+            event_source_arn: String::from(
+                "arn:aws:dynamodb:us-east-1:123456789012:table/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
+            ),
         };
 
         assert_eq!(result, expected);
@@ -382,7 +383,9 @@ mod tests {
             event_id: String::from("abc123"),
             event_name: String::from("INSERT"),
             event_version: String::from("1.1"),
-            event_source_arn: String::from("arn:aws:dynamodb:us-east-1:123456789012:table/TestTable/stream/2015-06-27T00:48:05.899"),
+            event_source_arn: String::from(
+                "arn:aws:dynamodb:us-east-1:123456789012:table/TestTable/stream/2015-06-27T00:48:05.899",
+            ),
         };
 
         let span_pointers = event.get_span_pointers().expect("Should return Some(vec)");
@@ -410,7 +413,9 @@ mod tests {
             event_id: String::from("123abc"),
             event_name: String::from("INSERT"),
             event_version: String::from("1.1"),
-            event_source_arn: String::from("arn:aws:dynamodb:us-east-1:123456789012:table/TestTable/stream/2015-06-27T00:48:05.899"),
+            event_source_arn: String::from(
+                "arn:aws:dynamodb:us-east-1:123456789012:table/TestTable/stream/2015-06-27T00:48:05.899",
+            ),
         };
 
         let span_pointers = event.get_span_pointers().expect("Should return Some(vec)");
@@ -439,7 +444,9 @@ mod tests {
             event_id: String::from("123abc"),
             event_name: String::from("INSERT"),
             event_version: String::from("1.1"),
-            event_source_arn: String::from("arn:aws:dynamodb:us-east-1:123456789012:table/TestTable/stream/2015-06-27T00:48:05.899"),
+            event_source_arn: String::from(
+                "arn:aws:dynamodb:us-east-1:123456789012:table/TestTable/stream/2015-06-27T00:48:05.899",
+            ),
         };
 
         let span_pointers = event.get_span_pointers().expect("Should return Some(vec)");

--- a/bottlecap/src/lifecycle/invocation/triggers/event_bridge_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/event_bridge_event.rs
@@ -8,7 +8,7 @@ use tracing::debug;
 use crate::lifecycle::invocation::{
     processor::{MS_TO_NS, S_TO_NS},
     triggers::{
-        ServiceNameResolver, Trigger, DATADOG_CARRIER_KEY, FUNCTION_TRIGGER_EVENT_SOURCE_TAG,
+        DATADOG_CARRIER_KEY, FUNCTION_TRIGGER_EVENT_SOURCE_TAG, ServiceNameResolver, Trigger,
     },
 };
 

--- a/bottlecap/src/lifecycle/invocation/triggers/kinesis_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/kinesis_event.rs
@@ -1,16 +1,16 @@
 #![allow(clippy::module_name_repetitions)]
-use base64::engine::general_purpose;
 use base64::Engine;
+use base64::engine::general_purpose;
 use datadog_trace_protobuf::pb::Span;
 use serde::{Deserialize, Serialize};
-use serde_json::{from_slice, Value};
+use serde_json::{Value, from_slice};
 use std::collections::HashMap;
 use tracing::debug;
 
 use crate::lifecycle::invocation::{
     processor::S_TO_NS,
     triggers::{
-        ServiceNameResolver, Trigger, DATADOG_CARRIER_KEY, FUNCTION_TRIGGER_EVENT_SOURCE_TAG,
+        DATADOG_CARRIER_KEY, FUNCTION_TRIGGER_EVENT_SOURCE_TAG, ServiceNameResolver, Trigger,
     },
 };
 
@@ -62,7 +62,6 @@ impl Trigger for KinesisRecord {
             .get("Records")
             .and_then(Value::as_array)
             .and_then(|r| r.first())
-            .take()
         {
             first_record.get("kinesis").is_some()
         } else {

--- a/bottlecap/src/lifecycle/invocation/triggers/lambda_function_url_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/lambda_function_url_event.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use crate::lifecycle::invocation::{
     processor::MS_TO_NS,
-    triggers::{lowercase_key, ServiceNameResolver, Trigger, FUNCTION_TRIGGER_EVENT_SOURCE_TAG},
+    triggers::{FUNCTION_TRIGGER_EVENT_SOURCE_TAG, ServiceNameResolver, Trigger, lowercase_key},
 };
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -310,7 +310,7 @@ mod tests {
 
     #[test]
     fn test_get_arn() {
-        env::set_var("AWS_LAMBDA_FUNCTION_NAME", "mock-lambda");
+        unsafe { env::set_var("AWS_LAMBDA_FUNCTION_NAME", "mock-lambda") };
         let json = read_json_file("lambda_function_url_event.json");
         let payload = serde_json::from_str(&json).expect("Failed to deserialize into Value");
         let event = LambdaFunctionUrlEvent::new(payload)
@@ -319,7 +319,7 @@ mod tests {
             event.get_arn("sa-east-1"),
             "arn:aws:lambda:sa-east-1:601427279990:url:mock-lambda"
         );
-        env::remove_var("AWS_LAMBDA_FUNCTION_NAME");
+        unsafe { env::remove_var("AWS_LAMBDA_FUNCTION_NAME") };
     }
 
     #[test]

--- a/bottlecap/src/lifecycle/invocation/triggers/msk_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/msk_event.rs
@@ -1,6 +1,6 @@
 use crate::lifecycle::invocation::processor::MS_TO_NS;
 use crate::lifecycle::invocation::triggers::{
-    ServiceNameResolver, Trigger, FUNCTION_TRIGGER_EVENT_SOURCE_TAG,
+    FUNCTION_TRIGGER_EVENT_SOURCE_TAG, ServiceNameResolver, Trigger,
 };
 use datadog_trace_protobuf::pb::Span;
 use serde::{Deserialize, Serialize};
@@ -131,14 +131,16 @@ mod tests {
         let record = MSKRecord {
             topic: String::from("topic1"),
             partition: 0,
-            timestamp: 1745846213022.0,
+            timestamp: 1_745_846_213_022f64,
         };
         let mut expected_records = HashMap::new();
         expected_records.insert(String::from("topic1"), vec![record]);
 
         let expected = MSKEvent {
             event_source: String::from("aws:kafka"),
-            event_source_arn: String::from("arn:aws:kafka:us-east-1:123456789012:cluster/demo-cluster/751d2973-a626-431c-9d4e-d7975eb44dd7-2"),
+            event_source_arn: String::from(
+                "arn:aws:kafka:us-east-1:123456789012:cluster/demo-cluster/751d2973-a626-431c-9d4e-d7975eb44dd7-2",
+            ),
             records: expected_records,
         };
 
@@ -173,7 +175,7 @@ mod tests {
         assert_eq!(span.service, "msk");
         assert_eq!(span.r#type, "web");
         assert_eq!(span.resource, "topic1");
-        assert_eq!(span.start, 1745846213022000128);
+        assert_eq!(span.start, 1_745_846_213_022_000_128);
 
         assert_eq!(
             span.meta,

--- a/bottlecap/src/lifecycle/invocation/triggers/s3_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/s3_event.rs
@@ -8,9 +8,9 @@ use tracing::debug;
 
 use crate::lifecycle::invocation::{
     processor::MS_TO_NS,
-    triggers::{ServiceNameResolver, Trigger, FUNCTION_TRIGGER_EVENT_SOURCE_TAG},
+    triggers::{FUNCTION_TRIGGER_EVENT_SOURCE_TAG, ServiceNameResolver, Trigger},
 };
-use crate::traces::span_pointers::{generate_span_pointer_hash, SpanPointer};
+use crate::traces::span_pointers::{SpanPointer, generate_span_pointer_hash};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct S3Event {
@@ -69,7 +69,6 @@ impl Trigger for S3Record {
             .get("Records")
             .and_then(Value::as_array)
             .and_then(|r| r.first())
-            .take()
         {
             first_record.get("s3").is_some()
         } else {

--- a/bottlecap/src/lifecycle/invocation/triggers/sns_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/sns_event.rs
@@ -10,8 +10,8 @@ use crate::lifecycle::invocation::{
     base64_to_string,
     processor::MS_TO_NS,
     triggers::{
-        event_bridge_event::EventBridgeEvent, ServiceNameResolver, Trigger, DATADOG_CARRIER_KEY,
-        FUNCTION_TRIGGER_EVENT_SOURCE_TAG,
+        DATADOG_CARRIER_KEY, FUNCTION_TRIGGER_EVENT_SOURCE_TAG, ServiceNameResolver, Trigger,
+        event_bridge_event::EventBridgeEvent,
     },
 };
 
@@ -74,7 +74,6 @@ impl Trigger for SnsRecord {
             .get("Records")
             .and_then(Value::as_array)
             .and_then(|r| r.first())
-            .take()
         {
             return first_record.get("Sns").is_some();
         }

--- a/bottlecap/src/lifecycle/invocation/triggers/sqs_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/sqs_event.rs
@@ -2,9 +2,9 @@ use crate::config::aws::get_aws_partition_by_region;
 use crate::lifecycle::invocation::{
     processor::MS_TO_NS,
     triggers::{
+        DATADOG_CARRIER_KEY, FUNCTION_TRIGGER_EVENT_SOURCE_TAG, ServiceNameResolver, Trigger,
         event_bridge_event::EventBridgeEvent,
         sns_event::{SnsEntity, SnsRecord},
-        ServiceNameResolver, Trigger, DATADOG_CARRIER_KEY, FUNCTION_TRIGGER_EVENT_SOURCE_TAG,
     },
 };
 use crate::traces::context::{Sampling, SpanContext};
@@ -88,7 +88,6 @@ impl Trigger for SqsRecord {
             .get("Records")
             .and_then(Value::as_array)
             .and_then(|r| r.first())
-            .take()
         {
             first_record
                 .get("eventSource")

--- a/bottlecap/src/lifecycle/invocation/triggers/step_function_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/step_function_event.rs
@@ -6,12 +6,12 @@ use sha2::{Digest, Sha256};
 
 use crate::{
     lifecycle::invocation::triggers::{
-        ServiceNameResolver, Trigger, FUNCTION_TRIGGER_EVENT_SOURCE_TAG,
+        FUNCTION_TRIGGER_EVENT_SOURCE_TAG, ServiceNameResolver, Trigger,
     },
     traces::{
         context::{Sampling, SpanContext},
         propagation::text_map_propagator::{
-            DatadogHeaderPropagator, DATADOG_HIGHER_ORDER_TRACE_ID_BITS_KEY, DATADOG_TAGS_KEY,
+            DATADOG_HIGHER_ORDER_TRACE_ID_BITS_KEY, DATADOG_TAGS_KEY, DatadogHeaderPropagator,
         },
     },
 };
@@ -239,11 +239,7 @@ impl StepFunctionEvent {
         result &= !(1u64 << 63);
 
         // Return 1 if result is 0
-        if result == 0 {
-            1
-        } else {
-            result
-        }
+        if result == 0 { 1 } else { result }
     }
 }
 
@@ -272,7 +268,9 @@ mod tests {
 
         let expected = StepFunctionEvent {
             execution: Execution {
-                id: String::from("arn:aws:states:us-east-1:425362996713:execution:agocsTestSF:bc9f281c-3daa-4e5a-9a60-471a3810bf44"),
+                id: String::from(
+                    "arn:aws:states:us-east-1:425362996713:execution:agocsTestSF:bc9f281c-3daa-4e5a-9a60-471a3810bf44",
+                ),
                 redrive_count: 0,
             },
             state: State {
@@ -307,7 +305,9 @@ mod tests {
 
         let expected = StepFunctionEvent {
             execution: Execution {
-                id: String::from("arn:aws:states:us-east-1:425362996713:execution:agocsTestSF:aa6c9316-713a-41d4-9c30-61131716744f"),
+                id: String::from(
+                    "arn:aws:states:us-east-1:425362996713:execution:agocsTestSF:aa6c9316-713a-41d4-9c30-61131716744f",
+                ),
                 redrive_count: 0,
             },
             state: State {
@@ -320,7 +320,9 @@ mod tests {
             }),
             trace_id: None,
             trace_tags: None,
-            root_execution_id: Some(String::from("arn:aws:states:sa-east-1:425362996713:execution:invokeJavaLambda:4875aba4-ae31-4a4c-bf8a-63e9eee31dad")),
+            root_execution_id: Some(String::from(
+                "arn:aws:states:sa-east-1:425362996713:execution:invokeJavaLambda:4875aba4-ae31-4a4c-bf8a-63e9eee31dad",
+            )),
             serverless_version: Some(String::from("v1")),
         };
 
@@ -342,7 +344,9 @@ mod tests {
 
         let expected = StepFunctionEvent {
             execution: Execution {
-                id: String::from("arn:aws:states:us-east-1:425362996713:execution:agocsTestSF:aa6c9316-713a-41d4-9c30-61131716744f"),
+                id: String::from(
+                    "arn:aws:states:us-east-1:425362996713:execution:agocsTestSF:aa6c9316-713a-41d4-9c30-61131716744f",
+                ),
                 redrive_count: 0,
             },
             state: State {
@@ -587,7 +591,9 @@ mod tests {
     #[test]
     fn test_generate_parent_id() {
         let parent_id = StepFunctionEvent::generate_parent_id(
-            String::from("arn:aws:states:sa-east-1:601427271234:express:DatadogStateMachine:acaf1a67-336a-e854-1599-2a627eb2dd8a:c8baf081-31f1-464d-971f-70cb17d01111"),
+            String::from(
+                "arn:aws:states:sa-east-1:601427271234:express:DatadogStateMachine:acaf1a67-336a-e854-1599-2a627eb2dd8a:c8baf081-31f1-464d-971f-70cb17d01111",
+            ),
             String::from("step-one"),
             String::from("2022-12-08T21:08:19.224Z"),
             0,
@@ -597,7 +603,9 @@ mod tests {
         assert_eq!(parent_id, 4_340_734_536_022_949_921);
 
         let parent_id = StepFunctionEvent::generate_parent_id(
-            String::from("arn:aws:states:sa-east-1:601427271234:express:DatadogStateMachine:acaf1a67-336a-e854-1599-2a627eb2dd8a:c8baf081-31f1-464d-971f-70cb17d01111"),
+            String::from(
+                "arn:aws:states:sa-east-1:601427271234:express:DatadogStateMachine:acaf1a67-336a-e854-1599-2a627eb2dd8a:c8baf081-31f1-464d-971f-70cb17d01111",
+            ),
             String::from("step-one"),
             String::from("2022-12-08T21:08:19.224Y"),
             0,
@@ -619,9 +627,9 @@ mod tests {
 
         assert_eq!(hex_tid, "60ee1db79e4803f8");
 
-        let (lo_tid, hi_tid) = StepFunctionEvent::generate_trace_id(
-            String::from("arn:aws:states:us-east-1:425362996713:execution:agocsTestSF:bc9f281c-3daa-4e5a-9a60-471a3810bf44")
-        );
+        let (lo_tid, hi_tid) = StepFunctionEvent::generate_trace_id(String::from(
+            "arn:aws:states:us-east-1:425362996713:execution:agocsTestSF:bc9f281c-3daa-4e5a-9a60-471a3810bf44",
+        ));
         let hex_tid = format!("{hi_tid:x}");
 
         assert_eq!(lo_tid, 5_744_042_798_732_701_615);

--- a/bottlecap/src/lifecycle/listener.rs
+++ b/bottlecap/src/lifecycle/listener.rs
@@ -5,7 +5,7 @@ use ddcommon::hyper_migration;
 use ddcommon::hyper_migration::Body;
 use http_body_util::BodyExt;
 use hyper::service::service_fn;
-use hyper::{http, HeaderMap, Method, Response, StatusCode};
+use hyper::{HeaderMap, Method, Response, StatusCode, http};
 use serde_json::json;
 use std::collections::HashMap;
 use std::io;

--- a/bottlecap/src/logger.rs
+++ b/bottlecap/src/logger.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 use tracing_core::{Event, Subscriber};
 use tracing_subscriber::fmt::{
-    format::{self, FormatEvent, FormatFields},
     FmtContext, FormattedFields,
+    format::{self, FormatEvent, FormatFields},
 };
 use tracing_subscriber::registry::LookupSpan;
 

--- a/bottlecap/src/logs/agent.rs
+++ b/bottlecap/src/logs/agent.rs
@@ -5,7 +5,7 @@ use crate::events::Event;
 use crate::logs::{aggregator::Aggregator, processor::LogsProcessor};
 use crate::tags;
 use crate::telemetry::events::TelemetryEvent;
-use crate::{config, LAMBDA_RUNTIME_SLUG};
+use crate::{LAMBDA_RUNTIME_SLUG, config};
 
 #[allow(clippy::module_name_repetitions)]
 pub struct LogsAgent {

--- a/bottlecap/src/logs/flusher.rs
+++ b/bottlecap/src/logs/flusher.rs
@@ -1,7 +1,7 @@
+use crate::FLUSH_RETRY_COUNT;
 use crate::config;
 use crate::http::get_client;
 use crate::logs::aggregator::Aggregator;
-use crate::FLUSH_RETRY_COUNT;
 use dogstatsd::api_key::ApiKeyFactory;
 use futures::future::join_all;
 use reqwest::header::HeaderMap;

--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -4,6 +4,7 @@ use tokio::sync::mpsc::Sender;
 
 use tracing::error;
 
+use crate::LAMBDA_RUNTIME_SLUG;
 use crate::config;
 use crate::events::Event;
 use crate::lifecycle::invocation::context::Context as InvocationContext;
@@ -11,7 +12,6 @@ use crate::logs::aggregator::Aggregator;
 use crate::logs::processor::{Processor, Rule};
 use crate::tags::provider;
 use crate::telemetry::events::{Status, TelemetryEvent, TelemetryRecord};
-use crate::LAMBDA_RUNTIME_SLUG;
 
 use crate::logs::lambda::{IntakeLog, Message};
 
@@ -590,10 +590,12 @@ mod tests {
 
         let result = processor.get_message(event).await;
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Unable to parse log"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Unable to parse log")
+        );
     }
 
     // get_intake_log

--- a/bottlecap/src/logs/processor.rs
+++ b/bottlecap/src/logs/processor.rs
@@ -7,7 +7,7 @@ use crate::config::processing_rule;
 use crate::events::Event;
 use crate::tags;
 use crate::telemetry::events::TelemetryEvent;
-use crate::{config, LAMBDA_RUNTIME_SLUG};
+use crate::{LAMBDA_RUNTIME_SLUG, config};
 
 use crate::logs::aggregator::Aggregator;
 use crate::logs::lambda::processor::LambdaProcessor;

--- a/bottlecap/src/lwa/mod.rs
+++ b/bottlecap/src/lwa/mod.rs
@@ -21,7 +21,7 @@
 use axum::http::{self, HeaderName, HeaderValue};
 use bytes::Bytes;
 use hyper::{HeaderMap, Uri};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 use tokio::sync::Mutex;
 use tracing::{debug, error};
@@ -40,7 +40,9 @@ pub fn get_lwa_proxy_socket_address(
     let port = uri.port_u16().ok_or("LWA: Missing port in URI")?;
 
     if host == "localhost" {
-        error!("LWA | Cannot use localhost as host in AWS_LWA_LAMBDA_RUNTIME_API_PROXY, use 127.0.0.1 instead");
+        error!(
+            "LWA | Cannot use localhost as host in AWS_LWA_LAMBDA_RUNTIME_API_PROXY, use 127.0.0.1 instead"
+        );
         return Err("Cannot use localhost as host, use 127.0.0.1 instead".into());
     }
 

--- a/bottlecap/src/metrics/enhanced/lambda.rs
+++ b/bottlecap/src/metrics/enhanced/lambda.rs
@@ -894,100 +894,130 @@ mod tests {
             now,
         );
         let aggr = metrics_aggr.lock().expect("lock poisoned");
-        assert!(aggr
-            .get_entry_by_id(constants::INVOCATIONS_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::ERRORS_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::TIMEOUTS_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::INIT_DURATION_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::RUNTIME_DURATION_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::PRODUCED_BYTES_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::POST_RUNTIME_DURATION_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::DURATION_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::BILLED_DURATION_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::MAX_MEMORY_USED_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::MEMORY_SIZE_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::ESTIMATED_COST_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::RX_BYTES_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::TX_BYTES_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::TOTAL_NETWORK_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::CPU_USER_TIME_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::CPU_SYSTEM_TIME_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::CPU_TOTAL_TIME_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(
+        assert!(
+            aggr.get_entry_by_id(constants::INVOCATIONS_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::ERRORS_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::TIMEOUTS_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::INIT_DURATION_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::RUNTIME_DURATION_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::PRODUCED_BYTES_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::POST_RUNTIME_DURATION_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::DURATION_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::BILLED_DURATION_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::MAX_MEMORY_USED_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::MEMORY_SIZE_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::ESTIMATED_COST_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::RX_BYTES_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::TX_BYTES_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::TOTAL_NETWORK_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::CPU_USER_TIME_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::CPU_SYSTEM_TIME_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::CPU_TOTAL_TIME_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(
                 constants::CPU_TOTAL_UTILIZATION_PCT_METRIC.into(),
                 &None,
                 now
             )
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::CPU_TOTAL_UTILIZATION_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::NUM_CORES_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::CPU_MIN_UTILIZATION_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::CPU_MAX_UTILIZATION_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::TMP_MAX_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::TMP_USED_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::TMP_FREE_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::FD_MAX_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::FD_USE_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::THREADS_MAX_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::THREADS_USE_METRIC.into(), &None, now)
-            .is_none());
+            .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::CPU_TOTAL_UTILIZATION_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::NUM_CORES_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::CPU_MIN_UTILIZATION_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::CPU_MAX_UTILIZATION_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::TMP_MAX_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::TMP_USED_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::TMP_FREE_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::FD_MAX_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::FD_USE_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::THREADS_MAX_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::THREADS_USE_METRIC.into(), &None, now)
+                .is_none()
+        );
     }
 
     #[test]
@@ -1272,11 +1302,13 @@ mod tests {
         assert_sketch(&metrics_aggr, constants::THREADS_MAX_METRIC, 1024.0, now);
 
         let aggr = lambda.aggregator.lock().expect("lock poisoned");
-        assert!(aggr
-            .get_entry_by_id(constants::FD_USE_METRIC.into(), &None, now)
-            .is_none());
-        assert!(aggr
-            .get_entry_by_id(constants::THREADS_USE_METRIC.into(), &None, now)
-            .is_none());
+        assert!(
+            aggr.get_entry_by_id(constants::FD_USE_METRIC.into(), &None, now)
+                .is_none()
+        );
+        assert!(
+            aggr.get_entry_by_id(constants::THREADS_USE_METRIC.into(), &None, now)
+                .is_none()
+        );
     }
 }

--- a/bottlecap/src/otlp/agent.rs
+++ b/bottlecap/src/otlp/agent.rs
@@ -1,9 +1,9 @@
 use axum::{
+    Router,
     extract::{Request, State},
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::post,
-    Router,
 };
 use datadog_trace_utils::trace_utils::TracerHeaderTags as DatadogTracerHeaderTags;
 use serde_json::json;
@@ -241,7 +241,7 @@ mod tests {
     #[test]
     fn test_parse_port_with_empty_endpoint() {
         // Test with an empty endpoint
-        let endpoint = Some("".to_string());
+        let endpoint = Some(String::new());
         assert_eq!(
             Agent::parse_port(endpoint.as_ref(), OTLP_AGENT_HTTP_PORT),
             OTLP_AGENT_HTTP_PORT

--- a/bottlecap/src/otlp/mod.rs
+++ b/bottlecap/src/otlp/mod.rs
@@ -40,7 +40,7 @@ mod tests {
             let config = get_config(Path::new("")).expect("should parse config");
 
             // Since the default for traces is `true`, we don't need to set it.
-            assert_eq!(should_enable_otlp_agent(&Arc::new(config)), true);
+            assert!(should_enable_otlp_agent(&Arc::new(config)));
 
             Ok(())
         });
@@ -58,7 +58,7 @@ mod tests {
             let config = get_config(Path::new("")).expect("should parse config");
 
             // Since the default for traces is `true`, we don't need to set it.
-            assert_eq!(should_enable_otlp_agent(&Arc::new(config)), true);
+            assert!(should_enable_otlp_agent(&Arc::new(config)));
 
             Ok(())
         });
@@ -76,7 +76,7 @@ mod tests {
 
             let config = get_config(Path::new("")).expect("should parse config");
 
-            assert_eq!(should_enable_otlp_agent(&Arc::new(config)), false);
+            assert!(!should_enable_otlp_agent(&Arc::new(config)));
 
             Ok(())
         });

--- a/bottlecap/src/otlp/transform.rs
+++ b/bottlecap/src/otlp/transform.rs
@@ -3,14 +3,14 @@ use datadog_trace_protobuf::pb::Span as DatadogSpan;
 use hex;
 use lazy_static::lazy_static;
 use opentelemetry_proto::tonic::common::v1::{
-    any_value, AnyValue, InstrumentationScope as OtelInstrumentationScope, KeyValue,
+    AnyValue, InstrumentationScope as OtelInstrumentationScope, KeyValue, any_value,
 };
 use opentelemetry_proto::tonic::resource::v1::Resource as OtelResource;
 use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
 use opentelemetry_proto::tonic::trace::v1::{
+    Span as OtelSpan,
     span::{Event, Link, SpanKind},
     status::StatusCode,
-    Span as OtelSpan,
 };
 use opentelemetry_semantic_conventions::attribute::{
     DB_QUERY_TEXT, DB_STATEMENT, DB_SYSTEM_NAME, DEPLOYMENT_ENVIRONMENT,
@@ -1164,6 +1164,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::approx_constant)]
     fn test_otel_value_to_string_double_value() {
         let value = Value::DoubleValue(3.14);
         assert_eq!(otel_value_to_string(&value), "3.14");
@@ -1229,8 +1230,8 @@ mod tests {
         // Note: The order of keys in a JSON object is not guaranteed
         assert!(result.contains("\"key1\":\"value1\""));
         assert!(result.contains("\"key2\":\"42\""));
-        assert!(result.starts_with("{"));
-        assert!(result.ends_with("}"));
+        assert!(result.starts_with('{'));
+        assert!(result.ends_with('}'));
     }
 
     #[test]

--- a/bottlecap/src/proc/clock.rs
+++ b/bottlecap/src/proc/clock.rs
@@ -1,4 +1,4 @@
-use nix::unistd::{sysconf, SysconfVar};
+use nix::unistd::{SysconfVar, sysconf};
 use std::io;
 
 #[allow(clippy::cast_sign_loss)]

--- a/bottlecap/src/proc/mod.rs
+++ b/bottlecap/src/proc/mod.rs
@@ -76,13 +76,13 @@ fn get_network_data_from_path(path: &str) -> Result<NetworkData, io::Error> {
                     return Ok(NetworkData {
                         rx_bytes: rx_val,
                         tx_bytes: tx_val,
-                    })
+                    });
                 }
                 (_, _) => {
                     return Err(io::Error::new(
                         io::ErrorKind::NotFound,
                         "Network data not found",
-                    ))
+                    ));
                 }
             }
         }
@@ -144,7 +144,7 @@ fn get_cpu_data_from_path(path: &str) -> Result<CPUData, io::Error> {
                         return Err(io::Error::new(
                             io::ErrorKind::InvalidData,
                             "Failed to parse CPU data",
-                        ))
+                        ));
                     }
                 }
             } else if label.starts_with("cpu") {
@@ -163,7 +163,7 @@ fn get_cpu_data_from_path(path: &str) -> Result<CPUData, io::Error> {
                         return Err(io::Error::new(
                             io::ErrorKind::InvalidData,
                             "Failed to parse per-core CPU data",
-                        ))
+                        ));
                     }
                 }
             }
@@ -259,8 +259,7 @@ fn get_fd_use_data_from_path(path: &str, pids: &[i64]) -> f64 {
         let Ok(files) = fs::read_dir(&fd_path) else {
             trace!(
                 "File descriptor use data not found in path {} with pid {}",
-                fd_path,
-                pid
+                fd_path, pid
             );
             continue;
         };

--- a/bottlecap/src/proxy/mod.rs
+++ b/bottlecap/src/proxy/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::config::{aws::AwsConfig, Config};
+use crate::config::{Config, aws::AwsConfig};
 
 pub mod interceptor;
 
@@ -37,8 +37,8 @@ mod tests {
         let aws_config = Arc::new(AwsConfig {
             region: "us-east-1".to_string(),
             aws_lwa_proxy_lambda_runtime_api: Some("127.0.0.1:12345".to_string()),
-            function_name: "".to_string(),
-            runtime_api: "".to_string(),
+            function_name: String::new(),
+            runtime_api: String::new(),
             sandbox_init_time: Instant::now(),
             exec_wrapper: Some("/opt/datadog_wrapper".to_string()),
         });
@@ -51,8 +51,8 @@ mod tests {
             region: "us-east-1".to_string(),
             // LWA proxy is set, so we should start the proxy
             aws_lwa_proxy_lambda_runtime_api: Some("127.0.0.1:12345".to_string()),
-            function_name: "".to_string(),
-            runtime_api: "".to_string(),
+            function_name: String::new(),
+            runtime_api: String::new(),
             sandbox_init_time: Instant::now(),
             exec_wrapper: None,
         });
@@ -69,8 +69,8 @@ mod tests {
         let aws_config = Arc::new(AwsConfig {
             region: "us-east-1".to_string(),
             aws_lwa_proxy_lambda_runtime_api: None,
-            function_name: "".to_string(),
-            runtime_api: "".to_string(),
+            function_name: String::new(),
+            runtime_api: String::new(),
             sandbox_init_time: Instant::now(),
             exec_wrapper: Some("/opt/datadog_wrapper".to_string()),
         });
@@ -87,8 +87,8 @@ mod tests {
         let aws_config = Arc::new(AwsConfig {
             region: "us-east-1".to_string(),
             aws_lwa_proxy_lambda_runtime_api: None,
-            function_name: "".to_string(),
-            runtime_api: "".to_string(),
+            function_name: String::new(),
+            runtime_api: String::new(),
             sandbox_init_time: Instant::now(),
             exec_wrapper: Some("/opt/datadog_wrapper".to_string()),
         });
@@ -105,8 +105,8 @@ mod tests {
         let aws_config = Arc::new(AwsConfig {
             region: "us-east-1".to_string(),
             aws_lwa_proxy_lambda_runtime_api: None,
-            function_name: "".to_string(),
-            runtime_api: "".to_string(),
+            function_name: String::new(),
+            runtime_api: String::new(),
             sandbox_init_time: Instant::now(),
             // Datadog wrapper is not set, so we should not start the proxy
             exec_wrapper: Some("/opt/not_datadog".to_string()),

--- a/bottlecap/src/secrets/decrypt.rs
+++ b/bottlecap/src/secrets/decrypt.rs
@@ -1,14 +1,14 @@
 use crate::config::{
-    aws::{AwsConfig, AwsCredentials},
     Config,
+    aws::{AwsConfig, AwsCredentials},
 };
 use crate::fips::compute_aws_api_host;
 use base64::prelude::*;
 use chrono::{DateTime, Utc};
 use datadog_fips::reqwest_adapter::create_reqwest_client_builder;
 use hmac::{Hmac, Mac};
-use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::Client;
+use reqwest::header::{HeaderMap, HeaderValue};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::io::Error;
@@ -281,7 +281,8 @@ fn build_get_secret_signed_headers(
     let canonical_querystring = "";
     let canonical_headers = format!(
         "content-type:application/x-amz-json-1.1\nhost:{}\nx-amz-date:{}\nx-amz-security-token:{}\nx-amz-target:{}",
-        host, amz_date, aws_credentials.aws_session_token, header_values.x_amz_target);
+        host, amz_date, aws_credentials.aws_session_token, header_values.x_amz_target
+    );
     let signed_headers = "content-type;host;x-amz-date;x-amz-security-token;x-amz-target";
 
     let payload_hash = Sha256::digest(header_values.body.to_string().as_bytes());

--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -316,11 +316,11 @@ mod tests {
             version: Some("1.0.0".to_string()),
             ..Config::default()
         });
-        std::env::set_var(MEMORY_SIZE_VAR, "128");
-        std::env::set_var(RUNTIME_VAR, "AWS_Lambda_java8");
+        unsafe { std::env::set_var(MEMORY_SIZE_VAR, "128") };
+        unsafe { std::env::set_var(RUNTIME_VAR, "AWS_Lambda_java8") };
         let tags = Lambda::new_from_config(config, &metadata);
-        std::env::remove_var(MEMORY_SIZE_VAR);
-        std::env::remove_var(RUNTIME_VAR);
+        unsafe { std::env::remove_var(MEMORY_SIZE_VAR) };
+        unsafe { std::env::remove_var(RUNTIME_VAR) };
         assert_eq!(tags.tags_map.get(ENV_KEY).unwrap(), "test");
         assert_eq!(tags.tags_map.get(VERSION_KEY).unwrap(), "1.0.0");
         assert_eq!(tags.tags_map.get(SERVICE_KEY).unwrap(), "my-service");

--- a/bottlecap/src/tags/provider.rs
+++ b/bottlecap/src/tags/provider.rs
@@ -1,5 +1,5 @@
 use crate::tags::lambda::tags::Lambda;
-use crate::{config, LAMBDA_RUNTIME_SLUG};
+use crate::{LAMBDA_RUNTIME_SLUG, config};
 use std::collections::hash_map;
 use std::sync::Arc;
 
@@ -106,8 +106,8 @@ impl GetTags for TagProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::Config;
     use crate::LAMBDA_RUNTIME_SLUG;
+    use crate::config::Config;
     use std::collections::hash_map::HashMap;
 
     #[test]

--- a/bottlecap/src/telemetry/client.rs
+++ b/bottlecap/src/telemetry/client.rs
@@ -4,7 +4,7 @@ use serde_json;
 use std::error::Error;
 use tracing::{debug, error};
 
-use crate::{base_url, EXTENSION_ID_HEADER, TELEMETRY_SUBSCRIPTION_ROUTE};
+use crate::{EXTENSION_ID_HEADER, TELEMETRY_SUBSCRIPTION_ROUTE, base_url};
 
 #[allow(clippy::module_name_repetitions)]
 pub struct TelemetryApiClient {

--- a/bottlecap/src/telemetry/listener.rs
+++ b/bottlecap/src/telemetry/listener.rs
@@ -4,11 +4,11 @@ use crate::{
 };
 
 use axum::{
+    Router,
     extract::{Request, State},
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::post,
-    Router,
 };
 use chrono::Utc;
 use std::net::SocketAddr;

--- a/bottlecap/src/traces/propagation/text_map_propagator.rs
+++ b/bottlecap/src/traces/propagation/text_map_propagator.rs
@@ -6,9 +6,9 @@ use tracing::{debug, error, warn};
 
 use crate::traces::context::{Sampling, SpanContext};
 use crate::traces::propagation::{
+    Propagator,
     carrier::{Extractor, Injector},
     error::Error,
-    Propagator,
 };
 
 // Datadog Keys
@@ -173,7 +173,9 @@ impl DatadogHeaderPropagator {
                 carrier.get(DATADOG_HIGHER_ORDER_TRACE_ID_BITS_KEY)
             {
                 if !Self::higher_order_bits_valid(trace_id_higher_order_bits) {
-                    warn!("Malformed Trace ID: {trace_id_higher_order_bits} Failed to decode trace ID from carrier.");
+                    warn!(
+                        "Malformed Trace ID: {trace_id_higher_order_bits} Failed to decode trace ID from carrier."
+                    );
                     tags.insert(
                         DATADOG_PROPAGATION_ERROR_KEY.to_string(),
                         format!("malformed tid {trace_id_higher_order_bits}"),
@@ -398,11 +400,14 @@ impl TraceContextPropagator {
                 return Err(Error::extract(
                     "`ff` is an invalid traceparent version",
                     "traceparent",
-                ))
+                ));
             }
             "00" => {
                 if !tail.is_empty() {
-                    return Err(Error::extract("Traceparent with version `00` should contain only 4 values delimited by `-`", "traceparent"));
+                    return Err(Error::extract(
+                        "Traceparent with version `00` should contain only 4 values delimited by `-`",
+                        "traceparent",
+                    ));
                 }
             }
             _ => {

--- a/bottlecap/src/traces/proxy_flusher.rs
+++ b/bottlecap/src/traces/proxy_flusher.rs
@@ -8,14 +8,13 @@ use tokio::{sync::Mutex, task::JoinSet};
 use tracing::{debug, error};
 
 use crate::{
-    config,
+    FLUSH_RETRY_COUNT, config,
     http::get_client,
     tags::provider,
     traces::{
-        proxy_aggregator::{Aggregator, ProxyRequest},
         DD_ADDITIONAL_TAGS_HEADER,
+        proxy_aggregator::{Aggregator, ProxyRequest},
     },
-    FLUSH_RETRY_COUNT,
 };
 
 #[derive(ThisError, Debug)]

--- a/bottlecap/src/traces/stats_processor.rs
+++ b/bottlecap/src/traces/stats_processor.rs
@@ -55,7 +55,9 @@ impl StatsProcessor for ServerlessStatsProcessor {
             if let Ok(length_str) = content_length.to_str() {
                 if let Ok(length) = length_str.parse::<usize>() {
                     if length > MAX_CONTENT_LENGTH {
-                        let error_msg = format!("Content-Length {length} exceeds maximum allowed size {MAX_CONTENT_LENGTH}");
+                        let error_msg = format!(
+                            "Content-Length {length} exceeds maximum allowed size {MAX_CONTENT_LENGTH}"
+                        );
                         error!("{}", error_msg);
                         return Ok((StatusCode::PAYLOAD_TOO_LARGE, error_msg).into_response());
                     }

--- a/bottlecap/src/traces/trace_agent.rs
+++ b/bottlecap/src/traces/trace_agent.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use axum::{
+    Router,
     extract::{Request, State},
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::{any, post},
-    Router,
 };
 use serde_json::json;
 use std::collections::VecDeque;
@@ -14,8 +14,8 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::{
-    mpsc::{self, Receiver, Sender},
     Mutex,
+    mpsc::{self, Receiver, Sender},
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error};
@@ -28,10 +28,11 @@ use crate::{
     },
     tags::provider,
     traces::{
+        INVOCATION_SPAN_RESOURCE,
         proxy_aggregator::{self, ProxyRequest},
         stats_aggregator, stats_processor,
         trace_aggregator::{self, SendDataBuilderInfo},
-        trace_processor, INVOCATION_SPAN_RESOURCE,
+        trace_processor,
     },
 };
 use datadog_trace_protobuf::pb;

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -4,7 +4,7 @@
 use crate::config;
 use crate::lifecycle::invocation::processor::S_TO_MS;
 use crate::tags::provider;
-use crate::traces::span_pointers::{attach_span_pointers_to_meta, SpanPointer};
+use crate::traces::span_pointers::{SpanPointer, attach_span_pointers_to_meta};
 use crate::traces::{
     AWS_XRAY_DAEMON_ADDRESS_URL_PREFIX, DNS_LOCAL_HOST_ADDRESS_URL_PREFIX,
     DNS_NON_ROUTABLE_ADDRESS_URL_PREFIX, INVOCATION_SPAN_RESOURCE, LAMBDA_EXTENSION_URL_PREFIX,
@@ -194,7 +194,7 @@ mod tests {
 
     use datadog_trace_obfuscation::obfuscation_config::ObfuscationConfig;
 
-    use crate::{config::Config, tags::provider::Provider, LAMBDA_RUNTIME_SLUG};
+    use crate::{LAMBDA_RUNTIME_SLUG, config::Config, tags::provider::Provider};
 
     use super::*;
 

--- a/bottlecap/tests/logs_integration_test.rs
+++ b/bottlecap/tests/logs_integration_test.rs
@@ -1,9 +1,9 @@
+use bottlecap::LAMBDA_RUNTIME_SLUG;
 use bottlecap::config::Config;
 use bottlecap::event_bus::bus::EventBus;
 use bottlecap::logs::{agent::LogsAgent, flusher::LogsFlusher};
 use bottlecap::tags::provider::Provider;
 use bottlecap::telemetry::events::TelemetryEvent;
-use bottlecap::LAMBDA_RUNTIME_SLUG;
 use dogstatsd::api_key::ApiKeyFactory;
 use httpmock::prelude::*;
 use std::collections::HashMap;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.85.0"
 components = [ "rustfmt", "clippy" ]
 profile = "minimal"


### PR DESCRIPTION
Also updates CI to run `clippy` on `--all-targets` so that linter errors aren't ignored on side targets such as tests.