### PR TITLE
feat: No longer launch Go-based agent for compatibility/OTLP/AAP config

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -37,6 +37,7 @@ use bottlecap::{
     },
     logger,
     logs::{agent::LogsAgent, flusher::LogsFlusher},
+    metrics::enhanced::lambda::Lambda as enhanced_metrics,
     otlp::{agent::Agent as OtlpAgent, should_enable_otlp_agent},
     proxy::{interceptor, should_start_proxy},
     secrets::decrypt,
@@ -84,9 +85,7 @@ use std::{
     collections::{HashMap, hash_map},
     env,
     io::{Error, Result},
-    os::unix::process::CommandExt,
     path::Path,
-    process::Command,
     sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
@@ -402,14 +401,7 @@ fn load_configs(start_time: Instant) -> (AwsConfig, AwsCredentials, Arc<Config>)
     let aws_credentials = AwsCredentials::from_env();
     let lambda_directory: String =
         env::var("LAMBDA_TASK_ROOT").unwrap_or_else(|_| "/var/task".to_string());
-    let config = match config::get_config(Path::new(&lambda_directory)) {
-        Ok(config) => Arc::new(config),
-        Err(_e) => {
-            let err = Command::new("/opt/datadog-agent-go").exec();
-            panic!("Error starting the extension: {err:?}");
-        }
-    };
-
+    let config = Arc::new(config::get_config(Path::new(&lambda_directory)));
     (aws_config, aws_credentials, config)
 }
 
@@ -508,12 +500,22 @@ async fn extension_loop_active(
             .as_micros()
             .to_string()
     );
-
+    let metrics_intake_url = create_metrics_intake_url_prefix(config);
     let metrics_flushers = Arc::new(TokioMutex::new(start_metrics_flushers(
         Arc::clone(&api_key_factory),
         &metrics_aggr,
+        &metrics_intake_url,
         config,
     )));
