### PR TITLE
 [cleanup]: Remove idle function calls when API key is empty or invalid

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -377,7 +377,7 @@ async fn main() -> Result<()> {
         }
         Err(e) => {
             error!("Extension loop failed: {e:?}, Calling /next without Datadog instrumentation");
-            extension_loop_idle(&client, &r).await
+            Err(e)
         }
     }
 }
@@ -438,20 +438,6 @@ fn create_api_key_factory(
 
         Box::pin(async move { resolve_secrets(config, aws_config, aws_credentials).await })
     })))
-}
-
-async fn extension_loop_idle(client: &Client, r: &RegisterResponse) -> Result<()> {
-    loop {
-        match next_event(client, &r.extension_id).await {
-            Ok(_) => {
-                debug!("Extension is idle, skipping next event");
-            }
-            Err(e) => {
-                error!("Error getting next event: {e:?}");
-                return Err(e);
-            }
-        };
-    }
 }
 
 #[allow(clippy::too_many_lines)]


### PR DESCRIPTION
As bottlecap silently handles the API key access related errors([1](https://github.com/DataDog/datadog-lambda-extension/blob/main/bottlecap/src/bin/bottlecap/main.rs#L631), [2](https://github.com/DataDog/datadog-lambda-extension/blob/main/bottlecap/src/bin/bottlecap/main.rs#L649), [3](https://github.com/DataDog/datadog-lambda-extension/blob/main/bottlecap/src/bin/bottlecap/main.rs#L663)), it nulls the necessity of keeping idle call. Hence we decided to clean it up. 

| Scenario | Before the change | After the change | Conclusion|
|--------|--------|--------|--------|
| Normal | [link](https://docs.google.com/spreadsheets/d/1S_dkKmeybsBEcDsViV_C8zDdEvQ_nR0oOip9AqXuipc/edit?gid=0#gid=0) |[link](https://docs.google.com/spreadsheets/d/1S_dkKmeybsBEcDsViV_C8zDdEvQ_nR0oOip9AqXuipc/edit?gid=1370505645#gid=1370505645)||
| No key | [link](https://docs.google.com/spreadsheets/d/1S_dkKmeybsBEcDsViV_C8zDdEvQ_nR0oOip9AqXuipc/edit?gid=1521060450#gid=1521060450) | [link](https://docs.google.com/spreadsheets/d/1S_dkKmeybsBEcDsViV_C8zDdEvQ_nR0oOip9AqXuipc/edit?gid=1759134716#gid=1759134716) |No diverging behavior observed|
| Empty key | [link](https://docs.google.com/spreadsheets/d/1S_dkKmeybsBEcDsViV_C8zDdEvQ_nR0oOip9AqXuipc/edit?gid=1349611818#gid=1349611818) | [link](https://docs.google.com/spreadsheets/d/1S_dkKmeybsBEcDsViV_C8zDdEvQ_nR0oOip9AqXuipc/edit?gid=609303510#gid=609303510) |No diverging behavior observed|
| Invalid key | [link](https://docs.google.com/spreadsheets/d/1S_dkKmeybsBEcDsViV_C8zDdEvQ_nR0oOip9AqXuipc/edit?gid=2069462126#gid=2069462126) | [link](https://docs.google.com/spreadsheets/d/1S_dkKmeybsBEcDsViV_C8zDdEvQ_nR0oOip9AqXuipc/edit?gid=309886672#gid=309886672) |No diverging behavior observed|