### PR TITLE
Clear aggregator queue when API key resolution fails to avoid retries…

### DIFF
--- a/bottlecap/src/traces/proxy_aggregator.rs
+++ b/bottlecap/src/traces/proxy_aggregator.rs
@@ -30,4 +30,9 @@ impl Aggregator {
     pub fn get_batch(&mut self) -> Vec<ProxyRequest> {
         std::mem::take(&mut self.queue)
     }
+
+    /// Flush the queue.
+    pub fn clear(&mut self) {
+        self.queue.clear();
+    }
 }

--- a/bottlecap/src/traces/proxy_flusher.rs
+++ b/bottlecap/src/traces/proxy_flusher.rs
@@ -82,7 +82,11 @@ impl Flusher {
         retry_requests: Option<Vec<reqwest::RequestBuilder>>,
     ) -> Option<Vec<reqwest::RequestBuilder>> {
         let Some(api_key) = self.api_key_factory.get_api_key().await else {
-            error!("Skipping flush in proxy flusher: Failed to resolve API key");
+            error!("Skipping flush in proxy flusher: Failed to resolve API key.");
+            {
+                let mut aggregator = self.aggregator.lock().await;
+                aggregator.clear();
+            }
             return None;
         };
 


### PR DESCRIPTION
Clear aggregator queue when API key resolution fails to avoid retries and prevent wasted billing time.

Test:
| Scenario | Log | Observation |
|--------|--------|--------|
| Baseline+good DD_API_KEY | REPORT RequestId: cac9fb53-c84f-4c4b-b5fb-f2965589e559	**Duration: 126.62 ms	Billed Duration: 127 ms**	Memory Size: 1024 MB	Max Memory Used: 94 MB | Normal |
|Baseline+bad DD_API_KEY|REPORT RequestId: bfff6cc0-3ab2-4a35-86a5-0ba29d1ba1d6	**Duration: 120000.00 ms	Billed Duration: 120000 ms**	Memory Size: 1024 MB	Max Memory Used: 90 MB	Status: timeout|Time out with excessive billed time|
|Change+good DD_API_KEY|REPORT RequestId: 58ef36bf-7b05-47da-8173-a204d0c74ff6	**Duration: 46.62 ms	Billed Duration: 47 ms**	Memory Size: 1024 MB	Max Memory Used: 94 MB|Normal|
|Change+bad DD_API_KEY|REPORT RequestId: 333cd454-6765-4817-98d9-95a9b754f567	**Duration: 67.33 ms	Billed Duration: 68 ms**	Memory Size: 1024 MB	Max Memory Used: 94 MB|Fail fast w/o excessive billed time|

[Tracking records](https://docs.google.com/spreadsheets/d/1G7Lq7e1Apr43beDQh6J4ekonixDMXWLImhYv90Umbls/edit?gid=831661199#gid=831661199)