+
+    // Create lambda enhanced metrics instance once
+    let lambda_enhanced_metrics =
+        enhanced_metrics::new(Arc::clone(&metrics_aggr), Arc::clone(config));
+
+    // Send config issue metrics
+    let config_issues = config::fallback(config);
+    send_config_issue_metric(&config_issues, &lambda_enhanced_metrics);
+
     // Lifecycle Invocation Processor
     let invocation_processor = Arc::new(TokioMutex::new(InvocationProcessor::new(
         Arc::clone(&tags_provider),
@@ -1006,33 +1008,33 @@ fn start_logs_agent(
     (logs_agent_channel, logs_flusher)
 }
 
+fn create_metrics_intake_url_prefix(config: &Config) -> MetricsIntakeUrlPrefix {
+    if !config.dd_url.is_empty() {
+        let dd_dd_url = DdDdUrl::new(config.dd_url.clone()).expect("can't parse DD_DD_URL");
+        let prefix_override = MetricsIntakeUrlPrefixOverride::maybe_new(None, Some(dd_dd_url));
+        MetricsIntakeUrlPrefix::new(None, prefix_override).expect("can't parse DD_DD_URL prefix")
+    } else if !config.url.is_empty() {
+        let dd_url = DdUrl::new(config.url.clone()).expect("can't parse DD_URL");
+        let prefix_override = MetricsIntakeUrlPrefixOverride::maybe_new(Some(dd_url), None);
+        MetricsIntakeUrlPrefix::new(None, prefix_override).expect("can't parse DD_URL prefix")
+    } else {
+        let metrics_site = MetricsSite::new(config.site.clone()).expect("can't parse site");
+        MetricsIntakeUrlPrefix::new(Some(metrics_site), None).expect("can't parse site prefix")
+    }
+}
+
 fn start_metrics_flushers(
     api_key_factory: Arc<ApiKeyFactory>,
     metrics_aggr: &Arc<Mutex<MetricsAggregator>>,
+    metrics_intake_url: &MetricsIntakeUrlPrefix,
     config: &Arc<Config>,
 ) -> Vec<MetricsFlusher> {
     let mut flushers = Vec::new();
 
-    let metrics_intake_url = if !config.dd_url.is_empty() {
-        let dd_dd_url = DdDdUrl::new(config.dd_url.clone()).expect("can't parse DD_DD_URL");
-
-        let prefix_override = MetricsIntakeUrlPrefixOverride::maybe_new(None, Some(dd_dd_url));
-        MetricsIntakeUrlPrefix::new(None, prefix_override)
-    } else if !config.url.is_empty() {
-        let dd_url = DdUrl::new(config.url.clone()).expect("can't parse DD_URL");
-
-        let prefix_override = MetricsIntakeUrlPrefixOverride::maybe_new(Some(dd_url), None);
-        MetricsIntakeUrlPrefix::new(None, prefix_override)
-    } else {
-        // use site
-        let metrics_site = MetricsSite::new(config.site.clone()).expect("can't parse site");
-        MetricsIntakeUrlPrefix::new(Some(metrics_site), None)
-    };
-
     let flusher_config = MetricsFlusherConfig {
         api_key_factory,
         aggregator: Arc::clone(metrics_aggr),
-        metrics_intake_url_prefix: metrics_intake_url.expect("can't parse site or override"),
+        metrics_intake_url_prefix: metrics_intake_url.clone(),
         https_proxy: config.proxy_https.clone(),
         timeout: Duration::from_secs(config.flush_timeout),
         retry_strategy: DsdRetryStrategy::Immediate(3),
@@ -1155,6 +1157,28 @@ fn start_trace_agent(
         proxy_flusher,
         shutdown_token,
     )
+}
+
+/// Sends metrics indicating issue with configuration.
+///
+/// # Arguments
+/// * `issue_reasons` - Vector of messages describing the issue with the configurations
+/// * `lambda_enhanced_metrics` - The lambda enhanced metrics instance
+fn send_config_issue_metric(issue_reasons: &[String], lambda_enhanced_metrics: &enhanced_metrics) {
+    if issue_reasons.is_empty() {
+        return;
+    }
+    let now = std::time::UNIX_EPOCH
+        .elapsed()
+        .expect("can't poll clock")
+        .as_secs()
+        .try_into()
+        .unwrap_or_default();
+
+    // Setup a separate metric for each config issue reason
+    for issue_reason in issue_reasons {
+        lambda_enhanced_metrics.set_config_load_issue_metric(now, issue_reason);
+    }
 }
 
 async fn start_dogstatsd(metrics_aggr: &Arc<Mutex<MetricsAggregator>>) -> CancellationToken {

--- a/bottlecap/src/metrics/enhanced/constants.rs
+++ b/bottlecap/src/metrics/enhanced/constants.rs
@@ -45,6 +45,8 @@ pub const THREADS_USE_METRIC: &str = "aws.lambda.enhanced.threads_use";
 pub const SHUTDOWNS_METRIC: &str = "aws.lambda.enhanced.shutdowns";
 //pub const ASM_INVOCATIONS_METRIC: &str = "aws.lambda.enhanced.asm.invocations";
 pub const UNUSED_INIT: &str = "aws.lambda.enhanced.unused_init";
+pub const DATADOG_SERVERLESS_EXTENSION_FAILOVER_CONFIG_ISSUE_METRIC: &str =
+    "datadog.serverless.extension.failover";
 pub const ENHANCED_METRICS_ENV_VAR: &str = "DD_ENHANCED_METRICS";
 
 // Monitoring interval for tmp, fd, and threads metrics

--- a/bottlecap/src/metrics/enhanced/lambda.rs
+++ b/bottlecap/src/metrics/enhanced/lambda.rs
@@ -60,16 +60,27 @@ impl Lambda {
             .insert(String::from("runtime"), runtime.to_string());
     }
 
-    fn get_dynamic_value_tags(&self) -> Option<SortedTags> {
-        let vec_tags: Vec<String> = self
-            .dynamic_value_tags
-            .iter()
-            .map(|(k, v)| format!("{k}:{v}"))
-            .collect();
+    fn tags_to_sorted_tags(tags: &HashMap<String, String>) -> Option<SortedTags> {
+        let vec_tags: Vec<String> = tags.iter().map(|(k, v)| format!("{k}:{v}")).collect();
 
         let string_tags = vec_tags.join(",");
 
         SortedTags::parse(&string_tags).ok()
+    }
+
+    fn get_dynamic_value_tags(&self) -> Option<SortedTags> {
+        Self::tags_to_sorted_tags(&self.dynamic_value_tags)
+    }
+
+    fn get_combined_tags(&self, additional_tags: &HashMap<String, String>) -> Option<SortedTags> {
+        if additional_tags.is_empty() {
+            return self.get_dynamic_value_tags();
+        }
+
+        let mut combined_tags = self.dynamic_value_tags.clone();
+        combined_tags.extend(additional_tags.clone());
+
+        Self::tags_to_sorted_tags(&combined_tags)
     }
 
     pub fn increment_invocation_metric(&self, timestamp: i64) {
@@ -92,6 +103,19 @@ impl Lambda {
     // This is our best effort to cover different cases without double counting. We can adjust this if we find more cases.
     pub fn increment_oom_metric(&self, timestamp: i64) {
         self.increment_metric(constants::OUT_OF_MEMORY_METRIC, timestamp);
+    }
+
+    /// Set up a metric tracking configuration load issue with details
+    pub fn set_config_load_issue_metric(&self, timestamp: i64, reason_msg: &str) {
+        let dynamic_tags = self.get_combined_tags(&HashMap::from([(
+            "reason".to_string(),
+            reason_msg.to_string(),
+        )]));
+        self.increment_metric_with_tags(
+            constants::DATADOG_SERVERLESS_EXTENSION_FAILOVER_CONFIG_ISSUE_METRIC,
+            timestamp,
+            dynamic_tags,
+        );
     }
 
     pub fn set_init_duration_metric(
@@ -127,13 +151,23 @@ impl Lambda {
     }
 
     fn increment_metric(&self, metric_name: &str, timestamp: i64) {
+        self.increment_metric_with_tags(metric_name, timestamp, self.get_dynamic_value_tags());
+    }
+
+    /// Helper function to emit metric with supplied tags
+    fn increment_metric_with_tags(
+        &self,
+        metric_name: &str,
+        timestamp: i64,
+        tags: Option<SortedTags>,
+    ) {
         if !self.config.enhanced_metrics {
             return;
         }
         let metric = Metric::new(
             metric_name.into(),
             MetricValue::distribution(1f64),
-            self.get_dynamic_value_tags(),
+            tags,
             Some(timestamp),
         );
         if let Err(e) = self
@@ -818,9 +852,19 @@ mod tests {
         value: f64,
         timestamp: i64,
     ) {
+        assert_sketch_with_tag(aggregator_mutex, metric_id, value, timestamp, None);
+    }
+
+    fn assert_sketch_with_tag(
+        aggregator_mutex: &Mutex<Aggregator>,
+        metric_id: &str,
+        value: f64,
+        timestamp: i64,
+        tags: Option<SortedTags>,
+    ) {
         let ts = (timestamp / 10) * 10;
         let aggregator = aggregator_mutex.lock().unwrap();
-        if let Some(e) = aggregator.get_entry_by_id(metric_id.into(), &None, ts) {
+        if let Some(e) = aggregator.get_entry_by_id(metric_id.into(), &tags, ts) {
             let metric = e.value.get_sketch().unwrap();
             assert!((metric.max().unwrap() - value).abs() < PRECISION);
             assert!((metric.min().unwrap() - value).abs() < PRECISION);
@@ -1327,6 +1371,31 @@ mod tests {
         assert!(
             aggr.get_entry_by_id(constants::THREADS_USE_METRIC.into(), &None, now)
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn test_set_config_load_issue_metric() {
+        let (metrics_aggr, my_config) = setup();
+        let lambda = Lambda::new(metrics_aggr.clone(), my_config);
+        let now: i64 = std::time::UNIX_EPOCH
+            .elapsed()
+            .expect("unable to poll clock, unrecoverable")
+            .as_secs()
+            .try_into()
+            .unwrap_or_default();
+        let test_reason = "test_config_issue";
+
+        lambda.set_config_load_issue_metric(now, test_reason);
+
+        // Create the expected tags for the metric lookup
+        let expected_tags = SortedTags::parse(&format!("reason:{test_reason}")).ok();
+        assert_sketch_with_tag(
+            &metrics_aggr,
+            constants::DATADOG_SERVERLESS_EXTENSION_FAILOVER_CONFIG_ISSUE_METRIC,
+            1f64,
+            now,
+            expected_tags,
         );
     }
 }

--- a/bottlecap/src/otlp/mod.rs
+++ b/bottlecap/src/otlp/mod.rs
@@ -37,7 +37,7 @@ mod tests {
             ",
             )?;
 
-            let config = get_config(Path::new("")).expect("should parse config");
+            let config = get_config(Path::new(""));
 
             // Since the default for traces is `true`, we don't need to set it.
             assert!(should_enable_otlp_agent(&Arc::new(config)));
@@ -55,7 +55,7 @@ mod tests {
                 "0.0.0.0:4318",
             );
 
-            let config = get_config(Path::new("")).expect("should parse config");
+            let config = get_config(Path::new(""));
 
             // Since the default for traces is `true`, we don't need to set it.
             assert!(should_enable_otlp_agent(&Arc::new(config)));
@@ -74,7 +74,7 @@ mod tests {
                 "0.0.0.0:4318",
             );
 
-            let config = get_config(Path::new("")).expect("should parse config");
+            let config = get_config(Path::new(""));
 
             assert!(!should_enable_otlp_agent(&Arc::new(config)));
 


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/SVLS-7398

- As part of coming release, bottlecap agent no longer launches Go-based agent when compatibility/AAP/OTLP features are active
- Emit the same metric when detecting any of above configuration
- Update corresponding unit tests

Manifests:
- [Test lambda function](https://us-east-1.console.aws.amazon.com/lambda/home?region=us-east-1#/functions/ltn1-fullinstrument-bn-cold-python310-lambda?code=&subtab=envVars&tab=testing) with [logs](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fltn1-fullinstrument-bn-cold-python310-lambda/log-events/2025$252F08$252F21$252F$255B$2524LATEST$255Df3788d359677452dad162488ff15456f$3FfilterPattern$3Dotel) showing compatibility/AAP/OTPL are enabled
<img width="2260" height="454" alt="image" src="https://github.com/user-attachments/assets/5dfd4954-5191-4390-83f5-a8eb3bffb9d3" />

- [Logging](https://app.datadoghq.com/logs/livetail?query=functionname%3Altn1-fullinstrument-bn-cold-python310-lambda%20Metric&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=driveline&stream_sort=desc&viz=stream&from_ts=1755787655569&to_ts=1755787689060&live=false)
<img width="1058" height="911" alt="image" src="https://github.com/user-attachments/assets/629f75d1-e115-4478-afac-ad16d9369fa7" />

- [Metric](https://app.datadoghq.com/screen/integration/aws_lambda_enhanced_metrics?fromUser=false&fullscreen_end_ts=1755788220000&fullscreen_paused=true&fullscreen_refresh_mode=paused&fullscreen_section=overview&fullscreen_start_ts=1755787200000&fullscreen_widget=2&graph-explorer__tile_def=N4IgbglgXiBcIBcD2AHANhAzgkAaEAxgK7ZIC2A%2BhgHYDWmcA2gLr4BOApgI5EfYOxGoTphRJqmDhQBmSNmQCGOeJgIK0CtnhA8ObCHyagAJkoUVMSImwIc4IMhwT6CDfNQWP7utgE8AjNo%2BvvaYRGSwpggKxkgA5gB0kmxgemh8mAkcAB4IHBIQ4gnSChBoSKlswAAkCgDumBQKBARW1Ai41ZxxhdSd0kTUBAi9AL4ABABGvuPAA0Mj4h6OowkKja2DCAAUAJTaCnFx3UpyoeEgo6wgsvJEGgJCN3Jk9wrevH6BV-iWbMqgTbtOAAJgADPg5MY9BRpkZEL4UHZ4LdXhptBBqNDsnAISAoXp7NDVJdmKMfiBsL50nBgOSgA&refresh_mode=sliding&from_ts=1755783890661&to_ts=1755787490661&live=true)
<img width="1227" height="1196" alt="image" src="https://github.com/user-attachments/assets/2922eb54-9853-4512-a902-dfa97916b643" />


