### PR TITLE
fix: Upgrade libdatadog to mute an error

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -748,8 +748,8 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-normalization"
-version = "19.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=f8a01a563f3cacbc825cb5bff5d5611b2ac88f55#f8a01a563f3cacbc825cb5bff5d5611b2ac88f55"
+version = "20.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=9405db9cb4ef733f3954c3ee77ce71a502e98e50#9405db9cb4ef733f3954c3ee77ce71a502e98e50"
 dependencies = [
  "anyhow",
  "datadog-trace-protobuf",
@@ -757,8 +757,8 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-obfuscation"
-version = "19.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=f8a01a563f3cacbc825cb5bff5d5611b2ac88f55#f8a01a563f3cacbc825cb5bff5d5611b2ac88f55"
+version = "20.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=9405db9cb4ef733f3954c3ee77ce71a502e98e50#9405db9cb4ef733f3954c3ee77ce71a502e98e50"
 dependencies = [
  "anyhow",
  "datadog-trace-protobuf",
@@ -774,8 +774,8 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-protobuf"
-version = "19.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=f8a01a563f3cacbc825cb5bff5d5611b2ac88f55#f8a01a563f3cacbc825cb5bff5d5611b2ac88f55"
+version = "20.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=9405db9cb4ef733f3954c3ee77ce71a502e98e50#9405db9cb4ef733f3954c3ee77ce71a502e98e50"
 dependencies = [
  "prost",
  "serde",
@@ -784,8 +784,8 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-utils"
-version = "19.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=f8a01a563f3cacbc825cb5bff5d5611b2ac88f55#f8a01a563f3cacbc825cb5bff5d5611b2ac88f55"
+version = "20.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=9405db9cb4ef733f3954c3ee77ce71a502e98e50#9405db9cb4ef733f3954c3ee77ce71a502e98e50"
 dependencies = [
  "anyhow",
  "bytes",
@@ -812,8 +812,8 @@ dependencies = [
 
 [[package]]
 name = "ddcommon"
-version = "19.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=f8a01a563f3cacbc825cb5bff5d5611b2ac88f55#f8a01a563f3cacbc825cb5bff5d5611b2ac88f55"
+version = "20.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=9405db9cb4ef733f3954c3ee77ce71a502e98e50#9405db9cb4ef733f3954c3ee77ce71a502e98e50"
 dependencies = [
  "anyhow",
  "cc",
@@ -3312,8 +3312,8 @@ dependencies = [
 
 [[package]]
 name = "tinybytes"
-version = "19.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=f8a01a563f3cacbc825cb5bff5d5611b2ac88f55#f8a01a563f3cacbc825cb5bff5d5611b2ac88f55"
+version = "20.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=9405db9cb4ef733f3954c3ee77ce71a502e98e50#9405db9cb4ef733f3954c3ee77ce71a502e98e50"
 dependencies = [
  "serde",
 ]

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -49,11 +49,11 @@ axum = { version = "0.8.4", default-features = false, features = ["default"] }
 # be found in the clippy.toml file adjacent to this Cargo.toml.
 datadog-protos = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "c89b58e5784b985819baf11f13f7d35876741222"}
 ddsketch-agent = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/" }
-ddcommon = { git = "https://github.com/DataDog/libdatadog", rev = "f8a01a563f3cacbc825cb5bff5d5611b2ac88f55" }
-datadog-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "f8a01a563f3cacbc825cb5bff5d5611b2ac88f55"  }
-datadog-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "f8a01a563f3cacbc825cb5bff5d5611b2ac88f55" , features = ["mini_agent"] }
-datadog-trace-normalization = { git = "https://github.com/DataDog/libdatadog",  rev = "f8a01a563f3cacbc825cb5bff5d5611b2ac88f55" }
-datadog-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "f8a01a563f3cacbc825cb5bff5d5611b2ac88f55"  }
+ddcommon = { git = "https://github.com/DataDog/libdatadog", rev = "9405db9cb4ef733f3954c3ee77ce71a502e98e50" }
+datadog-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "9405db9cb4ef733f3954c3ee77ce71a502e98e50"  }
+datadog-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "9405db9cb4ef733f3954c3ee77ce71a502e98e50" , features = ["mini_agent"] }
+datadog-trace-normalization = { git = "https://github.com/DataDog/libdatadog",  rev = "9405db9cb4ef733f3954c3ee77ce71a502e98e50" }
+datadog-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "9405db9cb4ef733f3954c3ee77ce71a502e98e50"  }
 dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "d131de8419c191ce21c91bb30b5915c4d8a2cc5a", default-features = false }
 datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "d131de8419c191ce21c91bb30b5915c4d8a2cc5a", default-features = false }
 


### PR DESCRIPTION
Upgrade libdatadog so this spammy error won't be logged:
> Could not find the root span for trace

Details in: https://github.com/DataDog/libdatadog/pull/1177