### PR TITLE
fix(aap): fallback on .NET runtimes

### DIFF
--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -32,6 +32,7 @@ use crate::config::{
     trace_propagation_style::TracePropagationStyle,
     yaml::YamlConfigSource,
 };
+use crate::proc::has_dotnet_binary;
 
 /// Helper macro to merge Option<String> fields to String fields
 ///
@@ -448,6 +449,15 @@ fn fallback(config: &Config) -> Result<(), ConfigError> {
         log_fallback_reason("extension_version");
         return Err(ConfigError::UnsupportedField(
             "extension_version".to_string(),
+        ));
+    }
+
+    // ASM / .NET
+    // todo(duncanista): Remove once the .NET runtime is fixed
+    if config.serverless_appsec_enabled && has_dotnet_binary() {
+        log_fallback_reason("serverless_appsec_enabled_dotnet");
+        return Err(ConfigError::UnsupportedField(
+            "serverless_appsec_enabled_dotnet".to_string(),
         ));
     }
 

--- a/bottlecap/src/proc/constants.rs
+++ b/bottlecap/src/proc/constants.rs
@@ -3,6 +3,7 @@ pub const PROC_STAT_PATH: &str = "/proc/stat";
 pub const PROC_UPTIME_PATH: &str = "/proc/uptime";
 pub const PROC_PATH: &str = "/proc";
 pub const ETC_PATH: &str = "/etc/os-release";
+pub const VAR_LANG_BIN_PATH: &str = "/var/lang/bin";
 
 pub const LAMBDA_NETWORK_INTERFACE: &str = "vinternal_1";
 pub const LAMBDA_RUNTIME_NETWORK_INTERFACE: &str = "vint_runtime";

--- a/bottlecap/src/proc/mod.rs
+++ b/bottlecap/src/proc/mod.rs
@@ -9,10 +9,31 @@ use std::{
 
 use constants::{
     LAMBDA_NETWORK_INTERFACE, LAMBDA_RUNTIME_NETWORK_INTERFACE, PROC_NET_DEV_PATH, PROC_PATH,
-    PROC_STAT_PATH, PROC_UPTIME_PATH,
+    PROC_STAT_PATH, PROC_UPTIME_PATH, VAR_LANG_BIN_PATH,
 };
 use regex::Regex;
 use tracing::{debug, trace};
+
+#[must_use]
+pub fn has_dotnet_binary() -> bool {
+    match fs::read_dir(VAR_LANG_BIN_PATH) {
+        Ok(mut entries) => entries.any(|entry| match entry {
+            Ok(entry) => {
+                let file_name = entry.file_name();
+                let file_name_str = file_name.to_str().unwrap_or_default();
+                file_name_str.contains("dotnet")
+            }
+            Err(e) => {
+                debug!("Error reading VAR_LANG_BIN_PATH: {e}");
+                false
+            }
+        }),
+        Err(e) => {
+            debug!("Error reading VAR_LANG_BIN_PATH: {e}");
+            false
+        }
+    }
+}
 
 #[must_use]
 pub fn get_pid_list() -> Vec<i64> {

--- a/scripts/datadog_wrapper
+++ b/scripts/datadog_wrapper
@@ -21,17 +21,13 @@ DD_SERVERLESS_APPSEC_ENABLED=$(echo "$DD_SERVERLESS_APPSEC_ENABLED" | tr '[:uppe
 
 if [ "$DD_EXPERIMENTAL_ENABLE_PROXY" == "true" ] || [[ "$DD_SERVERLESS_APPSEC_ENABLED" =~ ^(1|t|true)$ ]]
 then
-  if [[ "$AWS_EXECUTION_ENV" == *"dotnet"* ]]; then
-    debug_log "Skipping proxy rerouting for .NET functions due to runtime issue, LWA and AAP won't work correctly."
-  else
-    debug_log "Enabling Datadog's Runtime API proxy"
-    debug_log "The original AWS_LAMBDA_RUNTIME_API value is $AWS_LAMBDA_RUNTIME_API"
+  debug_log "Enabling Datadog's Runtime API proxy"
+  debug_log "The original AWS_LAMBDA_RUNTIME_API value is $AWS_LAMBDA_RUNTIME_API"
 
-    # Replace the Runtime API address with the proxy address of the extension
-    export AWS_LAMBDA_RUNTIME_API="127.0.0.1:9000"
+  # Replace the Runtime API address with the proxy address of the extension
+  export AWS_LAMBDA_RUNTIME_API="127.0.0.1:9000"
 
-    debug_log "Rerouting AWS_LAMBDA_RUNTIME_API to the Datadog extension at $AWS_LAMBDA_RUNTIME_API"
-  fi
+  debug_log "Rerouting AWS_LAMBDA_RUNTIME_API to the Datadog extension at $AWS_LAMBDA_RUNTIME_API"
 fi
 
 if [[ "$DD_SERVERLESS_APPSEC_ENABLED" =~ ^(1|t|true)$ ]]


### PR DESCRIPTION
# What?

Fallbacks on .NET runtimes by checking the `dotnet` binary presence in `/var/lang/bin`

# Motivation

Provide a fallback + appsec for .NET until runtime is fixed

# Notes

Reverts #803 