### PR TITLE
fix(proxy): ensure correct headers are set when forwarding request

### DIFF
--- a/bottlecap/src/proxy/interceptor.rs
+++ b/bottlecap/src/proxy/interceptor.rs
@@ -304,6 +304,12 @@ fn build_forward_response(
 
     if let Some(h) = forward_response.headers_mut() {
         *h = parts.headers;
+
+        // Since the body has been already collected, we can set the content-length header instead.
+        if h.contains_key("transfer-encoding") {
+            h.remove("transfer-encoding");
+            h.insert("content-length", body_bytes.len().to_string().parse()?);
+        }
     }
 
     let forward_response = forward_response.body(Body::from(body_bytes))?;
@@ -333,6 +339,12 @@ fn build_proxy_request(
 
     if let Some(h) = request.headers_mut() {
         *h = parts.headers.clone();
+
+        // Since the body has been already collected, we can set the content-length header instead.
+        if h.contains_key("transfer-encoding") {
+            h.remove("transfer-encoding");
+            h.insert("content-length", body_bytes.len().to_string().parse()?);
+        }
     }
 
     let request = request.body(Body::from(body_bytes))?;


### PR DESCRIPTION
# What?

Fixes an issue where proxy would fail because a response could come as a streamed buffer

# Why?

We were not taking into account that we are collecting the body before even forwarding the request to the Lambda Runtime, so headers will sent `as-is`. Causing issues when a streamed buffer arrived to ourselves as `transfer-encoding: chunked` which will confuse the runtime since we are proxying it already.

