### PR TITLE
fix(aap): use `dynamic` feature in `libddwaf`

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -1921,7 +1921,7 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 [[package]]
 name = "libddwaf"
 version = "1.27.0"
-source = "git+https://github.com/DataDog/libddwaf-rust?rev=91a8332d0c4d642b4149cb8d17b385b057bd96ff#91a8332d0c4d642b4149cb8d17b385b057bd96ff"
+source = "git+https://github.com/DataDog/libddwaf-rust?rev=1d57bf0ca49782723e556ba327ee7f378978aaa7#1d57bf0ca49782723e556ba327ee7f378978aaa7"
 dependencies = [
  "libddwaf-sys",
  "serde",
@@ -1930,7 +1930,7 @@ dependencies = [
 [[package]]
 name = "libddwaf-sys"
 version = "1.27.0"
-source = "git+https://github.com/DataDog/libddwaf-rust?rev=91a8332d0c4d642b4149cb8d17b385b057bd96ff#91a8332d0c4d642b4149cb8d17b385b057bd96ff"
+source = "git+https://github.com/DataDog/libddwaf-rust?rev=1d57bf0ca49782723e556ba327ee7f378978aaa7#1d57bf0ca49782723e556ba327ee7f378978aaa7"
 dependencies = [
  "bindgen 0.72.0",
  "flate2",
@@ -1943,6 +1943,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tracing",
+ "zstd",
 ]
 
 [[package]]

--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -1920,8 +1920,8 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libddwaf"
-version = "1.26.0"
-source = "git+https://github.com/DataDog/libddwaf-rust?rev=89c693078d392e344b594281c1e8f9f3f94685c0#89c693078d392e344b594281c1e8f9f3f94685c0"
+version = "1.27.0"
+source = "git+https://github.com/DataDog/libddwaf-rust?rev=91a8332d0c4d642b4149cb8d17b385b057bd96ff#91a8332d0c4d642b4149cb8d17b385b057bd96ff"
 dependencies = [
  "libddwaf-sys",
  "serde",
@@ -1929,16 +1929,20 @@ dependencies = [
 
 [[package]]
 name = "libddwaf-sys"
-version = "1.26.0"
-source = "git+https://github.com/DataDog/libddwaf-rust?rev=89c693078d392e344b594281c1e8f9f3f94685c0#89c693078d392e344b594281c1e8f9f3f94685c0"
+version = "1.27.0"
+source = "git+https://github.com/DataDog/libddwaf-rust?rev=91a8332d0c4d642b4149cb8d17b385b057bd96ff#91a8332d0c4d642b4149cb8d17b385b057bd96ff"
 dependencies = [
  "bindgen 0.72.0",
  "flate2",
  "hyper-rustls",
+ "lazy_static",
  "libc",
+ "libloading",
  "reqwest",
  "rustls",
  "tar",
+ "tempfile",
+ "tracing",
 ]
 
 [[package]]

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -64,7 +64,7 @@ datadog-trace-normalization = { git = "https://github.com/DataDog/libdatadog",  
 datadog-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "9405db9cb4ef733f3954c3ee77ce71a502e98e50"  }
 dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "d131de8419c191ce21c91bb30b5915c4d8a2cc5a", default-features = false }
 datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "d131de8419c191ce21c91bb30b5915c4d8a2cc5a", default-features = false }
-libddwaf = { version = "1.26.0", git = "https://github.com/DataDog/libddwaf-rust", rev = "91a8332d0c4d642b4149cb8d17b385b057bd96ff", default-features = false, features = ["serde", "dynamic"] }
+libddwaf = { version = "1.26.0", git = "https://github.com/DataDog/libddwaf-rust", rev = "1d57bf0ca49782723e556ba327ee7f378978aaa7", default-features = false, features = ["serde", "dynamic"] }
 
 [dev-dependencies]
 figment = { version = "0.10", default-features = false, features = ["yaml", "env", "test"] }

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -64,7 +64,7 @@ datadog-trace-normalization = { git = "https://github.com/DataDog/libdatadog",  
 datadog-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "9405db9cb4ef733f3954c3ee77ce71a502e98e50"  }
 dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "d131de8419c191ce21c91bb30b5915c4d8a2cc5a", default-features = false }
 datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "d131de8419c191ce21c91bb30b5915c4d8a2cc5a", default-features = false }
-libddwaf = { version = "1.26.0", git = "https://github.com/DataDog/libddwaf-rust", rev = "89c693078d392e344b594281c1e8f9f3f94685c0", default-features = false, features = ["serde", "static"] }
+libddwaf = { version = "1.26.0", git = "https://github.com/DataDog/libddwaf-rust", rev = "91a8332d0c4d642b4149cb8d17b385b057bd96ff", default-features = false, features = ["serde", "dynamic"] }
 
 [dev-dependencies]
 figment = { version = "0.10", default-features = false, features = ["yaml", "env", "test"] }

--- a/bottlecap/LICENSE-3rdparty.csv
+++ b/bottlecap/LICENSE-3rdparty.csv
@@ -106,6 +106,7 @@ lazy_static,https://github.com/rust-lang-nursery/lazy-static.rs,MIT OR Apache-2.
 libc,https://github.com/rust-lang/libc,MIT OR Apache-2.0,The Rust Project Developers
 libddwaf,https://github.com/DataDog/libddwaf-rust,Apache-2.0,"DataDog, Inc. <support@datadoghq.com>"
 libddwaf-sys,https://github.com/DataDog/libddwaf-rust,Apache-2.0,"DataDog, Inc. <support@datadoghq.com>"
+libloading,https://github.com/nagisa/rust_libloading,ISC,Simonas Kazlauskas <libloading@kazlauskas.me>
 linux-raw-sys,https://github.com/sunfishcode/linux-raw-sys,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Dan Gohman <dev@sunfishcode.online>
 litemap,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
 lock_api,https://github.com/Amanieu/parking_lot,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>


### PR DESCRIPTION
# What?

Uses latest version of `libddwaf` in order to dynamically load the binary

# Motivation

Avoid having performance regression for all customers