### PR TITLE
fix(inferred-spans): refactor and decouple span inferrer

### DIFF
--- a/bottlecap/src/http.rs
+++ b/bottlecap/src/http.rs
@@ -1,14 +1,14 @@
 use crate::config;
 use axum::{
     extract::{FromRequest, Request},
-    http::{self, StatusCode},
+    http::{self, HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
 use bytes::Bytes;
 use core::time::Duration;
 use datadog_fips::reqwest_adapter::create_reqwest_client_builder;
-use std::error::Error;
 use std::sync::Arc;
+use std::{collections::HashMap, error::Error};
 use tracing::error;
 
 #[must_use]
@@ -67,4 +67,17 @@ pub async fn extract_request_body(
     let bytes = Bytes::from_request(Request::from_parts(parts.clone(), body), &()).await?;
 
     Ok((parts, bytes))
+}
+
+#[must_use]
+pub fn headers_to_map(headers: &HeaderMap) -> HashMap<String, String> {
+    headers
+        .iter()
+        .map(|(k, v)| {
+            (
+                k.as_str().to_string(),
+                v.to_str().unwrap_or_default().to_string(),
+            )
+        })
+        .collect()
 }

--- a/bottlecap/src/lifecycle/invocation/context.rs
+++ b/bottlecap/src/lifecycle/invocation/context.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use datadog_trace_protobuf::pb::Span;
+use serde_json::Value;
 use tracing::debug;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -127,7 +128,7 @@ pub struct ContextBuffer {
 
 struct UniversalInstrumentationData {
     headers: HashMap<String, String>,
-    payload: Vec<u8>,
+    payload_value: Value,
 }
 
 impl Default for ContextBuffer {
@@ -225,12 +226,14 @@ impl ContextBuffer {
     pub fn pair_invoke_event(
         &mut self,
         request_id: &str,
-    ) -> Option<(HashMap<String, String>, Vec<u8>)> {
-        if let Some(UniversalInstrumentationData { headers, payload }) =
-            self.universal_instrumentation_start_events.pop_front()
+    ) -> Option<(HashMap<String, String>, Value)> {
+        if let Some(UniversalInstrumentationData {
+            headers,
+            payload_value,
+        }) = self.universal_instrumentation_start_events.pop_front()
         {
             // Bad scenario, we found an `UniversalInstrumentationStart`
-            Some((headers, payload))
+            Some((headers, payload_value))
         } else {
             // `UniversalInstrumentationStart` event hasn't occurred yet, this is good,
             // push the Invoke event to the queue and return `None`
@@ -246,7 +249,7 @@ impl ContextBuffer {
     pub fn pair_universal_instrumentation_start_event(
         &mut self,
         headers: &HashMap<String, String>,
-        payload: &[u8],
+        payload_value: &Value,
     ) -> Option<String> {
         if let Some(request_id) = self.invoke_events_request_ids.pop_front() {
             // Bad scenario, we found an `UniversalInstrumentationStart`
@@ -257,7 +260,7 @@ impl ContextBuffer {
             self.universal_instrumentation_start_events
                 .push_back(UniversalInstrumentationData {
                     headers: headers.clone(),
-                    payload: payload.to_vec(),
+                    payload_value: payload_value.clone(),
                 });
             None
         }
@@ -269,7 +272,7 @@ impl ContextBuffer {
     pub fn pair_universal_instrumentation_end_event(
         &mut self,
         headers: &HashMap<String, String>,
-        payload: &[u8],
+        payload_value: &Value,
     ) -> Option<String> {
         if let Some(request_id) = self.platform_runtime_done_events_request_ids.pop_front() {
             // Bad scenario, we found a `PlatformRuntimeDone`
@@ -280,7 +283,7 @@ impl ContextBuffer {
             self.universal_instrumentation_end_events
                 .push_back(UniversalInstrumentationData {
                     headers: headers.clone(),
-                    payload: payload.to_vec(),
+                    payload_value: payload_value.clone(),
                 });
             None
         }
@@ -292,12 +295,14 @@ impl ContextBuffer {
     pub fn pair_platform_runtime_done_event(
         &mut self,
         request_id: &str,
-    ) -> Option<(HashMap<String, String>, Vec<u8>)> {
-        if let Some(UniversalInstrumentationData { headers, payload }) =
-            self.universal_instrumentation_end_events.pop_front()
+    ) -> Option<(HashMap<String, String>, Value)> {
+        if let Some(UniversalInstrumentationData {
+            headers,
+            payload_value,
+        }) = self.universal_instrumentation_end_events.pop_front()
         {
             // Good scenario, we found an `UniversalInstrumentationEnd`
-            Some((headers, payload))
+            Some((headers, payload_value))
         } else {
             // `UniversalInstrumentationEnd` hasn't occurred yet, this is bad,
             // push the `PlatformRuntimeDone` event to the queue and return `None`
@@ -423,6 +428,7 @@ impl ContextBuffer {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use crate::proc::{CPUData, NetworkData};
+    use serde_json::json;
     use std::collections::HashMap;
     use tokio::sync::watch;
 
@@ -617,14 +623,14 @@ mod tests {
         let request_id = "test-request-1".to_string();
         let mut headers = HashMap::new();
         headers.insert("test-header".to_string(), "test-value".to_string());
-        let payload = vec![1, 2, 3];
+        let payload = json!({ "test": "payload" });
 
         // Test case 1: UniversalInstrumentationStart arrives before Invoke
         buffer
             .universal_instrumentation_start_events
             .push_back(UniversalInstrumentationData {
                 headers: headers.clone(),
-                payload: payload.clone(),
+                payload_value: payload.clone(),
             });
 
         // When Invoke arrives, it should pair with the existing UniversalInstrumentationStart
@@ -651,7 +657,7 @@ mod tests {
         let request_id = "test-request-1".to_string();
         let mut headers = HashMap::new();
         headers.insert("test-header".to_string(), "test-value".to_string());
-        let payload = vec![1, 2, 3];
+        let payload = json!({ "test": "payload" });
 
         // Test case 1: Invoke arrives before UniversalInstrumentationStart
         buffer
@@ -672,7 +678,7 @@ mod tests {
             .front()
             .unwrap();
         assert_eq!(stored_event.headers, headers);
-        assert_eq!(stored_event.payload, payload);
+        assert_eq!(stored_event.payload_value, payload);
     }
 
     #[test]
@@ -681,7 +687,7 @@ mod tests {
         let request_id = "test-request-1".to_string();
         let mut headers = HashMap::new();
         headers.insert("test-header".to_string(), "test-value".to_string());
-        let payload = vec![1, 2, 3];
+        let payload = json!({ "test": "payload" });
 
         // Test case 1: PlatformRuntimeDone arrives before UniversalInstrumentationEnd
         buffer
@@ -699,7 +705,7 @@ mod tests {
         assert_eq!(buffer.universal_instrumentation_end_events.len(), 1);
         let stored_event = buffer.universal_instrumentation_end_events.front().unwrap();
         assert_eq!(stored_event.headers, headers);
-        assert_eq!(stored_event.payload, payload);
+        assert_eq!(stored_event.payload_value, payload);
     }
 
     #[test]
@@ -708,14 +714,14 @@ mod tests {
         let request_id = "test-request-1".to_string();
         let mut headers = HashMap::new();
         headers.insert("test-header".to_string(), "test-value".to_string());
-        let payload = vec![1, 2, 3];
+        let payload = json!({ "test": "payload" });
 
         // Test case 1: UniversalInstrumentationEnd arrives before PlatformRuntimeDone
         buffer
             .universal_instrumentation_end_events
             .push_back(UniversalInstrumentationData {
                 headers: headers.clone(),
-                payload: payload.clone(),
+                payload_value: payload.clone(),
             });
 
         // When PlatformRuntimeDone arrives, it should pair with the existing UniversalInstrumentationEnd
@@ -745,7 +751,7 @@ mod tests {
         let request_id = "test-request-1".to_string();
         let mut headers = HashMap::new();
         headers.insert("test-header".to_string(), "test-value".to_string());
-        let payload = vec![1, 2, 3];
+        let payload = json!({ "test": "payload" });
 
         // Test the complete flow with events arriving in different orders
         // Case 1: Events arrive in reverse order
@@ -753,7 +759,7 @@ mod tests {
             .universal_instrumentation_end_events
             .push_back(UniversalInstrumentationData {
                 headers: headers.clone(),
-                payload: payload.clone(),
+                payload_value: payload.clone(),
             });
         buffer
             .platform_runtime_done_events_request_ids

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -8,15 +8,17 @@ use chrono::{DateTime, Utc};
 use datadog_trace_protobuf::pb::Span;
 use datadog_trace_utils::tracer_header_tags;
 use dogstatsd::aggregator::Aggregator as MetricsAggregator;
-use serde_json::{Value, json};
+use serde_json::Value;
 use tokio::sync::watch;
 use tracing::{debug, warn};
 
 use crate::{
     config::{self, aws::AwsConfig},
     lifecycle::invocation::{
-        base64_to_string, context::Context, context::ContextBuffer, context::ReparentingInfo,
-        create_empty_span, generate_span_id, get_metadata_from_value, span_inferrer::SpanInferrer,
+        base64_to_string,
+        context::{Context, ContextBuffer, ReparentingInfo},
+        create_empty_span, generate_span_id, get_metadata_from_value,
+        span_inferrer::{self, SpanInferrer},
     },
     metrics::enhanced::lambda::{EnhancedMetricData, Lambda as EnhancedMetrics},
     proc::{
@@ -58,7 +60,7 @@ pub struct Processor {
     /// extract trace context if available.
     inferrer: SpanInferrer,
     /// Propagator to extract span context from carriers.
-    propagator: DatadogCompositePropagator,
+    propagator: Arc<DatadogCompositePropagator>,
     /// Helper class to send enhanced metrics.
     enhanced_metrics: EnhancedMetrics,
     /// AWS configuration from the Lambda environment.
@@ -89,6 +91,7 @@ impl Processor {
         config: Arc<config::Config>,
         aws_config: Arc<AwsConfig>,
         metrics_aggregator: Arc<Mutex<MetricsAggregator>>,
+        propagator: Arc<DatadogCompositePropagator>,
     ) -> Self {
         let resource = tags_provider
             .get_canonical_resource_name()
@@ -99,14 +102,10 @@ impl Processor {
             "aws.lambda",
             config.trace_aws_service_representation_enabled,
         );
-        let propagator = DatadogCompositePropagator::new(Arc::clone(&config));
 
         Processor {
             context_buffer: ContextBuffer::default(),
-            inferrer: SpanInferrer::new(
-                config.service_mapping.clone(),
-                config.trace_aws_service_representation_enabled,
-            ),
+            inferrer: SpanInferrer::new(Arc::clone(&config)),
             propagator,
             enhanced_metrics: EnhancedMetrics::new(metrics_aggregator, Arc::clone(&config)),
             aws_config,
@@ -167,14 +166,10 @@ impl Processor {
         self.enhanced_metrics.set_invoked_received();
 
         // If `UniversalInstrumentationStart` event happened first, process it
-        if let Some((headers, payload)) = self.context_buffer.pair_invoke_event(&request_id) {
-            let payload_value =
-                serde_json::from_slice::<Value>(&payload).unwrap_or_else(|_| json!({}));
+        if let Some((headers, payload_value)) = self.context_buffer.pair_invoke_event(&request_id) {
             // Infer span
             self.inferrer.infer_span(&payload_value, &self.aws_config);
-            let span_context = self.extract_span_context(&headers, &payload_value);
-
-            self.process_on_universal_instrumentation_start(request_id, payload, span_context);
+            self.process_on_universal_instrumentation_start(request_id, headers, payload_value);
         }
     }
 
@@ -594,44 +589,32 @@ impl Processor {
     pub fn on_universal_instrumentation_start(
         &mut self,
         headers: HashMap<String, String>,
-        payload: Vec<u8>,
-    ) -> Option<SpanContext> {
+        payload_value: Value,
+    ) {
         self.tracer_detected = true;
 
-        let payload_value = serde_json::from_slice::<Value>(&payload).unwrap_or_else(|_| json!({}));
-        // Infer span
-        // todo(jordan): `infer_span` needs to be called before `extract_span_context`,
-        // this is not ideal, as they are separate operations and should not depend on each other.
         self.inferrer.infer_span(&payload_value, &self.aws_config);
-        let span_context = self.extract_span_context(&headers, &payload_value);
 
         // If `Invoke` event happened first, process right away
         if let Some(request_id) = self
             .context_buffer
-            .pair_universal_instrumentation_start_event(&headers, &payload)
+            .pair_universal_instrumentation_start_event(&headers, &payload_value)
         {
-            self.process_on_universal_instrumentation_start(
-                request_id,
-                payload,
-                span_context.clone(),
-            );
+            self.process_on_universal_instrumentation_start(request_id, headers, payload_value);
         }
-
-        span_context
     }
 
     fn process_on_universal_instrumentation_start(
         &mut self,
         request_id: String,
-        payload: Vec<u8>,
-        span_context: Option<SpanContext>,
+        headers: HashMap<String, String>,
+        payload_value: Value,
     ) {
         let Some(context) = self.context_buffer.get_mut(&request_id) else {
             debug!("Cannot process on invocation start, no context for request_id: {request_id}");
             return;
         };
 
-        let payload_value = serde_json::from_slice::<Value>(&payload).unwrap_or_else(|_| json!({}));
         // Tag the invocation span with the request payload
         if self.config.capture_lambda_payload {
             let metadata = get_metadata_from_value(
@@ -643,7 +626,8 @@ impl Processor {
             context.invocation_span.meta.extend(metadata);
         }
 
-        context.extracted_span_context = span_context;
+        context.extracted_span_context =
+            Self::extract_span_context(&headers, &payload_value, Arc::clone(&self.propagator));
 
         // Set the extracted trace context to the spans
         if let Some(sc) = &context.extracted_span_context {
@@ -747,23 +731,25 @@ impl Processor {
         ctx_to_send
     }
 
-    fn extract_span_context(
-        &self,
+    pub fn extract_span_context(
         headers: &HashMap<String, String>,
         payload_value: &Value,
+        propagator: Arc<impl Propagator>,
     ) -> Option<SpanContext> {
-        if let Some(sc) = self.inferrer.get_span_context(&self.propagator) {
+        if let Some(sc) =
+            span_inferrer::extract_span_context(payload_value, Arc::clone(&propagator))
+        {
             return Some(sc);
         }
 
         if let Some(payload_headers) = payload_value.get("headers") {
-            if let Some(sc) = self.propagator.extract(payload_headers) {
+            if let Some(sc) = propagator.extract(payload_headers) {
                 debug!("Extracted trace context from event headers");
                 return Some(sc);
             }
         }
 
-        if let Some(sc) = self.propagator.extract(headers) {
+        if let Some(sc) = propagator.extract(headers) {
             debug!("Extracted trace context from headers");
             return Some(sc);
         }
@@ -776,14 +762,14 @@ impl Processor {
     pub fn on_universal_instrumentation_end(
         &mut self,
         headers: HashMap<String, String>,
-        payload: Vec<u8>,
+        payload_value: Value,
     ) {
         // If `PlatformRuntimeDone` event happened first, process
         if let Some(request_id) = self
             .context_buffer
-            .pair_universal_instrumentation_end_event(&headers, &payload)
+            .pair_universal_instrumentation_end_event(&headers, &payload_value)
         {
-            self.process_on_universal_instrumentation_end(request_id, headers, payload);
+            self.process_on_universal_instrumentation_end(request_id, headers, payload_value);
         }
     }
 
@@ -791,14 +777,12 @@ impl Processor {
         &mut self,
         request_id: String,
         headers: HashMap<String, String>,
-        payload: Vec<u8>,
+        payload_value: Value,
     ) {
         let Some(context) = self.context_buffer.get_mut(&request_id) else {
             debug!("Cannot process on invocation end, no context for request_id: {request_id}");
             return;
         };
-
-        let payload_value = serde_json::from_slice::<Value>(&payload).unwrap_or_else(|_| json!({}));
 
         // Tag the invocation span with the request payload
         if self.config.capture_lambda_payload {
@@ -976,6 +960,7 @@ mod tests {
     use base64::{Engine, engine::general_purpose::STANDARD};
     use dogstatsd::aggregator::Aggregator;
     use dogstatsd::metric::EMPTY_TAGS;
+    use serde_json::json;
 
     fn setup() -> Processor {
         let aws_config = Arc::new(AwsConfig {
@@ -1003,7 +988,14 @@ mod tests {
             Aggregator::new(EMPTY_TAGS, 1024).expect("failed to create aggregator"),
         ));
 
-        Processor::new(tags_provider, config, aws_config, metrics_aggregator)
+        let propagator = Arc::new(DatadogCompositePropagator::new(Arc::clone(&config)));
+        Processor::new(
+            tags_provider,
+            config,
+            aws_config,
+            metrics_aggregator,
+            propagator,
+        )
     }
 
     #[test]
@@ -1077,7 +1069,7 @@ mod tests {
         let request_id = String::from("request_id");
         p.context_buffer.start_context(&request_id, Span::default());
 
-        p.process_on_universal_instrumentation_end(request_id.clone(), headers, vec![]);
+        p.process_on_universal_instrumentation_end(request_id.clone(), headers, json!({}));
 
         let context = p
             .context_buffer
@@ -1109,7 +1101,7 @@ mod tests {
         let request_id = String::from("request_id");
         p.context_buffer.start_context(&request_id, Span::default());
 
-        p.process_on_universal_instrumentation_end(request_id.clone(), headers, vec![]);
+        p.process_on_universal_instrumentation_end(request_id.clone(), headers, json!({}));
 
         let context = p.context_buffer.get(&request_id).unwrap();
 
@@ -1134,7 +1126,7 @@ mod tests {
         let request_id = String::from("request_id");
         p.context_buffer.start_context(&request_id, Span::default());
 
-        p.process_on_universal_instrumentation_end(request_id.clone(), headers, vec![]);
+        p.process_on_universal_instrumentation_end(request_id.clone(), headers, json!({}));
 
         let context = p.context_buffer.get(&request_id).unwrap();
 
@@ -1169,10 +1161,11 @@ mod tests {
         let request_id = String::from("request_id");
         p.context_buffer.start_context(&request_id, Span::default());
         p.context_buffer.add_start_time(&request_id, 1);
+        let parsed_response = serde_json::from_str(response).unwrap();
         p.process_on_universal_instrumentation_end(
             request_id.clone(),
             HashMap::new(),
-            response.as_bytes().to_vec(),
+            parsed_response,
         );
 
         let context = p.context_buffer.get(&request_id).unwrap();

--- a/bottlecap/src/lifecycle/invocation/span_inferrer.rs
+++ b/bottlecap/src/lifecycle/invocation/span_inferrer.rs
@@ -564,7 +564,9 @@ mod tests {
             "Should have event source in trigger tags"
         );
         assert_eq!(
-            trigger_tags.get("function_trigger.event_source").expect("Should have event source"),
+            trigger_tags
+                .get("function_trigger.event_source")
+                .expect("Should have event source"),
             "sqs",
             "Should have SQS as event source"
         );

--- a/bottlecap/src/lifecycle/invocation/span_inferrer.rs
+++ b/bottlecap/src/lifecycle/invocation/span_inferrer.rs
@@ -447,7 +447,7 @@ mod tests {
                 "routeKey": "GET /httpapi/get",
                 "stage": "$default",
                 "time": "09/Sep/2021:18:31:23 +0000",
-                "timeEpoch": 1631212283738_i64
+                "timeEpoch": 1_631_212_283_738_i64
             },
             "isBase64Encoded": false
         });
@@ -558,13 +558,13 @@ mod tests {
         );
 
         // Verify the trigger tags contain the expected SQS information
-        let trigger_tags = inferrer.trigger_tags.unwrap();
+        let trigger_tags = inferrer.trigger_tags.expect("Should have trigger tags");
         assert!(
             trigger_tags.contains_key("function_trigger.event_source"),
             "Should have event source in trigger tags"
         );
         assert_eq!(
-            trigger_tags.get("function_trigger.event_source").unwrap(),
+            trigger_tags.get("function_trigger.event_source").expect("Should have event source"),
             "sqs",
             "Should have SQS as event source"
         );

--- a/bottlecap/src/lifecycle/invocation/span_inferrer.rs
+++ b/bottlecap/src/lifecycle/invocation/span_inferrer.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use datadog_trace_protobuf::pb::Span;
 use serde_json::Value;
 use tracing::debug;
 
+use crate::config::Config;
 use crate::lifecycle::invocation::triggers::IdentifiedTrigger;
 use crate::traces::span_pointers::SpanPointer;
 use crate::traces::{context::SpanContext, propagation::Propagator};
@@ -22,16 +24,13 @@ use crate::{
 
 #[derive(Default)]
 pub struct SpanInferrer {
-    service_mapping: HashMap<String, String>,
-    aws_service_representation_enabled: bool,
+    config: Arc<Config>,
     // Span inferred from the Lambda incoming request payload
     pub inferred_span: Option<Span>,
     // Nested span inferred from the Lambda incoming request payload
     pub wrapped_inferred_span: Option<Span>,
     // If the inferred span is async
     is_async_span: bool,
-    // Carrier to extract the span context from
-    carrier: Option<HashMap<String, String>>,
     // Generated Span Context from Step Functions or context taken from `AWSTraceHeader` when java->sqs->java
     generated_span_context: Option<SpanContext>,
     // Tags generated from the trigger
@@ -42,20 +41,153 @@ pub struct SpanInferrer {
 
 impl SpanInferrer {
     #[must_use]
-    pub fn new(
-        service_mapping: HashMap<String, String>,
-        aws_service_representation_enabled: bool,
-    ) -> Self {
+    pub fn new(config: Arc<Config>) -> Self {
         Self {
-            service_mapping,
-            aws_service_representation_enabled,
+            config,
             inferred_span: None,
             wrapped_inferred_span: None,
             is_async_span: false,
-            carrier: None,
             generated_span_context: None,
             trigger_tags: None,
             span_pointers: None,
+        }
+    }
+
+    #[must_use]
+    pub fn get_trigger_type(identified_trigger: IdentifiedTrigger) -> Option<Box<dyn Trigger>> {
+        match identified_trigger {
+            IdentifiedTrigger::APIGatewayHttpEvent(t) => Some(Box::new(t)),
+            IdentifiedTrigger::APIGatewayRestEvent(t) => Some(Box::new(t)),
+            IdentifiedTrigger::APIGatewayWebSocketEvent(t) => Some(Box::new(t)),
+            IdentifiedTrigger::ALBEvent(t) => Some(Box::new(t)),
+            IdentifiedTrigger::LambdaFunctionUrlEvent(t) => Some(Box::new(t)),
+            IdentifiedTrigger::MSKEvent(t) => Some(Box::new(t)),
+            IdentifiedTrigger::SqsRecord(t) => Some(Box::new(t)),
+            IdentifiedTrigger::SnsRecord(t) => Some(Box::new(t)),
+            IdentifiedTrigger::DynamoDbRecord(t) => Some(Box::new(t)),
+            IdentifiedTrigger::S3Record(t) => Some(Box::new(t)),
+            IdentifiedTrigger::EventBridgeEvent(t) => Some(Box::new(t)),
+            IdentifiedTrigger::KinesisRecord(t) => Some(Box::new(t)),
+            IdentifiedTrigger::StepFunctionEvent(t) => Some(Box::new(t)),
+            IdentifiedTrigger::Unknown => None,
+        }
+    }
+
+    #[must_use]
+    pub fn should_enrich_span(identified_trigger: &IdentifiedTrigger) -> bool {
+        !matches!(
+            identified_trigger,
+            IdentifiedTrigger::ALBEvent(_)
+                | IdentifiedTrigger::StepFunctionEvent(_)
+                | IdentifiedTrigger::Unknown
+        )
+    }
+
+    fn get_wrapped_inferred_span(
+        identified_trigger: &IdentifiedTrigger,
+        inferred_span: &mut Span,
+        config: &Arc<Config>,
+    ) -> Option<Span> {
+        match identified_trigger {
+            IdentifiedTrigger::SqsRecord(t) => {
+                // Check for SNS event wrapped in the SQS body
+                if let Ok(sns_entity) = serde_json::from_str::<SnsEntity>(&t.body) {
+                    debug!("Found an SNS event wrapped in the SQS body");
+                    let mut wrapped_inferred_span = Span {
+                        span_id: generate_span_id(),
+                        ..Default::default()
+                    };
+
+                    let wrapped_trigger = SnsRecord {
+                        sns: sns_entity,
+                        event_subscription_arn: None,
+                    };
+                    wrapped_trigger.enrich_span(
+                        &mut wrapped_inferred_span,
+                        &config.service_mapping,
+                        config.trace_aws_service_representation_enabled,
+                    );
+                    inferred_span.meta.extend(wrapped_trigger.get_tags());
+
+                    wrapped_inferred_span.duration =
+                        inferred_span.start - wrapped_inferred_span.start;
+
+                    return Some(wrapped_inferred_span);
+                } else if let Ok(event_bridge_entity) =
+                    serde_json::from_str::<EventBridgeEvent>(&t.body)
+                {
+                    let mut wrapped_inferred_span = Span {
+                        span_id: generate_span_id(),
+                        ..Default::default()
+                    };
+
+                    event_bridge_entity.enrich_span(
+                        &mut wrapped_inferred_span,
+                        &config.service_mapping,
+                        config.trace_aws_service_representation_enabled,
+                    );
+                    inferred_span.meta.extend(event_bridge_entity.get_tags());
+
+                    wrapped_inferred_span.duration =
+                        inferred_span.start - wrapped_inferred_span.start;
+
+                    return Some(wrapped_inferred_span);
+                }
+
+                None
+            }
+            IdentifiedTrigger::SnsRecord(t) => {
+                if let Some(message) = &t.sns.message {
+                    if let Ok(event_bridge_wrapper_message) =
+                        serde_json::from_str::<EventBridgeEvent>(message)
+                    {
+                        let mut wrapped_inferred_span = Span {
+                            span_id: generate_span_id(),
+                            ..Default::default()
+                        };
+
+                        event_bridge_wrapper_message.enrich_span(
+                            &mut wrapped_inferred_span,
+                            &config.service_mapping,
+                            config.trace_aws_service_representation_enabled,
+                        );
+                        inferred_span
+                            .meta
+                            .extend(event_bridge_wrapper_message.get_tags());
+
+                        wrapped_inferred_span.duration =
+                            inferred_span.start - wrapped_inferred_span.start;
+
+                        return Some(wrapped_inferred_span);
+                    }
+                }
+
+                None
+            }
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    fn get_span_pointers(identified_trigger: &IdentifiedTrigger) -> Option<Vec<SpanPointer>> {
+        match identified_trigger {
+            IdentifiedTrigger::DynamoDbRecord(t) => t.get_span_pointers(),
+            IdentifiedTrigger::S3Record(t) => t.get_span_pointers(),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    fn should_skip_inferred_span(identified_trigger: &IdentifiedTrigger) -> bool {
+        match identified_trigger {
+            // There is no inferred span for ALB events
+            IdentifiedTrigger::ALBEvent(_) => true,
+            // There is no inferred span for Step Functions events
+            // unless the `SpanContext` is generated
+            IdentifiedTrigger::StepFunctionEvent(_) => {
+                extract_generated_span_context(identified_trigger).is_some()
+            }
+            _ => false,
         }
     }
 
@@ -68,201 +200,36 @@ impl SpanInferrer {
         self.inferred_span = None;
         self.wrapped_inferred_span = None;
         self.is_async_span = false;
-        self.carrier = None;
         self.generated_span_context = None;
         self.trigger_tags = None;
 
-        let mut trigger: Option<Box<dyn Trigger>> = None;
         let mut inferred_span = Span {
             span_id: generate_span_id(),
             ..Default::default()
         };
 
-        let mut is_step_function = false;
-        let mut is_alb_event = false;
+        let identified_trigger = IdentifiedTrigger::from_value(payload_value);
+        let should_enrich_span = Self::should_enrich_span(&identified_trigger);
+        let should_skip_inferred_span = Self::should_skip_inferred_span(&identified_trigger);
+        let wrapped_inferred_span =
+            Self::get_wrapped_inferred_span(&identified_trigger, &mut inferred_span, &self.config);
+        let span_pointers = Self::get_span_pointers(&identified_trigger);
 
-        match IdentifiedTrigger::from_value(payload_value) {
-            IdentifiedTrigger::APIGatewayHttpEvent(t) => {
-                t.enrich_span(
-                    &mut inferred_span,
-                    &self.service_mapping,
-                    self.aws_service_representation_enabled,
-                );
-                trigger = Some(Box::new(t));
-            }
-            IdentifiedTrigger::APIGatewayRestEvent(t) => {
-                t.enrich_span(
-                    &mut inferred_span,
-                    &self.service_mapping,
-                    self.aws_service_representation_enabled,
-                );
-                trigger = Some(Box::new(t));
-            }
-            IdentifiedTrigger::APIGatewayWebSocketEvent(t) => {
-                t.enrich_span(
-                    &mut inferred_span,
-                    &self.service_mapping,
-                    self.aws_service_representation_enabled,
-                );
-                trigger = Some(Box::new(t));
-            }
-            IdentifiedTrigger::ALBEvent(t) => {
-                is_alb_event = true;
-                trigger = Some(Box::new(t));
-            }
-            IdentifiedTrigger::LambdaFunctionUrlEvent(t) => {
-                t.enrich_span(
-                    &mut inferred_span,
-                    &self.service_mapping,
-                    self.aws_service_representation_enabled,
-                );
-                trigger = Some(Box::new(t));
-            }
-            IdentifiedTrigger::MSKEvent(t) => {
-                t.enrich_span(
-                    &mut inferred_span,
-                    &self.service_mapping,
-                    self.aws_service_representation_enabled,
-                );
-                trigger = Some(Box::new(t));
-            }
-            IdentifiedTrigger::SqsRecord(t) => {
-                t.enrich_span(
-                    &mut inferred_span,
-                    &self.service_mapping,
-                    self.aws_service_representation_enabled,
-                );
+        // Get trigger event type
+        let trigger = Self::get_trigger_type(identified_trigger);
 
-                self.generated_span_context = extract_trace_context_from_aws_trace_header(
-                    t.attributes.aws_trace_header.clone(),
-                );
-
-                // Check for SNS event wrapped in the SQS body
-                if let Ok(sns_entity) = serde_json::from_str::<SnsEntity>(&t.body) {
-                    debug!("Found an SNS event wrapped in the SQS body");
-                    let mut wrapped_inferred_span = Span {
-                        span_id: generate_span_id(),
-                        ..Default::default()
-                    };
-
-                    let wt = SnsRecord {
-                        sns: sns_entity,
-                        event_subscription_arn: None,
-                    };
-                    wt.enrich_span(
-                        &mut wrapped_inferred_span,
-                        &self.service_mapping,
-                        self.aws_service_representation_enabled,
-                    );
-                    inferred_span.meta.extend(wt.get_tags());
-
-                    wrapped_inferred_span.duration =
-                        inferred_span.start - wrapped_inferred_span.start;
-
-                    self.wrapped_inferred_span = Some(wrapped_inferred_span);
-                } else if let Ok(event_bridge_entity) =
-                    serde_json::from_str::<EventBridgeEvent>(&t.body)
-                {
-                    let mut wrapped_inferred_span = Span {
-                        span_id: generate_span_id(),
-                        ..Default::default()
-                    };
-
-                    event_bridge_entity.enrich_span(
-                        &mut wrapped_inferred_span,
-                        &self.service_mapping,
-                        self.aws_service_representation_enabled,
-                    );
-                    inferred_span.meta.extend(event_bridge_entity.get_tags());
-
-                    wrapped_inferred_span.duration =
-                        inferred_span.start - wrapped_inferred_span.start;
-
-                    self.wrapped_inferred_span = Some(wrapped_inferred_span);
-                };
-
-                trigger = Some(Box::new(t));
-            }
-            IdentifiedTrigger::SnsRecord(t) => {
-                t.enrich_span(
-                    &mut inferred_span,
-                    &self.service_mapping,
-                    self.aws_service_representation_enabled,
-                );
-
-                if let Some(message) = &t.sns.message {
-                    if let Ok(event_bridge_wrapper_message) =
-                        serde_json::from_str::<EventBridgeEvent>(message)
-                    {
-                        let mut wrapped_inferred_span = Span {
-                            span_id: generate_span_id(),
-                            ..Default::default()
-                        };
-
-                        event_bridge_wrapper_message.enrich_span(
-                            &mut wrapped_inferred_span,
-                            &self.service_mapping,
-                            self.aws_service_representation_enabled,
-                        );
-                        inferred_span
-                            .meta
-                            .extend(event_bridge_wrapper_message.get_tags());
-
-                        wrapped_inferred_span.duration =
-                            inferred_span.start - wrapped_inferred_span.start;
-
-                        self.wrapped_inferred_span = Some(wrapped_inferred_span);
-                    }
-                }
-
-                trigger = Some(Box::new(t));
-            }
-            IdentifiedTrigger::DynamoDbRecord(t) => {
-                t.enrich_span(
-                    &mut inferred_span,
-                    &self.service_mapping,
-                    self.aws_service_representation_enabled,
-                );
-                self.span_pointers = t.get_span_pointers();
-                trigger = Some(Box::new(t));
-            }
-            IdentifiedTrigger::S3Record(t) => {
-                t.enrich_span(
-                    &mut inferred_span,
-                    &self.service_mapping,
-                    self.aws_service_representation_enabled,
-                );
-                self.span_pointers = t.get_span_pointers();
-                trigger = Some(Box::new(t));
-            }
-            IdentifiedTrigger::EventBridgeEvent(t) => {
-                t.enrich_span(
-                    &mut inferred_span,
-                    &self.service_mapping,
-                    self.aws_service_representation_enabled,
-                );
-                trigger = Some(Box::new(t));
-            }
-            IdentifiedTrigger::KinesisRecord(t) => {
-                t.enrich_span(
-                    &mut inferred_span,
-                    &self.service_mapping,
-                    self.aws_service_representation_enabled,
-                );
-                trigger = Some(Box::new(t));
-            }
-            IdentifiedTrigger::StepFunctionEvent(t) => {
-                self.generated_span_context = Some(t.get_span_context());
-                trigger = Some(Box::new(t));
-                is_step_function = true;
-            }
-            IdentifiedTrigger::Unknown => {
-                debug!("Unable to infer span from payload: no matching trigger found");
-            }
-        };
-
-        // Inferred a trigger
         if let Some(t) = trigger {
+            if should_enrich_span {
+                t.enrich_span(
+                    &mut inferred_span,
+                    &self.config.service_mapping,
+                    self.config.trace_aws_service_representation_enabled,
+                );
+            }
+
+            self.wrapped_inferred_span = wrapped_inferred_span;
+            self.span_pointers = span_pointers;
+
             let mut trigger_tags = t.get_tags();
             trigger_tags.insert(
                 FUNCTION_TRIGGER_EVENT_SOURCE_ARN_TAG.to_string(),
@@ -270,11 +237,9 @@ impl SpanInferrer {
             );
 
             self.trigger_tags = Some(trigger_tags);
-            self.carrier = Some(t.get_carrier());
             self.is_async_span = t.is_async();
 
-            // For Step Functions & ALB, there is no inferred span
-            if is_alb_event || (is_step_function && self.generated_span_context.is_some()) {
+            if should_skip_inferred_span {
                 self.inferred_span = None;
             } else {
                 self.inferred_span = Some(inferred_span);
@@ -352,29 +317,6 @@ impl SpanInferrer {
         }
     }
 
-    /// Returns the span context from the inferred span if it exist.
-    ///
-    /// If the carrier is set, it will try to extract the span context,
-    /// otherwise it will return `None`.
-    ///
-    pub fn get_span_context(&self, propagator: &impl Propagator) -> Option<SpanContext> {
-        // Order matters here: check inferred span for trace context first, then fallback to generated span context.
-        // If the order is flipped, trace propagation will be broken when AWS Xray is enabled.
-        // https://github.com/DataDog/datadog-lambda-extension/pull/655
-        if let Some(sc) = self.carrier.as_ref().and_then(|c| propagator.extract(c)) {
-            debug!("Extracted trace context from inferred span");
-            return Some(sc);
-        }
-
-        // Step Functions `SpanContext` is deterministically generated
-        if self.generated_span_context.is_some() {
-            debug!("Returning generated span context");
-            return self.generated_span_context.clone();
-        }
-
-        None
-    }
-
     /// Returns a clone of the tags associated with the inferred span
     ///
     #[must_use]
@@ -383,30 +325,58 @@ impl SpanInferrer {
     }
 }
 
+pub fn extract_span_context(
+    payload_value: &Value,
+    propagator: Arc<impl Propagator>,
+) -> Option<SpanContext> {
+    let identified_trigger = IdentifiedTrigger::from_value(payload_value);
+    let generated_span_context = extract_generated_span_context(&identified_trigger);
+    let trigger = SpanInferrer::get_trigger_type(identified_trigger);
+
+    // Order matters here: check inferred span for trace context first, then fallback to generated span context.
+    // If the order is flipped, trace propagation will be broken when AWS Xray is enabled.
+    // https://github.com/DataDog/datadog-lambda-extension/pull/655
+    if let Some(t) = trigger {
+        if let Some(sc) = propagator.extract(&t.get_carrier()) {
+            debug!("Extracted trace context from inferred span");
+            return Some(sc);
+        }
+
+        // Step Functions `SpanContext` is deterministically generated
+        if let Some(generated_sc) = generated_span_context {
+            debug!("Returning generated span context");
+            return Some(generated_sc);
+        }
+    }
+
+    None
+}
+
+#[must_use]
+pub fn extract_generated_span_context(
+    identified_trigger: &IdentifiedTrigger,
+) -> Option<SpanContext> {
+    match identified_trigger {
+        IdentifiedTrigger::StepFunctionEvent(t) => Some(t.get_span_context()),
+        IdentifiedTrigger::SqsRecord(t) => {
+            extract_trace_context_from_aws_trace_header(t.attributes.aws_trace_header.clone())
+        }
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::traces::context::{Sampling, SpanContext};
     use crate::traces::propagation::text_map_propagator::DatadogHeaderPropagator;
     use serde_json::json;
-    use std::collections::HashMap;
     use std::sync::Arc;
     use std::time::Instant;
 
     use super::*;
 
-    fn test_context_source(
-        carrier: Option<HashMap<String, String>>,
-        generated_context: Option<SpanContext>,
-        expected_source: &str,
-    ) {
-        let inferrer = SpanInferrer {
-            carrier,
-            generated_span_context: generated_context,
-            ..SpanInferrer::default()
-        };
-
-        let propagator = DatadogHeaderPropagator;
-        let context = inferrer.get_span_context(&propagator);
+    fn test_context_source(payload: &Value, expected_source: &str) {
+        let propagator = Arc::new(DatadogHeaderPropagator);
+        let context = extract_span_context(payload, propagator);
 
         let context = context.expect("Should return a span context");
         match expected_source {
@@ -421,14 +391,10 @@ mod tests {
                 );
             }
             "generated" => {
-                assert_eq!(
-                    context.trace_id, 111_111_111,
-                    "Should have trace_id from generated context"
-                );
-                assert_eq!(
-                    context.span_id, 222_222_222,
-                    "Should have span_id from generated context"
-                );
+                // For Step Functions, the trace_id and span_id are deterministically generated
+                // based on the execution ID, so we can't predict exact values
+                assert!(context.trace_id > 0, "Should have a valid trace_id");
+                assert!(context.span_id > 0, "Should have a valid span_id");
             }
             "aws_trace_header" => {
                 assert_eq!(
@@ -446,49 +412,108 @@ mod tests {
 
     #[test]
     fn test_get_span_context_from_inferred_span() {
-        let carrier = HashMap::from([
-            ("x-datadog-trace-id".to_string(), "123456789".to_string()),
-            ("x-datadog-parent-id".to_string(), "987654321".to_string()),
-            ("x-datadog-sampling-priority".to_string(), "1".to_string()),
-        ]);
+        // Use the exact payload from the test file
+        let payload = json!({
+            "version": "2.0",
+            "routeKey": "GET /httpapi/get",
+            "rawPath": "/httpapi/get",
+            "rawQueryString": "",
+            "headers": {
+                "Accept": "*/*",
+                "Content-Length": "0",
+                "Host": "x02yirxc7a.execute-api.sa-east-1.amazonaws.com",
+                "User-Agent": "curl/7.64.1",
+                "X-amzn-trace-id": "Root=1-613a52fb-4c43cfc95e0241c1471bfa05",
+                "X-forwarded-for": "38.122.226.210",
+                "X-forwarded-port": "443",
+                "X-forwarded-proto": "https",
+                "X-datadog-trace-id": "123456789",
+                "X-datadog-parent-id": "987654321",
+                "X-datadog-sampling-priority": "1"
+            },
+            "requestContext": {
+                "accountId": "425362996713",
+                "apiId": "x02yirxc7a",
+                "domainName": "x02yirxc7a.execute-api.sa-east-1.amazonaws.com",
+                "domainPrefix": "x02yirxc7a",
+                "http": {
+                    "method": "GET",
+                    "path": "/httpapi/get",
+                    "protocol": "HTTP/1.1",
+                    "sourceIp": "38.122.226.210",
+                    "userAgent": "curl/7.64.1"
+                },
+                "requestId": "FaHnXjKCGjQEJ7A=",
+                "routeKey": "GET /httpapi/get",
+                "stage": "$default",
+                "time": "09/Sep/2021:18:31:23 +0000",
+                "timeEpoch": 1631212283738_i64
+            },
+            "isBase64Encoded": false
+        });
 
-        let generated_context = SpanContext {
-            trace_id: 111_111_111,
-            span_id: 222_222_222,
-            sampling: Some(Sampling {
-                priority: Some(1),
-                mechanism: None,
-            }),
-            origin: None,
-            tags: HashMap::new(),
-            links: Vec::new(),
-        };
-
-        // Should prefer inferred span context from carrier over generated context
-        test_context_source(Some(carrier), Some(generated_context), "inferred");
+        // Should extract trace context from inferred span
+        test_context_source(&payload, "inferred");
     }
 
     #[test]
     fn test_get_span_context_fallback_to_generated() {
-        let generated_context = SpanContext {
-            trace_id: 111_111_111,
-            span_id: 222_222_222,
-            sampling: Some(Sampling {
-                priority: Some(1),
-                mechanism: None,
-            }),
-            origin: None,
-            tags: HashMap::new(),
-            links: Vec::new(),
-        };
+        // Use the exact payload from the test file
+        let payload = json!({
+            "Execution": {
+                "Id": "arn:aws:states:us-east-1:425362996713:execution:agocsTestSF:bc9f281c-3daa-4e5a-9a60-471a3810bf44",
+                "Input": {},
+                "StartTime": "2024-07-30T19:55:52.976Z",
+                "Name": "bc9f281c-3daa-4e5a-9a60-471a3810bf44",
+                "RoleArn": "arn:aws:iam::425362996713:role/test-serverless-stepfunctions-dev-AgocsTestSFRole-tRkeFXScjyk4",
+                "RedriveCount": 0
+            },
+            "StateMachine": {
+                "Id": "arn:aws:states:us-east-1:425362996713:stateMachine:agocsTestSF",
+                "Name": "agocsTestSF"
+            },
+            "State": {
+                "Name": "agocsTest1",
+                "EnteredTime": "2024-07-30T19:55:53.018Z",
+                "RetryCount": 0
+            }
+        });
 
-        // Should fallback to generated context when no carrier exists
-        test_context_source(None, Some(generated_context), "generated");
+        // Should fallback to generated context for Step Functions
+        test_context_source(&payload, "generated");
     }
 
     #[test]
     fn test_java_sqs_aws_trace_header() {
-        let mut inferrer = SpanInferrer::default();
+        // Create a payload with AWSTraceHeader from Java->SQS->Java
+        let payload = json!({
+            "Records": [{
+                "messageId": "fde33907-bdf2-4e37-bb5b-f19c4f0e5ec2",
+                "receiptHandle": "test-receipt-handle",
+                "body": "Hello World",
+                "attributes": {
+                    "ApproximateReceiveCount": "1",
+                    "AWSTraceHeader": "Root=1-68029e8a-0000000035578e774943fd9d;Parent=76c040bdc454a7ac;Sampled=1",
+                    "SentTimestamp": "1745002122577",
+                    "SenderId": "AROAWGCM4HXUTNAMSZ533:nhulston-java-test-dev-main",
+                    "ApproximateFirstReceiveTimestamp": "1745002122578"
+                },
+                "messageAttributes": {},
+                "md5OfBody": "b10a8db164e0754105b7a99be72e3fe5",
+                "eventSource": "aws:sqs",
+                "eventSourceARN": "arn:aws:sqs:us-east-1:425362996713:nhulston-java",
+                "awsRegion": "us-east-1"
+            }]
+        });
+
+        // Should extract trace context from AWSTraceHeader
+        test_context_source(&payload, "aws_trace_header");
+    }
+
+    #[test]
+    fn test_span_inferrer_infer_span() {
+        let config = Arc::new(Config::default());
+        let mut inferrer = SpanInferrer::new(config);
 
         // Create a payload with AWSTraceHeader from Java->SQS->Java
         let payload = json!({
@@ -519,30 +544,29 @@ mod tests {
             sandbox_init_time: Instant::now(),
             exec_wrapper: None,
         });
+
         inferrer.infer_span(&payload, &aws_config);
 
+        // Test that the inferrer processed the SQS event correctly
         assert!(
-            inferrer.generated_span_context.is_some(),
-            "Should generate span context from AWSTraceHeader"
+            inferrer.inferred_span.is_some(),
+            "Should have inferred span from SQS event"
         );
         assert!(
-            inferrer.carrier.is_some(),
-            "Should have carrier from SQS event"
-        );
-        let propagator = DatadogHeaderPropagator;
-        let inferred_context = inferrer
-            .carrier
-            .as_ref()
-            .and_then(|c| propagator.extract(c));
-        assert!(
-            inferred_context.is_none(),
-            "Carrier should not have trace context for Java->SQS->Java case"
+            inferrer.trigger_tags.is_some(),
+            "Should have trigger tags from SQS event"
         );
 
-        test_context_source(
-            inferrer.carrier,
-            inferrer.generated_span_context,
-            "aws_trace_header",
+        // Verify the trigger tags contain the expected SQS information
+        let trigger_tags = inferrer.trigger_tags.unwrap();
+        assert!(
+            trigger_tags.contains_key("function_trigger.event_source"),
+            "Should have event source in trigger tags"
+        );
+        assert_eq!(
+            trigger_tags.get("function_trigger.event_source").unwrap(),
+            "sqs",
+            "Should have SQS as event source"
         );
     }
 }

--- a/bottlecap/src/lifecycle/invocation/span_inferrer.rs
+++ b/bottlecap/src/lifecycle/invocation/span_inferrer.rs
@@ -183,7 +183,7 @@ impl SpanInferrer {
             // There is no inferred span for ALB events
             IdentifiedTrigger::ALBEvent(_) => true,
             // There is no inferred span for Step Functions events
-            // unless the `SpanContext` is generated
+            // if the `SpanContext` is generated
             IdentifiedTrigger::StepFunctionEvent(_) => {
                 extract_generated_span_context(identified_trigger).is_some()
             }

--- a/bottlecap/src/lifecycle/listener.rs
+++ b/bottlecap/src/lifecycle/listener.rs
@@ -9,7 +9,7 @@ use axum::{
     routing::{get, post},
 };
 use bytes::Bytes;
-use serde_json::json;
+use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -19,11 +19,17 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, warn};
 
 use crate::{
-    http::extract_request_body,
+    http::{extract_request_body, headers_to_map},
     lifecycle::invocation::processor::Processor as InvocationProcessor,
-    traces::propagation::text_map_propagator::{
-        DATADOG_HIGHER_ORDER_TRACE_ID_BITS_KEY, DATADOG_SAMPLING_PRIORITY_KEY, DATADOG_TAGS_KEY,
-        DATADOG_TRACE_ID_KEY,
+    traces::{
+        context::SpanContext,
+        propagation::{
+            DatadogCompositePropagator,
+            text_map_propagator::{
+                DATADOG_HIGHER_ORDER_TRACE_ID_BITS_KEY, DATADOG_SAMPLING_PRIORITY_KEY,
+                DATADOG_TAGS_KEY, DATADOG_TRACE_ID_KEY,
+            },
+        },
     },
 };
 
@@ -33,16 +39,25 @@ const END_INVOCATION_PATH: &str = "/lambda/end-invocation";
 const AGENT_PORT: usize = 8124;
 
 pub struct Listener {
+    propagator: Arc<DatadogCompositePropagator>,
     pub invocation_processor: Arc<Mutex<InvocationProcessor>>,
     pub shutdown_token: CancellationToken,
 }
 
-type ListenerState = (Arc<Mutex<InvocationProcessor>>, Arc<Mutex<JoinSet<()>>>);
+type ListenerState = (
+    Arc<Mutex<InvocationProcessor>>,
+    Arc<DatadogCompositePropagator>,
+    Arc<Mutex<JoinSet<()>>>,
+);
 
 impl Listener {
-    pub fn new(invocation_processor: Arc<Mutex<InvocationProcessor>>) -> Self {
+    pub fn new(
+        invocation_processor: Arc<Mutex<InvocationProcessor>>,
+        propagator: Arc<DatadogCompositePropagator>,
+    ) -> Self {
         let shutdown_token = CancellationToken::new();
         Self {
+            propagator,
             invocation_processor,
             shutdown_token,
         }
@@ -59,7 +74,11 @@ impl Listener {
         let listener = TcpListener::bind(&addr).await?;
 
         let tasks = Arc::new(Mutex::new(JoinSet::new()));
-        let state: ListenerState = (self.invocation_processor.clone(), tasks.clone());
+        let state: ListenerState = (
+            self.invocation_processor.clone(),
+            self.propagator.clone(),
+            tasks.clone(),
+        );
         let router = Self::make_router(state);
 
         debug!("Lifecycle API | Starting listener on {}", addr);
@@ -91,7 +110,7 @@ impl Listener {
 
     // TODO(duncanista): spawn task to handle start invocation request
     async fn handle_start_invocation(
-        State((invocation_processor, _tasks)): State<ListenerState>,
+        State((invocation_processor, propagator, tasks)): State<ListenerState>,
         request: Request,
     ) -> Response {
         let (parts, body) = match extract_request_body(request).await {
@@ -106,14 +125,27 @@ impl Listener {
             }
         };
 
-        let (_, response) =
-            Self::universal_instrumentation_start(&parts.headers, body, invocation_processor).await;
+        let headers = headers_to_map(&parts.headers);
+        let payload_value = serde_json::from_slice::<Value>(&body).unwrap_or_else(|_| json!({}));
 
-        response
+        let mut response_headers = HeaderMap::new();
+        let extracted_span_context =
+            InvocationProcessor::extract_span_context(&headers, &payload_value, propagator);
+        if let Some(sp) = &extracted_span_context {
+            Self::inject_span_context_to_headers(&mut response_headers, sp);
+        }
+
+        let mut join_set = tasks.lock().await;
+        join_set.spawn(async move {
+            Self::universal_instrumentation_start(headers, payload_value, invocation_processor)
+                .await;
+        });
+
+        (StatusCode::OK, response_headers, json!({}).to_string()).into_response()
     }
 
     async fn handle_end_invocation(
-        State((invocation_processor, tasks)): State<ListenerState>,
+        State((invocation_processor, _, tasks)): State<ListenerState>,
         request: Request,
     ) -> Response {
         let mut join_set = tasks.lock().await;
@@ -126,12 +158,7 @@ impl Listener {
                 }
             };
 
-            if let Err(e) =
-                Self::universal_instrumentation_end(&parts.headers, body, invocation_processor)
-                    .await
-            {
-                error!("Failed to process end invocation request {e}");
-            }
+            Self::universal_instrumentation_end(&parts.headers, body, invocation_processor).await;
         });
 
         (StatusCode::OK, json!({}).to_string()).into_response()
@@ -144,92 +171,63 @@ impl Listener {
     }
 
     pub async fn universal_instrumentation_start(
-        headers: &HeaderMap,
-        body: Bytes,
+        headers: HashMap<String, String>,
+        payload_value: Value,
         invocation_processor: Arc<Mutex<InvocationProcessor>>,
-    ) -> (u64, Response) {
+    ) {
         debug!("Received start invocation request");
-        let body = body.to_vec();
 
-        let headers = Self::headers_to_map(headers);
+        let mut processor = invocation_processor.lock().await;
+        processor.on_universal_instrumentation_start(headers, payload_value);
+    }
 
-        let extracted_span_context = {
-            let mut processor = invocation_processor.lock().await;
-            processor.on_universal_instrumentation_start(headers, body)
-        };
+    // If a `SpanContext` exists, then tell the tracer to use it.
+    // todo: update this whole code with DatadogHeaderPropagator::inject
+    // since this logic looks messy
+    fn inject_span_context_to_headers(headers: &mut HeaderMap, span_context: &SpanContext) {
+        headers.insert(
+            DATADOG_TRACE_ID_KEY,
+            span_context
+                .trace_id
+                .to_string()
+                .parse()
+                .expect("Failed to parse trace id"),
+        );
 
-        let found_parent_span_id;
-
-        // If a `SpanContext` exists, then tell the tracer to use it.
-        // todo: update this whole code with DatadogHeaderPropagator::inject
-        // since this logic looks messy
-        let response = if let Some(sp) = extracted_span_context {
-            let mut headers = HeaderMap::new();
+        if let Some(priority) = span_context.sampling.and_then(|s| s.priority) {
             headers.insert(
-                DATADOG_TRACE_ID_KEY,
-                sp.trace_id
+                DATADOG_SAMPLING_PRIORITY_KEY,
+                priority
                     .to_string()
                     .parse()
-                    .expect("Failed to parse trace id"),
+                    .expect("Failed to parse sampling priority"),
             );
-            if let Some(priority) = sp.sampling.and_then(|s| s.priority) {
-                headers.insert(
-                    DATADOG_SAMPLING_PRIORITY_KEY,
-                    priority
-                        .to_string()
-                        .parse()
-                        .expect("Failed to parse sampling priority"),
-                );
-            }
+        }
 
-            // Handle 128 bit trace ids
-            if let Some(trace_id_higher_order_bits) =
-                sp.tags.get(DATADOG_HIGHER_ORDER_TRACE_ID_BITS_KEY)
-            {
-                headers.insert(
-                    DATADOG_TAGS_KEY,
-                    format!(
-                        "{DATADOG_HIGHER_ORDER_TRACE_ID_BITS_KEY}={trace_id_higher_order_bits}"
-                    )
+        // Handle 128 bit trace ids
+        if let Some(trace_id_higher_order_bits) = span_context
+            .tags
+            .get(DATADOG_HIGHER_ORDER_TRACE_ID_BITS_KEY)
+        {
+            headers.insert(
+                DATADOG_TAGS_KEY,
+                format!("{DATADOG_HIGHER_ORDER_TRACE_ID_BITS_KEY}={trace_id_higher_order_bits}")
                     .parse()
                     .expect("Failed to parse tags"),
-                );
-            }
-            found_parent_span_id = sp.span_id;
-
-            (StatusCode::OK, headers, json!({}).to_string()).into_response()
-        } else {
-            found_parent_span_id = 0;
-            (StatusCode::OK, json!({}).to_string()).into_response()
-        };
-
-        (found_parent_span_id, response)
+            );
+        }
     }
 
     pub async fn universal_instrumentation_end(
         headers: &HeaderMap,
         body: Bytes,
         invocation_processor: Arc<Mutex<InvocationProcessor>>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) {
         debug!("Received end invocation request");
-        let body = body.to_vec();
         let mut processor = invocation_processor.lock().await;
 
-        let headers = Self::headers_to_map(headers);
-        processor.on_universal_instrumentation_end(headers, body);
-
-        Ok(())
-    }
-
-    fn headers_to_map(headers: &HeaderMap) -> HashMap<String, String> {
-        headers
-            .iter()
-            .map(|(k, v)| {
-                (
-                    k.as_str().to_string(),
-                    v.to_str().unwrap_or_default().to_string(),
-                )
-            })
-            .collect()
+        let headers = headers_to_map(headers);
+        let payload_value = serde_json::from_slice::<Value>(&body).unwrap_or_else(|_| json!({}));
+        processor.on_universal_instrumentation_end(headers, payload_value);
     }
 }

--- a/bottlecap/src/traces/propagation/mod.rs
+++ b/bottlecap/src/traces/propagation/mod.rs
@@ -21,7 +21,7 @@ pub trait Propagator {
 }
 
 pub struct DatadogCompositePropagator {
-    propagators: Vec<Box<dyn Propagator + Send + 'static>>,
+    propagators: Vec<Box<dyn Propagator + Send + Sync>>,
     config: Arc<config::Config>,
 }
 
@@ -61,17 +61,17 @@ impl Propagator for DatadogCompositePropagator {
 impl DatadogCompositePropagator {
     #[must_use]
     pub fn new(config: Arc<config::Config>) -> Self {
-        let propagators: Vec<Box<dyn Propagator + Send + 'static>> = config
+        let propagators: Vec<Box<dyn Propagator + Send + Sync>> = config
             .trace_propagation_style_extract
             .iter()
             .filter_map(|style| match style {
                 TracePropagationStyle::Datadog => {
                     Some(Box::new(text_map_propagator::DatadogHeaderPropagator)
-                        as Box<dyn Propagator + Send>)
+                        as Box<dyn Propagator + Send + Sync>)
                 }
                 TracePropagationStyle::TraceContext => {
                     Some(Box::new(text_map_propagator::TraceContextPropagator)
-                        as Box<dyn Propagator + Send>)
+                        as Box<dyn Propagator + Send + Sync>)
                 }
                 _ => None,
             })


### PR DESCRIPTION
# What?

Decouples Span Inferrer methods by refactoring them

# Motivation

Help remove lock on hot-path, delegate lock for task in universal instrumentation start, while maintaining span context extraction for tracer to use

# Notes

It's a long refactor 😴 