### PR TITLE
chore: Update error message when fail to send log

### DIFF
--- a/bottlecap/src/logs/flusher.rs
+++ b/bottlecap/src/logs/flusher.rs
@@ -129,7 +129,9 @@ impl Flusher {
                     _ = resp.text().await;
                     if status == StatusCode::FORBIDDEN {
                         // Access denied. Stop retrying.
-                        error!("Failed to send logs to datadog because access was rejected. Is the API key invalid?");
+                        error!(
+                            "Failed to send logs to Datadog: Access denied. Please verify that your API key is valid."
+                        );
                         return Ok(());
                     }
                     if status == 202 {

--- a/bottlecap/src/logs/flusher.rs
+++ b/bottlecap/src/logs/flusher.rs
@@ -128,7 +128,8 @@ impl Flusher {
                     let status = resp.status();
                     _ = resp.text().await;
                     if status == StatusCode::FORBIDDEN {
-                        error!("No more retries as the access was rejected");
+                        // Access denied. Stop retrying.
+                        error!("Failed to send logs to datadog because access was rejected. Is the API key invalid?");
                         return Ok(());
                     }
                     if status == 202 {


### PR DESCRIPTION
## Problem
When logs fail to be sent to Datadog, the extension prints an error:
> No more retries as the access was rejected

which I think can be more clear.

<img width="709" height="305" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/6eae0497-8b24-48d0-a192-5215c6e1560f" />


## This PR
Change the error message to:
> Failed to send logs to datadog because access was rejected. Is the API key invalid?