### PR TITLE
fix: Drop aggregated trace data on API key failure to reduce memory usage

### DIFF
--- a/bottlecap/src/traces/trace_aggregator.rs
+++ b/bottlecap/src/traces/trace_aggregator.rs
@@ -78,6 +78,11 @@ impl TraceAggregator {
 
         std::mem::take(&mut self.buffer)
     }
+    
+    /// Flush the queue.
+    pub fn clear(&mut self) {
+        self.queue.clear();
+    }
 }
 
 #[cfg(test)]

--- a/bottlecap/src/traces/trace_flusher.rs
+++ b/bottlecap/src/traces/trace_flusher.rs
@@ -86,7 +86,11 @@ impl TraceFlusher for ServerlessTraceFlusher {
 
     async fn flush(&self, failed_traces: Option<Vec<SendData>>) -> Option<Vec<SendData>> {
         let Some(api_key) = self.api_key_factory.get_api_key().await else {
-            error!("Skipping flushing traces: Failed to resolve API key");
+            error!("Purging the aggregated data and skipping flushing traces: Failed to resolve API key");
+            {
+                let mut guard = self.aggregator.lock().await;
+                guard.clear()
+            }
             return None;
         };
 


### PR DESCRIPTION
In case of API key failure, we should drop the aggregated tracing data as there is no way to send them back. By doing so we expect to reduce the memory wasted on the unsent data. 
Tested with [fullinstrument stack in self-monitor repo](https://github.com/DataDog/serverless-self-monitoring/tree/main/self_monitor/aws/stacks/fullinstrument)
[Manifest](https://docs.google.com/spreadsheets/d/16gL-e_kHw9SAM3u3cjDD5485aqbOUMMr3C51f69t8uY/edit?gid=0#gid=0)
<img width="1504" height="912" alt="image" src="https://github.com/user-attachments/assets/ba6a366c-b0ca-415d-a23a-fd367ace4587" />
