### PR TITLE
feat: add metric to track proactive initialization with no invocations

### DIFF
--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -156,6 +156,7 @@ impl Processor {
 
         // Increment the invocation metric
         self.enhanced_metrics.increment_invocation_metric(timestamp);
+        self.enhanced_metrics.set_invoked_received();
 
         // If `UniversalInstrumentationStart` event happened first, process it
         if let Some((headers, payload)) = self.context_buffer.pair_invoke_event(&request_id) {
@@ -577,6 +578,8 @@ impl Processor {
             .as_secs();
         self.enhanced_metrics
             .set_shutdown_metric(i64::try_from(now).expect("can't convert now to i64"));
+        self.enhanced_metrics
+            .set_unused_init_metric(i64::try_from(now).expect("can't convert now to i64"));
     }
 
     /// If this method is called, it means that we are operating in a Universally Instrumented
@@ -1175,6 +1178,37 @@ mod tests {
                 .get("http.status_code")
                 .expect("Status code not parsed!"),
             "200"
+        );
+    }
+
+    #[test]
+    fn test_on_shutdown_event_creates_unused_init_metrics() {
+        let mut processor = setup();
+
+        let now1 = i64::try_from(std::time::UNIX_EPOCH.elapsed().unwrap().as_secs()).unwrap();
+        let ts1 = (now1 / 10) * 10;
+        processor.on_shutdown_event();
+        let now2 = i64::try_from(std::time::UNIX_EPOCH.elapsed().unwrap().as_secs()).unwrap();
+        let ts2 = (now2 / 10) * 10;
+
+        let aggregator = processor.enhanced_metrics.aggregator.lock().unwrap();
+
+        assert!(
+            aggregator
+                .get_entry_by_id(
+                    crate::metrics::enhanced::constants::UNUSED_INIT.into(),
+                    &None,
+                    ts1
+                )
+                .is_some()
+                || aggregator
+                    .get_entry_by_id(
+                        crate::metrics::enhanced::constants::UNUSED_INIT.into(),
+                        &None,
+                        ts2
+                    )
+                    .is_some(),
+            "UNUSED_INIT metric should be created when invoked_received=false"
         );
     }
 }

--- a/bottlecap/src/metrics/enhanced/constants.rs
+++ b/bottlecap/src/metrics/enhanced/constants.rs
@@ -44,6 +44,7 @@ pub const THREADS_MAX_METRIC: &str = "aws.lambda.enhanced.threads_max";
 pub const THREADS_USE_METRIC: &str = "aws.lambda.enhanced.threads_use";
 pub const SHUTDOWNS_METRIC: &str = "aws.lambda.enhanced.shutdowns";
 //pub const ASM_INVOCATIONS_METRIC: &str = "aws.lambda.enhanced.asm.invocations";
+pub const UNUSED_INIT: &str = "aws.lambda.enhanced.unused_init";
 pub const ENHANCED_METRICS_ENV_VAR: &str = "DD_ENHANCED_METRICS";
 
 // Monitoring interval for tmp, fd, and threads metrics

--- a/bottlecap/src/metrics/enhanced/lambda.rs
+++ b/bottlecap/src/metrics/enhanced/lambda.rs
@@ -23,6 +23,7 @@ pub struct Lambda {
     pub config: Arc<crate::config::Config>,
     // Dynamic value tags are the ones we cannot obtain statically from the sandbox
     dynamic_value_tags: HashMap<String, String>,
+    invoked_received: bool,
 }
 
 impl Lambda {
@@ -32,6 +33,7 @@ impl Lambda {
             aggregator,
             config,
             dynamic_value_tags: HashMap::new(),
+            invoked_received: false,
         }
     }
 
@@ -114,6 +116,10 @@ impl Lambda {
         }
     }
 
+    pub fn set_invoked_received(&mut self) {
+        self.invoked_received = true;
+    }
+
     fn increment_metric(&self, metric_name: &str, timestamp: i64) {
         if !self.config.enhanced_metrics {
             return;
@@ -178,6 +184,12 @@ impl Lambda {
             return;
         }
         self.increment_metric(constants::SHUTDOWNS_METRIC, timestamp);
+    }
+
+    pub fn set_unused_init_metric(&self, timestamp: i64) {
+        if !self.invoked_received {
+            self.increment_metric(constants::UNUSED_INIT, timestamp);
+        }
     }
 
     pub fn set_post_runtime_duration_metric(&self, duration_ms: f64, timestamp: i64) {


### PR DESCRIPTION
## Task
https://datadoghq.atlassian.net/browse/SVLS-7257?quickFilter=5438

## Overview
Lambda warms up functions for you via “proactive initialization”. We want to track how often functions are initialized, but never invoked.

## PR
This PR add a new enhanced metric, `aws.lamdba.enhanced.unused_init` which gets emitted at shutdown. We emit `1` when the lambda function was shutdown, but had no invocations. Discussed offline emitting `0` to signal there were invocations, but decided against it.

## Testing
I deployed lambda with provisioned concurrency with the updated lambda extensions. I didn't invoke the lambda, but redeployed it and checked our metrics. I checked our DD metrics and saw we were correctly emitting ``aws.lamdba.enhanced.unused_init`, [metric explorer link](https://ddserverless.datadoghq.com/metric/explorer?fromUser=false&start=1754326574963&end=1754412974963&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGniqyBhgGgB0mKoARsl1cCKMGCLZUHV4InhaUE6i4sAAVDx1GBpOmfgiCAAUAJQgPAC6VK7ueJih4TuqexgxpfHrWyAacmg5oPIYdwgIOUk4MHP7GhCZiWiiOBOOSKco4AFQf6Apz0JjKERuDxodb8CD2TBYYEKN4AkRKTY8PjXeQAhAAYSkwhgKAGaDQPCAA)