### PR TITLE
fix: Fix parsing provided.al runtime by reading /etc/os-release

### DIFF
--- a/bottlecap/src/proc/constants.rs
+++ b/bottlecap/src/proc/constants.rs
@@ -2,7 +2,7 @@ pub const PROC_NET_DEV_PATH: &str = "/proc/net/dev";
 pub const PROC_STAT_PATH: &str = "/proc/stat";
 pub const PROC_UPTIME_PATH: &str = "/proc/uptime";
 pub const PROC_PATH: &str = "/proc";
-pub const ETC_PATH: &str = "/etc";
+pub const ETC_PATH: &str = "/etc/os-release";
 
 pub const LAMBDA_NETWORK_INTERFACE: &str = "vinternal_1";
 pub const LAMBDA_RUNTIME_NETWORK_INTERFACE: &str = "vint_runtime";

--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -4,7 +4,7 @@ use std::env::consts::ARCH;
 use std::fs;
 use std::sync::Arc;
 use std::time::Instant;
-use tracing::{debug, error};
+use tracing::{debug, warn};
 
 // Environment variables for the Lambda execution environment info
 const QUALIFIER_ENV_VAR: &str = "AWS_LAMBDA_FUNCTION_VERSION";
@@ -193,7 +193,7 @@ pub fn resolve_runtime_from_proc(proc_path: &str, fallback_provided_al_path: &st
                 )
         })
         .unwrap_or_else(|| {
-            error!("Failed to read os-release file or extract runtime");
+            warn!("Failed to read os-release file or extract runtime");
             "unknown".to_string()
         });
 

--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -4,7 +4,7 @@ use std::env::consts::ARCH;
 use std::fs;
 use std::sync::Arc;
 use std::time::Instant;
-use tracing::debug;
+use tracing::{debug, error};
 
 // Environment variables for the Lambda execution environment info
 const QUALIFIER_ENV_VAR: &str = "AWS_LAMBDA_FUNCTION_VERSION";
@@ -192,7 +192,10 @@ pub fn resolve_runtime_from_proc(proc_path: &str, fallback_provided_al_path: &st
                     },
                 )
         })
-        .unwrap_or_else(|| "unknown".to_string());
+        .unwrap_or_else(|| {
+            error!("Failed to read os-release file or extract runtime");
+            "unknown".to_string()
+        });
 
     debug!(
         "Provided runtime {provided_al}, it took: {:?}",


### PR DESCRIPTION
# Problem
We fail to parse the runtime when it is `provided.al2` or `provided.al2023`. I don't though what's the impact though, because in Datadog logs, the runtime tag is shown correctly even if I removed all the env vars related to runtime.
<img width="142" height="29" alt="image" src="https://github.com/user-attachments/assets/2e81c6d8-9695-4880-82fe-76561abd8e32" />


# This PR
Fix the problem by changing the path from `/etc` to `/etc/os-release`.

Thanks @shreyamalpani for the idea about the fix.

# Test
## Before
Failed to parse the runtime
<img width="489" height="34" alt="image" src="https://github.com/user-attachments/assets/ac1961f7-7565-4f82-9ab5-7b1f0ae48d07" />
## After
Works for both al2 and al2023
<img width="525" height="93" alt="image" src="https://github.com/user-attachments/assets/840db400-9995-439e-8ee0-0b819f8f76a2" />

<img width="546" height="90" alt="image" src="https://github.com/user-attachments/assets/d24071dc-670b-4cc7-8fab-4d3fe6b222b0" />
