### PR TITLE
fix(images): build to use `COPY --mount`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,1 @@
-/.layers/
 /bottlecap/target/


### PR DESCRIPTION
# What?

I wrongly used a base image in #798, but I want to keep it as a scratch

It just looks cleaner