### PR TITLE
vulnerability: upgrade `go` to `1.24.6`

### DIFF
--- a/images/Dockerfile.go_agent.alpine.compile
+++ b/images/Dockerfile.go_agent.alpine.compile
@@ -14,7 +14,7 @@ RUN apk add --no-cache git make musl-dev gcc
 # listed in the agen't go.work files. The go we install here will download the
 # appropriate version  specified in the go.work file before running go commands
 # for the agent.
-COPY --from=registry.ddbuild.io/images/mirror/golang:1.24.4-alpine /usr/local/go/ /usr/lib/go
+COPY --from=registry.ddbuild.io/images/mirror/golang:1.24.6-alpine /usr/local/go/ /usr/lib/go
 
 ENV GOROOT=/usr/lib/go
 ENV GOPATH=/go

--- a/images/Dockerfile.go_agent.compile
+++ b/images/Dockerfile.go_agent.compile
@@ -21,8 +21,8 @@ RUN arch="$(uname -m)"; \
     if [ "${arch}" = 'x86_64' ]; then \
     arch='amd64'; \
     fi; \
-    wget -O go1.24.4.linux-${arch}.tar.gz https://go.dev/dl/go1.24.4.linux-${arch}.tar.gz; \
-    tar -C /usr/local -xzf go1.24.4.linux-${arch}.tar.gz
+    wget -O go1.24.6.linux-${arch}.tar.gz https://go.dev/dl/go1.24.6.linux-${arch}.tar.gz; \
+    tar -C /usr/local -xzf go1.24.6.linux-${arch}.tar.gz
 
 # Copy cached dependencies
 COPY ./scripts/.cache/go.mod /tmp/dd/datadog-agent

--- a/scripts/Dockerfile.alpine.build
+++ b/scripts/Dockerfile.alpine.build
@@ -13,7 +13,7 @@ RUN apk add --no-cache git make musl-dev gcc
 # listed in the agen't go.work files. The go we install here will download the
 # appropriate version  specified in the go.work file before running go commands
 # for the agent.
-COPY --from=golang:1.24.4-alpine /usr/local/go/ /usr/lib/go
+COPY --from=golang:1.24.6-alpine /usr/local/go/ /usr/lib/go
 
 ENV GOROOT /usr/lib/go
 ENV GOPATH /go

--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -21,8 +21,8 @@ RUN arch="$(uname -m)"; \
     if [ "${arch}" = 'x86_64' ]; then \
     arch='amd64'; \
     fi; \
-    wget -O go1.24.4.linux-${arch}.tar.gz https://go.dev/dl/go1.24.4.linux-${arch}.tar.gz; \
-    tar -C /usr/local -xzf go1.24.4.linux-${arch}.tar.gz
+    wget -O go1.24.6.linux-${arch}.tar.gz https://go.dev/dl/go1.24.6.linux-${arch}.tar.gz; \
+    tar -C /usr/local -xzf go1.24.6.linux-${arch}.tar.gz
 
 # cache dependencies
 COPY ./scripts/.cache/go.mod /tmp/dd/datadog-agent

--- a/scripts/Dockerfile.race.build
+++ b/scripts/Dockerfile.race.build
@@ -5,7 +5,7 @@
 # listed in the agen't go.work files. The go we install here will download the
 # appropriate version  specified in the go.work file before running go commands
 # for the agent.
-FROM golang:1.24.4 as builder
+FROM golang:1.24.6 as builder
 
 ARG EXTENSION_VERSION
 ARG ENABLE_RACE_DETECTION


### PR DESCRIPTION
# What?

Solves vulnerability issues