### PR TITLE
chore(dependencies): remove `datadog-trace-agent`

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -494,7 +494,6 @@ dependencies = [
  "chrono",
  "datadog-fips",
  "datadog-protos 0.1.0 (git+https://github.com/DataDog/saluki/?rev=c89b58e5784b985819baf11f13f7d35876741222)",
- "datadog-trace-agent",
  "datadog-trace-normalization",
  "datadog-trace-obfuscation",
  "datadog-trace-protobuf",
@@ -756,28 +755,6 @@ dependencies = [
  "protobuf-codegen",
  "tonic",
  "tonic-build",
-]
-
-[[package]]
-name = "datadog-trace-agent"
-version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=d131de8419c191ce21c91bb30b5915c4d8a2cc5a#d131de8419c191ce21c91bb30b5915c4d8a2cc5a"
-dependencies = [
- "anyhow",
- "async-trait",
- "datadog-trace-normalization",
- "datadog-trace-obfuscation",
- "datadog-trace-protobuf",
- "datadog-trace-utils",
- "ddcommon",
- "http-body-util",
- "hyper 1.6.0",
- "hyper-util",
- "serde",
- "serde_json",
- "tokio",
- "tower 0.5.2",
- "tracing",
 ]
 
 [[package]]

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -45,6 +45,7 @@ serde-aux = { version = "4.7", default-features = false }
 opentelemetry-proto = { version = "0.29", features = ["trace", "with-serde", "gen-tonic"] }
 opentelemetry-semantic-conventions = { version = "0.29", features = ["semconv_experimental"] }
 rustls-native-certs = { version = "0.8.1", optional = true }
+axum = { version = "0.8.4", default-features = false, features = ["default"] }
 # If you are adding or updating a datadog-owned code dependency, please ensure
 # that it has a clippy.toml rule for disallowing the reqwest::Client::builder
 # method in favor of our
@@ -58,9 +59,7 @@ datadog-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "8a
 datadog-trace-normalization = { git = "https://github.com/DataDog/libdatadog",  rev = "8a49c7df2d9cbf05118bfd5b85772676f71b34f2" }
 datadog-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "8a49c7df2d9cbf05118bfd5b85772676f71b34f2"  }
 dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "d131de8419c191ce21c91bb30b5915c4d8a2cc5a", default-features = false }
-datadog-trace-agent = { git = "https://github.com/DataDog/serverless-components", rev = "d131de8419c191ce21c91bb30b5915c4d8a2cc5a" }
 datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "d131de8419c191ce21c91bb30b5915c4d8a2cc5a", default-features = false }
-axum = { version = "0.8.4", default-features = false, features = ["default"] }
 
 [dev-dependencies]
 figment = { version = "0.10", default-features = false, features = ["yaml", "env", "test"] }


### PR DESCRIPTION
# What?

Removes the `datadog-trace-agent` dependency

# Why?

It's not generally needed anymore