### PR TITLE
fix(aap): stop crashing on .NET runtimes by not rerouting on wrapper

### DIFF
--- a/scripts/datadog_wrapper
+++ b/scripts/datadog_wrapper
@@ -21,13 +21,17 @@ DD_SERVERLESS_APPSEC_ENABLED=$(echo "$DD_SERVERLESS_APPSEC_ENABLED" | tr '[:uppe
 
 if [ "$DD_EXPERIMENTAL_ENABLE_PROXY" == "true" ] || [[ "$DD_SERVERLESS_APPSEC_ENABLED" =~ ^(1|t|true)$ ]]
 then
-  debug_log "Enabling Datadog's Runtime API proxy"
-  debug_log "The original AWS_LAMBDA_RUNTIME_API value is $AWS_LAMBDA_RUNTIME_API"
+  if [[ "$AWS_EXECUTION_ENV" == *"dotnet"* ]]; then
+    debug_log "Skipping proxy rerouting for .NET functions due to runtime issue, LWA and AAP won't work correctly."
+  else
+    debug_log "Enabling Datadog's Runtime API proxy"
+    debug_log "The original AWS_LAMBDA_RUNTIME_API value is $AWS_LAMBDA_RUNTIME_API"
 
-  # Replace the Runtime API address with the proxy address of the extension
-  export AWS_LAMBDA_RUNTIME_API="127.0.0.1:9000"
+    # Replace the Runtime API address with the proxy address of the extension
+    export AWS_LAMBDA_RUNTIME_API="127.0.0.1:9000"
 
-  debug_log "Rerouting AWS_LAMBDA_RUNTIME_API to the Datadog extension at $AWS_LAMBDA_RUNTIME_API"
+    debug_log "Rerouting AWS_LAMBDA_RUNTIME_API to the Datadog extension at $AWS_LAMBDA_RUNTIME_API"
+  fi
 fi
 
 if [[ "$DD_SERVERLESS_APPSEC_ENABLED" =~ ^(1|t|true)$ ]]


### PR DESCRIPTION
# What?

Disable AAP for .NET runtimes, AAP and LWA won't work correctly for .NET runtimes, proxying still gets enabled, it's just not used because we don't reroute.

# Motivation

Rust proxy lowercases headers based on the standard for HTTP, most runtimes don't care about this, besides .NET.

This has been fixed in https://github.com/aws/aws-lambda-dotnet/pull/2094

But it's yet to be released, so the issue: https://github.com/aws/aws-lambda-dotnet/issues/2093 remains open