### PR TITLE
Fixed duplicate versions of the same crate by aligning the ddsketch-a…

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -513,13 +513,13 @@ dependencies = [
  "chrono",
  "cookie",
  "datadog-fips",
- "datadog-protos 0.1.0 (git+https://github.com/DataDog/saluki/?rev=c89b58e5784b985819baf11f13f7d35876741222)",
+ "datadog-protos",
  "datadog-trace-normalization",
  "datadog-trace-obfuscation",
  "datadog-trace-protobuf",
  "datadog-trace-utils",
  "ddcommon",
- "ddsketch-agent 0.1.0 (git+https://github.com/DataDog/saluki/)",
+ "ddsketch-agent",
  "dogstatsd",
  "figment",
  "fnv",
@@ -780,21 +780,8 @@ dependencies = [
  "prost",
  "protobuf",
  "protobuf-codegen",
- "tonic 0.12.3",
- "tonic-build 0.12.3",
-]
-
-[[package]]
-name = "datadog-protos"
-version = "0.1.0"
-source = "git+https://github.com/DataDog/saluki/#2d0d136bb6c52ca057c5436edecafa48c715d718"
-dependencies = [
- "bytes",
- "prost",
- "protobuf",
- "protobuf-codegen",
- "tonic 0.13.1",
- "tonic-build 0.13.1",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]
@@ -899,18 +886,7 @@ name = "ddsketch-agent"
 version = "0.1.0"
 source = "git+https://github.com/DataDog/saluki/?rev=c89b58e5784b985819baf11f13f7d35876741222#c89b58e5784b985819baf11f13f7d35876741222"
 dependencies = [
- "datadog-protos 0.1.0 (git+https://github.com/DataDog/saluki/?rev=c89b58e5784b985819baf11f13f7d35876741222)",
- "float-cmp",
- "ordered-float 4.6.0",
- "smallvec",
-]
-
-[[package]]
-name = "ddsketch-agent"
-version = "0.1.0"
-source = "git+https://github.com/DataDog/saluki/#2d0d136bb6c52ca057c5436edecafa48c715d718"
-dependencies = [
- "datadog-protos 0.1.0 (git+https://github.com/DataDog/saluki/)",
+ "datadog-protos",
  "float-cmp",
  "ordered-float 4.6.0",
  "smallvec",
@@ -995,8 +971,8 @@ version = "0.1.0"
 source = "git+https://github.com/DataDog/serverless-components?rev=d131de8419c191ce21c91bb30b5915c4d8a2cc5a#d131de8419c191ce21c91bb30b5915c4d8a2cc5a"
 dependencies = [
  "datadog-fips",
- "datadog-protos 0.1.0 (git+https://github.com/DataDog/saluki/?rev=c89b58e5784b985819baf11f13f7d35876741222)",
- "ddsketch-agent 0.1.0 (git+https://github.com/DataDog/saluki/?rev=c89b58e5784b985819baf11f13f7d35876741222)",
+ "datadog-protos",
+ "ddsketch-agent",
  "derive_more",
  "fnv",
  "hashbrown 0.15.4",
@@ -2204,7 +2180,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "serde",
- "tonic 0.12.3",
+ "tonic",
  "tracing",
 ]
 
@@ -3661,45 +3637,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "bytes",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "percent-encoding",
- "pin-project",
- "prost",
- "tokio-stream",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "tonic-build"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
-dependencies = [
- "prettyplease",
- "proc-macro2",
- "prost-build",
- "prost-types",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "tonic-build"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -56,7 +56,7 @@ ustr = { version = "1.0.0", default-features = false }
 # datadog_fips::reqwest_adapter::create_reqwest_client_builder. An example can
 # be found in the clippy.toml file adjacent to this Cargo.toml.
 datadog-protos = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "c89b58e5784b985819baf11f13f7d35876741222"}
-ddsketch-agent = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/" }
+ddsketch-agent = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "c89b58e5784b985819baf11f13f7d35876741222"}
 ddcommon = { git = "https://github.com/DataDog/libdatadog", rev = "9405db9cb4ef733f3954c3ee77ce71a502e98e50" }
 datadog-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "9405db9cb4ef733f3954c3ee77ce71a502e98e50"  }
 datadog-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "9405db9cb4ef733f3954c3ee77ce71a502e98e50" , features = ["mini_agent"] }


### PR DESCRIPTION
This PR fixes a dependency mismatch in Cargo.toml.
Previously, ddsketch-agent and datadog-protos were pinned to different revisions, which caused Cargo to pull in multiple versions of the same crate and inflate Cargo.lock.

By aligning the ddsketch-agent revision with datadog-protos, we avoid duplicate versions and simplify the dependency tree.

If the versions were intentionally kept different, feel free to reject this PR.