### PR TITLE
Support OpenTelemetry Trace Operation Name V1

### DIFF
--- a/bottlecap/src/appsec/processor/context.rs
+++ b/bottlecap/src/appsec/processor/context.rs
@@ -195,7 +195,7 @@ impl Context {
                 self.process_result(result);
             }
             Err(e) => log_waf_run_error(e),
-        };
+        }
     }
 
     /// Obtain the information about the endpoint that was invoked, if available.

--- a/bottlecap/src/appsec/processor/mod.rs
+++ b/bottlecap/src/appsec/processor/mod.rs
@@ -33,7 +33,7 @@ pub struct Processor {
     context_buffer: VecDeque<Context>,
 }
 impl Processor {
-    const CONTEXT_BUFFER_DEFAULT_CAPACITY: NonZero<usize> = unsafe { NonZero::new_unchecked(5) };
+    const CONTEXT_BUFFER_DEFAULT_CAPACITY: NonZero<usize> = NonZero::new(5).unwrap();
 
     /// Creates a new [`Processor`] instance using the provided [`Config`].
     ///
@@ -584,9 +584,9 @@ impl InvocationPayload for IdentifiedTrigger {
                 .unwrap_or_default()
                 .iter()
                 .flat_map(parse_cookie)
-                .chunk_by(|(k, _)| (*k).to_string())
+                .chunk_by(|(k, _)| (*k).clone())
                 .into_iter()
-                .map(|(k, v)| (k, v.into_iter().map(|(_, v)| v.to_string()).collect()))
+                .map(|(k, v)| (k, v.into_iter().map(|(_, v)| v.clone()).collect()))
                 .collect(),
             Self::APIGatewayWebSocketEvent(t) => t
                 .multi_value_headers
@@ -595,9 +595,9 @@ impl InvocationPayload for IdentifiedTrigger {
                 .unwrap_or_default()
                 .iter()
                 .flat_map(parse_cookie)
-                .chunk_by(|(k, _)| k.to_string())
+                .chunk_by(|(k, _)| k.clone())
                 .into_iter()
-                .map(|(k, v)| (k, v.into_iter().map(|(_, v)| v.to_string()).collect()))
+                .map(|(k, v)| (k, v.into_iter().map(|(_, v)| v.clone()).collect()))
                 .collect(),
             Self::ALBEvent(t) => t
                 .multi_value_headers
@@ -607,9 +607,9 @@ impl InvocationPayload for IdentifiedTrigger {
                 .unwrap_or_default()
                 .iter()
                 .flat_map(parse_cookie)
-                .chunk_by(|(k, _)| (*k).to_string())
+                .chunk_by(|(k, _)| (*k).clone())
                 .into_iter()
-                .map(|(k, v)| (k, v.into_iter().map(|(_, v)| v.to_string()).collect()))
+                .map(|(k, v)| (k, v.into_iter().map(|(_, v)| v.clone()).collect()))
                 .collect(),
             Self::LambdaFunctionUrlEvent(t) => {
                 t.cookies.as_ref().map(list_to_map).unwrap_or_default()

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -466,7 +466,7 @@ async fn extension_loop_idle(client: &Client, r: &RegisterResponse) -> Result<()
                 error!("Error getting next event: {e:?}");
                 return Err(e);
             }
-        };
+        }
     }
 }
 
@@ -481,11 +481,7 @@ async fn extension_loop_active(
 ) -> Result<()> {
     let mut event_bus = EventBus::run();
 
-    let account_id = r
-        .account_id
-        .as_ref()
-        .unwrap_or(&"none".to_string())
-        .to_string();
+    let account_id = r.account_id.as_ref().unwrap_or(&"none".to_string()).clone();
     let tags_provider = setup_tag_provider(&Arc::clone(&aws_config), config, &account_id);
 
     let (logs_agent_channel, logs_flusher) = start_logs_agent(
@@ -613,11 +609,10 @@ async fn extension_loop_active(
                 tokio::select! {
                 biased;
                     Some(event) = event_bus.rx.recv() => {
-                        if let Some(telemetry_event) = handle_event_bus_event(event, invocation_processor.clone(), appsec_processor.clone(), tags_provider.clone(), trace_processor.clone(), trace_agent_channel.clone()).await {
-                            if let TelemetryRecord::PlatformRuntimeDone{ .. } = telemetry_event.record {
+                        if let Some(telemetry_event) = handle_event_bus_event(event, invocation_processor.clone(), appsec_processor.clone(), tags_provider.clone(), trace_processor.clone(), trace_agent_channel.clone()).await
+                            && let TelemetryRecord::PlatformRuntimeDone{ .. } = telemetry_event.record {
                                 break 'flush_end;
                             }
-                        }
                     }
                     _ = race_flush_interval.tick() => {
                         let mut locked_metrics = metrics_flushers.lock().await;

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -189,10 +189,10 @@ impl ConfigBuilder {
 
         // If `proxy_https` is not set, set it from `HTTPS_PROXY` environment variable
         // if it exists
-        if let Ok(https_proxy) = std::env::var("HTTPS_PROXY") {
-            if self.config.proxy_https.is_none() {
-                self.config.proxy_https = Some(https_proxy);
-            }
+        if let Ok(https_proxy) = std::env::var("HTTPS_PROXY")
+            && self.config.proxy_https.is_none()
+        {
+            self.config.proxy_https = Some(https_proxy);
         }
 
         // If `proxy_https` is set, check if the site is in `NO_PROXY` environment variable

--- a/bottlecap/src/config/service_mapping.rs
+++ b/bottlecap/src/config/service_mapping.rs
@@ -12,8 +12,7 @@ where
 {
     let s: String = String::deserialize(deserializer)?;
 
-    let map = s
-        .split(',')
+    s.split(',')
         .map(|pair| {
             let mut split = pair.split(':');
 
@@ -29,7 +28,5 @@ where
                 )))
             }
         })
-        .collect();
-
-    map
+        .collect()
 }

--- a/bottlecap/src/lifecycle/invocation/mod.rs
+++ b/bottlecap/src/lifecycle/invocation/mod.rs
@@ -58,7 +58,7 @@ pub fn generate_span_id() -> u64 {
 }
 
 fn redact_value(key: &str, value: String) -> String {
-    let split_key = key.split('.').last().unwrap_or_default();
+    let split_key = key.split('.').next_back().unwrap_or_default();
     if REDACTABLE_KEYS.contains(&split_key) {
         String::from("redacted")
     } else {

--- a/bottlecap/src/lifecycle/invocation/span_inferrer.rs
+++ b/bottlecap/src/lifecycle/invocation/span_inferrer.rs
@@ -137,29 +137,28 @@ impl SpanInferrer {
                 None
             }
             IdentifiedTrigger::SnsRecord(t) => {
-                if let Some(message) = &t.sns.message {
-                    if let Ok(event_bridge_wrapper_message) =
+                if let Some(message) = &t.sns.message
+                    && let Ok(event_bridge_wrapper_message) =
                         serde_json::from_str::<EventBridgeEvent>(message)
-                    {
-                        let mut wrapped_inferred_span = Span {
-                            span_id: generate_span_id(),
-                            ..Default::default()
-                        };
+                {
+                    let mut wrapped_inferred_span = Span {
+                        span_id: generate_span_id(),
+                        ..Default::default()
+                    };
 
-                        event_bridge_wrapper_message.enrich_span(
-                            &mut wrapped_inferred_span,
-                            &config.service_mapping,
-                            config.trace_aws_service_representation_enabled,
-                        );
-                        inferred_span
-                            .meta
-                            .extend(event_bridge_wrapper_message.get_tags());
+                    event_bridge_wrapper_message.enrich_span(
+                        &mut wrapped_inferred_span,
+                        &config.service_mapping,
+                        config.trace_aws_service_representation_enabled,
+                    );
+                    inferred_span
+                        .meta
+                        .extend(event_bridge_wrapper_message.get_tags());
 
-                        wrapped_inferred_span.duration =
-                            inferred_span.start - wrapped_inferred_span.start;
+                    wrapped_inferred_span.duration =
+                        inferred_span.start - wrapped_inferred_span.start;
 
-                        return Some(wrapped_inferred_span);
-                    }
+                    return Some(wrapped_inferred_span);
                 }
 
                 None

--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_http_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_http_event.rs
@@ -179,11 +179,11 @@ impl Trigger for APIGatewayHttpEvent {
         }
 
         if let Some(referer) = self.headers.get("referer") {
-            tags.insert("http.referer".to_string(), referer.to_string());
+            tags.insert("http.referer".to_string(), referer.clone());
         }
 
         if let Some(user_agent) = self.headers.get("user-agent") {
-            tags.insert("http.user_agent".to_string(), user_agent.to_string());
+            tags.insert("http.user_agent".to_string(), user_agent.clone());
         }
 
         tags

--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_rest_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_rest_event.rs
@@ -161,7 +161,7 @@ impl Trigger for APIGatewayRestEvent {
             ),
             (
                 "http.user_agent".to_string(),
-                self.request_context.identity.user_agent.to_string(),
+                self.request_context.identity.user_agent.clone(),
             ),
             (
                 FUNCTION_TRIGGER_EVENT_SOURCE_TAG.to_string(),
@@ -170,7 +170,7 @@ impl Trigger for APIGatewayRestEvent {
         ]);
 
         if let Some(referer) = self.headers.get("referer") {
-            tags.insert("http.referer".to_string(), referer.to_string());
+            tags.insert("http.referer".to_string(), referer.clone());
         }
 
         tags

--- a/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/api_gateway_websocket_event.rs
@@ -155,7 +155,7 @@ impl Trigger for APIGatewayWebSocketEvent {
         ]);
 
         if let Some(referer) = self.headers.get("referer") {
-            tags.insert("http.referer".to_string(), referer.to_string());
+            tags.insert("http.referer".to_string(), referer.clone());
         }
 
         tags

--- a/bottlecap/src/lifecycle/invocation/triggers/dynamodb_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/dynamodb_event.rs
@@ -120,7 +120,7 @@ impl Trigger for DynamoDbRecord {
         );
 
         span.name = String::from("aws.dynamodb");
-        span.service = service_name.to_string();
+        span.service.clone_from(&service_name);
         span.resource = resource;
         span.r#type = String::from("web");
         span.start = start_time;
@@ -141,7 +141,7 @@ impl Trigger for DynamoDbRecord {
                 "stream_view_type".to_string(),
                 self.dynamodb.stream_view_type.clone(),
             ),
-            ("table_name".to_string(), table_name.to_string()),
+            ("table_name".to_string(), table_name.clone()),
         ]));
     }
 

--- a/bottlecap/src/lifecycle/invocation/triggers/event_bridge_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/event_bridge_event.rs
@@ -78,7 +78,7 @@ impl Trigger for EventBridgeEvent {
         );
 
         span.name = String::from("aws.eventbridge");
-        span.service = service_name.to_string();
+        span.service.clone_from(&service_name);
         span.resource = resource_name;
         span.r#type = String::from("web");
         span.start = start_time;
@@ -100,10 +100,10 @@ impl Trigger for EventBridgeEvent {
     }
 
     fn get_carrier(&self) -> HashMap<String, String> {
-        if let Ok(detail) = serde_json::from_value::<HashMap<String, Value>>(self.detail.clone()) {
-            if let Some(carrier) = detail.get(DATADOG_CARRIER_KEY) {
-                return serde_json::from_value(carrier.clone()).unwrap_or_default();
-            }
+        if let Ok(detail) = serde_json::from_value::<HashMap<String, Value>>(self.detail.clone())
+            && let Some(carrier) = detail.get(DATADOG_CARRIER_KEY)
+        {
+            return serde_json::from_value(carrier.clone()).unwrap_or_default();
         }
         HashMap::new()
     }
@@ -119,7 +119,7 @@ impl ServiceNameResolver for EventBridgeEvent {
         carrier
             .get(DATADOG_RESOURCE_NAME_KEY)
             .unwrap_or(&self.source)
-            .to_string()
+            .clone()
     }
 
     fn get_generic_identifier(&self) -> &'static str {

--- a/bottlecap/src/lifecycle/invocation/triggers/mod.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/mod.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
 use datadog_trace_protobuf::pb::Span;
-use lazy_static::lazy_static;
 use regex::Regex;
 use serde::{Deserialize, Deserializer};
 use serde_json::Value;
+use std::sync::LazyLock;
 
 pub mod body;
 mod serde_utils;
@@ -26,8 +26,8 @@ pub mod step_function_event;
 pub const DATADOG_CARRIER_KEY: &str = "_datadog";
 pub const FUNCTION_TRIGGER_EVENT_SOURCE_TAG: &str = "function_trigger.event_source";
 pub const FUNCTION_TRIGGER_EVENT_SOURCE_ARN_TAG: &str = "function_trigger.event_source_arn";
-lazy_static! {
-    static ref ULID_UUID_GUID: Regex = Regex::new(
+static ULID_UUID_GUID: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
         r"(?x)
         (
             [0-9a-fA-F]{8}-          # UUID/GUID segment 1
@@ -40,10 +40,10 @@ lazy_static! {
         (
             [0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}  # ULID
         )
-    "
+    ",
     )
-    .expect("failed to create regex");
-}
+    .expect("failed to create regex")
+});
 
 /// Resolves the service name for a given trigger depending on
 /// service mapping configuration.

--- a/bottlecap/src/lifecycle/invocation/triggers/msk_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/msk_event.rs
@@ -82,7 +82,7 @@ impl Trigger for MSKEvent {
             span.start = (first_value.timestamp * MS_TO_NS) as i64;
             span.meta.extend([
                 ("operation_name".to_string(), String::from("aws.msk")),
-                ("topic".to_string(), first_value.topic.to_string()),
+                ("topic".to_string(), first_value.topic.clone()),
                 ("partition".to_string(), first_value.partition.to_string()),
                 ("event_source".to_string(), self.event_source.clone()),
                 (
@@ -101,7 +101,7 @@ impl Trigger for MSKEvent {
     }
 
     fn get_arn(&self, _region: &str) -> String {
-        self.event_source_arn.to_string()
+        self.event_source_arn.clone()
     }
 
     fn get_carrier(&self) -> HashMap<String, String> {

--- a/bottlecap/src/lifecycle/invocation/triggers/sns_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/sns_event.rs
@@ -105,7 +105,7 @@ impl Trigger for SnsRecord {
         );
 
         span.name = "aws.sns".to_string();
-        span.service = service_name.to_string();
+        span.service.clone_from(&service_name);
         span.resource.clone_from(&resource_name);
         span.r#type = "web".to_string();
         span.start = start_time;
@@ -153,10 +153,10 @@ impl Trigger for SnsRecord {
                     debug!("Unsupported type in SNS message attribute");
                 }
             }
-        } else if let Some(event_bridge_message) = &self.sns.message {
-            if let Ok(event) = serde_json::from_str::<EventBridgeEvent>(event_bridge_message) {
-                return event.get_carrier();
-            }
+        } else if let Some(event_bridge_message) = &self.sns.message
+            && let Ok(event) = serde_json::from_str::<EventBridgeEvent>(event_bridge_message)
+        {
+            return event.get_carrier();
         }
 
         HashMap::new()
@@ -172,7 +172,7 @@ impl ServiceNameResolver for SnsRecord {
         self.sns
             .topic_arn
             .split(':')
-            .last()
+            .next_back()
             .unwrap_or_default()
             .to_string()
     }

--- a/bottlecap/src/lifecycle/invocation/triggers/sqs_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/sqs_event.rs
@@ -122,7 +122,7 @@ impl Trigger for SqsRecord {
         );
 
         span.name = "aws.sqs".to_string();
-        span.service = service_name.to_string();
+        span.service.clone_from(&service_name);
         span.resource = resource;
         span.r#type = "web".to_string();
         span.start = start_time;
@@ -177,10 +177,10 @@ impl Trigger for SqsRecord {
     fn get_carrier(&self) -> HashMap<String, String> {
         let carrier = HashMap::new();
 
-        if let Some(ma) = self.message_attributes.get(DATADOG_CARRIER_KEY) {
-            if let Some(string_value) = &ma.string_value {
-                return serde_json::from_str(string_value).unwrap_or_default();
-            }
+        if let Some(ma) = self.message_attributes.get(DATADOG_CARRIER_KEY)
+            && let Some(string_value) = &ma.string_value
+        {
+            return serde_json::from_str(string_value).unwrap_or_default();
         }
 
         // Check for SNS event sent through SQS
@@ -208,7 +208,7 @@ impl ServiceNameResolver for SqsRecord {
     fn get_specific_identifier(&self) -> String {
         self.event_source_arn
             .split(':')
-            .last()
+            .next_back()
             .unwrap_or_default()
             .to_string()
     }

--- a/bottlecap/src/lifecycle/invocation/triggers/step_function_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/step_function_event.rs
@@ -156,7 +156,7 @@ impl StepFunctionEvent {
 
                 let tags = DatadogHeaderPropagator::extract_tags(&HashMap::from([(
                     DATADOG_TAGS_KEY.to_string(),
-                    trace_tags.to_string(),
+                    trace_tags.clone(),
                 )]));
 
                 (lo_tid, tags)
@@ -196,6 +196,7 @@ impl StepFunctionEvent {
         }
     }
 
+    #[allow(clippy::format_push_string)]
     /// Generates a random 64 bit ID from the formatted hash of the
     /// Step Function context object. We omit `retry_count` and `redrive_count`
     /// when both are 0 to maintain backwards compatibility.

--- a/bottlecap/src/logs/flusher.rs
+++ b/bottlecap/src/logs/flusher.rs
@@ -115,10 +115,7 @@ impl Flusher {
             let time = Instant::now();
             attempts += 1;
             let Some(cloned_req) = req.try_clone() else {
-                return Err(Box::new(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "can't clone",
-                )));
+                return Err(Box::new(std::io::Error::other("can't clone")));
             };
             let resp = cloned_req.send().await;
             let elapsed = time.elapsed();
@@ -232,17 +229,16 @@ impl LogsFlusher {
 
         // If retry_request is provided, only process that request
         if let Some(req) = retry_request {
-            if let Some(req_clone) = req.try_clone() {
-                if let Err(e) = Flusher::send(req_clone).await {
-                    if let Some(failed_req_err) = e.downcast_ref::<FailedRequestError>() {
-                        failed_requests.push(
-                            failed_req_err
-                                .request
-                                .try_clone()
-                                .expect("should be able to clone request"),
-                        );
-                    }
-                }
+            if let Some(req_clone) = req.try_clone()
+                && let Err(e) = Flusher::send(req_clone).await
+                && let Some(failed_req_err) = e.downcast_ref::<FailedRequestError>()
+            {
+                failed_requests.push(
+                    failed_req_err
+                        .request
+                        .try_clone()
+                        .expect("should be able to clone request"),
+                );
             }
         } else {
             // Get batches from primary flusher's aggregator

--- a/bottlecap/src/lwa/mod.rs
+++ b/bottlecap/src/lwa/mod.rs
@@ -115,7 +115,7 @@ pub async fn process_invocation_next(
 
     if let Some(request_id) = request_id {
         let mut invocation_processor = processor.lock().await;
-        invocation_processor.add_reparenting(request_id.to_string(), generate_span_id(), parent_id);
+        invocation_processor.add_reparenting(request_id.clone(), generate_span_id(), parent_id);
     }
 }
 
@@ -156,11 +156,10 @@ pub async fn process_invocation_response(
 }
 
 fn inner_header(inner_payload: &Value) -> HashMap<String, String> {
-    let headers = if let Some(body) = inner_payload.get("headers") {
+    if let Some(body) = inner_payload.get("headers") {
         serde_json::from_value::<HashMap<String, String>>(body.clone())
             .unwrap_or_else(|_| HashMap::new())
     } else {
         HashMap::new()
-    };
-    headers
+    }
 }

--- a/bottlecap/src/metrics/enhanced/statfs.rs
+++ b/bottlecap/src/metrics/enhanced/statfs.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 /// Returns the block size, total number of blocks, and number of blocks available for the specified directory path.
 ///
 pub fn statfs_info(path: &str) -> Result<(f64, f64, f64), io::Error> {
-    let stat = statfs(Path::new(path)).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    let stat = statfs(Path::new(path)).map_err(io::Error::other)?;
     Ok((
         stat.block_size() as f64,
         stat.blocks() as f64,

--- a/bottlecap/src/proxy/interceptor.rs
+++ b/bottlecap/src/proxy/interceptor.rs
@@ -179,20 +179,19 @@ async fn invocation_next_proxy(
         if let Ok(body) = intercepted_completion_receiver.await {
             debug!("PROXY | invocation_next_proxy | intercepted body completed");
 
-            if let Some(appsec_processor) = appsec_processor {
-                if let Some(request_id) = intercepted_parts_clone
+            if let Some(appsec_processor) = appsec_processor
+                && let Some(request_id) = intercepted_parts_clone
                     .headers
                     .get("Lambda-Runtime-Aws-Request-Id")
                     .and_then(|v| v.to_str().ok())
+            {
                 {
-                    {
-                        if let Ok(trigger) = IdentifiedTrigger::from_slice(&body) {
-                            appsec_processor
-                                .lock()
-                                .await
-                                .process_invocation_next(request_id, &trigger)
-                                .await;
-                        }
+                    if let Ok(trigger) = IdentifiedTrigger::from_slice(&body) {
+                        appsec_processor
+                            .lock()
+                            .await
+                            .process_invocation_next(request_id, &trigger)
+                            .await;
                     }
                 }
             }

--- a/bottlecap/src/secrets/decrypt.rs
+++ b/bottlecap/src/secrets/decrypt.rs
@@ -114,7 +114,7 @@ pub async fn resolve_secrets(
 
 fn clean_api_key(maybe_key: Option<String>) -> Option<String> {
     if let Some(key) = maybe_key {
-        let clean_key = key.trim_end_matches('\n').replace(' ', "").to_string();
+        let clean_key = key.trim_end_matches('\n').replace(' ', "").clone();
         if !clean_key.is_empty() {
             return Some(clean_key);
         }

--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -78,14 +78,14 @@ fn tags_from_env(
             tags_map.insert(AWS_ACCOUNT_KEY.to_string(), parts[4].to_string());
             tags_map.insert(FUNCTION_NAME_KEY.to_string(), parts[6].to_string());
             tags_map.insert(RESOURCE_KEY.to_string(), parts[6].to_string());
-            if let Ok(qualifier) = std::env::var(QUALIFIER_ENV_VAR) {
-                if qualifier != "$LATEST" {
-                    tags_map.insert(
-                        RESOURCE_KEY.to_string(),
-                        format!("{}:{}", parts[6], qualifier),
-                    );
-                    tags_map.insert(EXECUTED_VERSION_KEY.to_string(), qualifier);
-                }
+            if let Ok(qualifier) = std::env::var(QUALIFIER_ENV_VAR)
+                && qualifier != "$LATEST"
+            {
+                tags_map.insert(
+                    RESOURCE_KEY.to_string(),
+                    format!("{}:{}", parts[6], qualifier),
+                );
+                tags_map.insert(EXECUTED_VERSION_KEY.to_string(), qualifier);
             }
         }
         tags_map.insert(
@@ -94,13 +94,13 @@ fn tags_from_env(
         );
     }
     if let Some(version) = &config.version {
-        tags_map.insert(VERSION_KEY.to_string(), version.to_string());
+        tags_map.insert(VERSION_KEY.to_string(), version.clone());
     }
     if let Some(env) = &config.env {
-        tags_map.insert(ENV_KEY.to_string(), env.to_string());
+        tags_map.insert(ENV_KEY.to_string(), env.clone());
     }
     if let Some(service) = &config.service {
-        tags_map.insert(SERVICE_KEY.to_string(), service.to_string());
+        tags_map.insert(SERVICE_KEY.to_string(), service.clone());
     }
     if let Ok(init_type) = std::env::var(INIT_TYPE) {
         tags_map.insert(INIT_TYPE_KEY.to_string(), init_type);
@@ -157,7 +157,7 @@ pub fn resolve_runtime_from_proc(proc_path: &str, fallback_provided_al_path: &st
                         .find(|line| line.contains(RUNTIME_VAR))
                         .and_then(|runtime_var_line| {
                             // AWS_EXECUTION_ENV=AWS_Lambda_java8
-                            runtime_var_line.split('_').last().map(String::from)
+                            runtime_var_line.split('_').next_back().map(String::from)
                         })
                 });
 
@@ -165,7 +165,7 @@ pub fn resolve_runtime_from_proc(proc_path: &str, fallback_provided_al_path: &st
             if let Some(runtime_from_environ) = search_environ_runtime {
                 debug!("Proc runtime search successful in {search_time}us: {runtime_from_environ}");
                 return runtime_from_environ.replace('\"', "");
-            };
+            }
             debug!("Proc runtime search unsuccessful after {search_time}us");
         }
         Err(e) => {

--- a/bottlecap/src/traces/propagation/text_map_propagator.rs
+++ b/bottlecap/src/traces/propagation/text_map_propagator.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
-use lazy_static::lazy_static;
 use regex::Regex;
 use tracing::{debug, error, warn};
 
@@ -30,20 +30,20 @@ pub const TRACESTATE_KEY: &str = "tracestate";
 
 pub const BAGGAGE_PREFIX: &str = "ot-baggage-";
 
-lazy_static! {
-    static ref TRACEPARENT_REGEX: Regex =
-        Regex::new(r"(?i)^([a-f0-9]{2})-([a-f0-9]{32})-([a-f0-9]{16})-([a-f0-9]{2})(-.*)?$")
-            .expect("failed creating regex");
-    static ref INVALID_SEGMENT_REGEX: Regex = Regex::new(r"^0+$").expect("failed creating regex");
-    static ref VALID_TAG_KEY_REGEX: Regex =
-        Regex::new(r"^_dd\.p\.[\x21-\x2b\x2d-\x7e]+$").expect("failed creating regex");
-    static ref VALID_TAG_VALUE_REGEX: Regex =
-        Regex::new(r"^[\x20-\x2b\x2d-\x7e]*$").expect("failed creating regex");
-    static ref INVALID_ASCII_CHARACTERS_REGEX: Regex =
-        Regex::new(r"[^\x20-\x7E]+").expect("failed creating regex");
-    static ref VALID_SAMPLING_DECISION_REGEX: Regex =
-        Regex::new(r"^-([0-9])$").expect("failed creating regex");
-}
+static TRACEPARENT_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)^([a-f0-9]{2})-([a-f0-9]{32})-([a-f0-9]{16})-([a-f0-9]{2})(-.*)?$")
+        .expect("failed creating regex")
+});
+static INVALID_SEGMENT_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^0+$").expect("failed creating regex"));
+// static VALID_TAG_KEY_REGEX: LazyLock<Regex> = LazyLock::new(||
+//     Regex::new(r"^_dd\.p\.[\x21-\x2b\x2d-\x7e]+$").expect("failed creating regex"));
+// static VALID_TAG_VALUE_REGEX: LazyLock<Regex> = LazyLock::new(||
+//     Regex::new(r"^[\x20-\x2b\x2d-\x7e]*$").expect("failed creating regex"));
+static INVALID_ASCII_CHARACTERS_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"[^\x20-\x7E]+").expect("failed creating regex"));
+static VALID_SAMPLING_DECISION_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^-([0-9])$").expect("failed creating regex"));
 
 #[derive(Clone, Copy)]
 pub struct DatadogHeaderPropagator;
@@ -168,21 +168,19 @@ impl DatadogHeaderPropagator {
         }
 
         // Handle 128bit trace ID
-        if !tags.is_empty() {
-            if let Some(trace_id_higher_order_bits) =
+        if !tags.is_empty()
+            && let Some(trace_id_higher_order_bits) =
                 carrier.get(DATADOG_HIGHER_ORDER_TRACE_ID_BITS_KEY)
-            {
-                if !Self::higher_order_bits_valid(trace_id_higher_order_bits) {
-                    warn!(
-                        "Malformed Trace ID: {trace_id_higher_order_bits} Failed to decode trace ID from carrier."
-                    );
-                    tags.insert(
-                        DATADOG_PROPAGATION_ERROR_KEY.to_string(),
-                        format!("malformed tid {trace_id_higher_order_bits}"),
-                    );
-                    tags.remove(DATADOG_HIGHER_ORDER_TRACE_ID_BITS_KEY);
-                }
-            }
+            && !Self::higher_order_bits_valid(trace_id_higher_order_bits)
+        {
+            warn!(
+                "Malformed Trace ID: {trace_id_higher_order_bits} Failed to decode trace ID from carrier."
+            );
+            tags.insert(
+                DATADOG_PROPAGATION_ERROR_KEY.to_string(),
+                format!("malformed tid {trace_id_higher_order_bits}"),
+            );
+            tags.remove(DATADOG_HIGHER_ORDER_TRACE_ID_BITS_KEY);
         }
 
         if !tags.contains_key(DATADOG_SAMPLING_DECISION_KEY) {
@@ -297,7 +295,7 @@ impl TraceContextPropagator {
             return None;
         }
 
-        tags.insert(TRACESTATE_KEY.to_string(), ts.to_string());
+        tags.insert(TRACESTATE_KEY.to_string(), ts.clone());
 
         let mut dd: Option<HashMap<String, String>> = None;
         for v in ts_v.clone() {
@@ -321,10 +319,10 @@ impl TraceContextPropagator {
                 lower_order_trace_id: None,
             };
 
-            if let Some(ts_sp) = dd.get("s") {
-                if let Ok(p_sp) = ts_sp.parse::<i8>() {
-                    tracestate.sampling_priority = Some(p_sp);
-                }
+            if let Some(ts_sp) = dd.get("s")
+                && let Ok(p_sp) = ts_sp.parse::<i8>()
+            {
+                tracestate.sampling_priority = Some(p_sp);
             }
 
             if let Some(o) = dd.get("o") {
@@ -332,7 +330,7 @@ impl TraceContextPropagator {
             }
 
             if let Some(lo_tid) = dd.get("p") {
-                tracestate.lower_order_trace_id = Some(lo_tid.to_string());
+                tracestate.lower_order_trace_id = Some(lo_tid.clone());
             }
 
             // Convert from `t.` to `_dd.p.`
@@ -357,12 +355,11 @@ impl TraceContextPropagator {
         traceparent_sampling_priority: i8,
         tracestate_sampling_priority: Option<i8>,
     ) -> i8 {
-        if let Some(ts_sp) = tracestate_sampling_priority {
-            if (traceparent_sampling_priority == 1 && ts_sp > 0)
-                || (traceparent_sampling_priority == 0 && ts_sp < 0)
-            {
-                return ts_sp;
-            }
+        if let Some(ts_sp) = tracestate_sampling_priority
+            && ((traceparent_sampling_priority == 1 && ts_sp > 0)
+                || (traceparent_sampling_priority == 0 && ts_sp < 0))
+        {
+            return ts_sp;
         }
 
         traceparent_sampling_priority

--- a/bottlecap/src/traces/proxy_flusher.rs
+++ b/bottlecap/src/traces/proxy_flusher.rs
@@ -144,10 +144,7 @@ impl Flusher {
             attempts += 1;
 
             let Some(cloned_request) = request.try_clone() else {
-                return Err(Box::new(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "can't clone proxy request",
-                )));
+                return Err(Box::new(std::io::Error::other("can't clone proxy request")));
             };
 
             let time = std::time::Instant::now();
@@ -197,12 +194,11 @@ impl Flusher {
         let mut failed_requests: Vec<reqwest::RequestBuilder> = Vec::new();
         for result in results {
             // There is no cleaner way to do this, so it's deeply nested.
-            if let Err(e) = result {
-                if let Some(fpre) = e.downcast_ref::<FailedProxyRequestError>() {
-                    if let Some(request) = fpre.request.try_clone() {
-                        failed_requests.push(request);
-                    }
-                }
+            if let Err(e) = result
+                && let Some(fpre) = e.downcast_ref::<FailedProxyRequestError>()
+                && let Some(request) = fpre.request.try_clone()
+            {
+                failed_requests.push(request);
             }
         }
 

--- a/bottlecap/src/traces/stats_flusher.rs
+++ b/bottlecap/src/traces/stats_flusher.rs
@@ -114,7 +114,7 @@ impl StatsFlusher for ServerlessStatsFlusher {
             Err(e) => {
                 error!("Error sending stats: {e:?}");
             }
-        };
+        }
     }
     async fn flush(&self) {
         let mut guard = self.aggregator.lock().await;

--- a/bottlecap/src/traces/stats_processor.rs
+++ b/bottlecap/src/traces/stats_processor.rs
@@ -51,18 +51,16 @@ impl StatsProcessor for ServerlessStatsProcessor {
             }
         };
 
-        if let Some(content_length) = parts.headers.get("content-length") {
-            if let Ok(length_str) = content_length.to_str() {
-                if let Ok(length) = length_str.parse::<usize>() {
-                    if length > MAX_CONTENT_LENGTH {
-                        let error_msg = format!(
-                            "Content-Length {length} exceeds maximum allowed size {MAX_CONTENT_LENGTH}"
-                        );
-                        error!("{}", error_msg);
-                        return Ok((StatusCode::PAYLOAD_TOO_LARGE, error_msg).into_response());
-                    }
-                }
-            }
+        if let Some(content_length) = parts.headers.get("content-length")
+            && let Ok(length_str) = content_length.to_str()
+            && let Ok(length) = length_str.parse::<usize>()
+            && length > MAX_CONTENT_LENGTH
+        {
+            let error_msg = format!(
+                "Content-Length {length} exceeds maximum allowed size {MAX_CONTENT_LENGTH}"
+            );
+            error!("{}", error_msg);
+            return Ok((StatusCode::PAYLOAD_TOO_LARGE, error_msg).into_response());
         }
 
         // deserialize trace stats from the request body, convert to protobuf structs (see

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -48,11 +48,11 @@ struct ChunkProcessor {
 
 impl TraceChunkProcessor for ChunkProcessor {
     fn process(&mut self, chunk: &mut pb::TraceChunk, root_span_index: usize) {
-        if let Some(root_span) = chunk.spans.get(root_span_index) {
-            if filter_span_by_tags(root_span, &self.config) {
-                chunk.spans.clear();
-                return;
-            }
+        if let Some(root_span) = chunk.spans.get(root_span_index)
+            && filter_span_by_tags(root_span, &self.config)
+        {
+            chunk.spans.clear();
+            return;
         }
 
         chunk
@@ -61,10 +61,10 @@ impl TraceChunkProcessor for ChunkProcessor {
         for span in &mut chunk.spans {
             // Service name could be incorrectly set to 'aws.lambda'
             // in datadog lambda libraries
-            if span.service == "aws.lambda" {
-                if let Some(service) = self.tags_provider.get_tags_map().get("service") {
-                    span.service.clone_from(service);
-                }
+            if span.service == "aws.lambda"
+                && let Some(service) = self.tags_provider.get_tags_map().get("service")
+            {
+                span.service.clone_from(service);
             }
 
             // Remove the _dd.base_service tag for unintentional service name override
@@ -88,70 +88,70 @@ impl TraceChunkProcessor for ChunkProcessor {
 
 fn filter_span_by_tags(span: &Span, config: &config::Config) -> bool {
     // Handle required tags from DD_APM_FILTER_TAGS_REQUIRE (exact match)
-    if let Some(require_tags) = &config.apm_filter_tags_require {
-        if !require_tags.is_empty() {
-            let matches_require = require_tags
-                .iter()
-                .all(|filter| span_matches_tag_exact_filter(span, filter));
-            if !matches_require {
-                debug!(
-                    "Filtering out span '{}' - doesn't match all required tags {}",
-                    span.name,
-                    require_tags.join(", ")
-                );
-                return true;
-            }
+    if let Some(require_tags) = &config.apm_filter_tags_require
+        && !require_tags.is_empty()
+    {
+        let matches_require = require_tags
+            .iter()
+            .all(|filter| span_matches_tag_exact_filter(span, filter));
+        if !matches_require {
+            debug!(
+                "Filtering out span '{}' - doesn't match all required tags {}",
+                span.name,
+                require_tags.join(", ")
+            );
+            return true;
         }
     }
 
     // Handle required regex tags from DD_APM_FILTER_TAGS_REGEX_REQUIRE (regex match)
-    if let Some(require_regex_tags) = &config.apm_filter_tags_regex_require {
-        if !require_regex_tags.is_empty() {
-            let matches_require_regex = require_regex_tags
-                .iter()
-                .all(|filter| span_matches_tag_regex_filter(span, filter));
-            if !matches_require_regex {
-                debug!(
-                    "Filtering out span '{}' - doesn't match all required regex tags {}",
-                    span.name,
-                    require_regex_tags.join(", ")
-                );
-                return true;
-            }
+    if let Some(require_regex_tags) = &config.apm_filter_tags_regex_require
+        && !require_regex_tags.is_empty()
+    {
+        let matches_require_regex = require_regex_tags
+            .iter()
+            .all(|filter| span_matches_tag_regex_filter(span, filter));
+        if !matches_require_regex {
+            debug!(
+                "Filtering out span '{}' - doesn't match all required regex tags {}",
+                span.name,
+                require_regex_tags.join(", ")
+            );
+            return true;
         }
     }
 
     // Handle reject tags from DD_APM_FILTER_TAGS_REJECT (exact match)
-    if let Some(reject_tags) = &config.apm_filter_tags_reject {
-        if !reject_tags.is_empty() {
-            let matches_reject = reject_tags
-                .iter()
-                .any(|filter| span_matches_tag_exact_filter(span, filter));
-            if matches_reject {
-                debug!(
-                    "Filtering out span '{}' - matches reject tags {}",
-                    span.name,
-                    reject_tags.join(", ")
-                );
-                return true;
-            }
+    if let Some(reject_tags) = &config.apm_filter_tags_reject
+        && !reject_tags.is_empty()
+    {
+        let matches_reject = reject_tags
+            .iter()
+            .any(|filter| span_matches_tag_exact_filter(span, filter));
+        if matches_reject {
+            debug!(
+                "Filtering out span '{}' - matches reject tags {}",
+                span.name,
+                reject_tags.join(", ")
+            );
+            return true;
         }
     }
 
     // Handle reject regex tags from DD_APM_FILTER_TAGS_REGEX_REJECT (regex match)
-    if let Some(reject_regex_tags) = &config.apm_filter_tags_regex_reject {
-        if !reject_regex_tags.is_empty() {
-            let matches_reject_regex = reject_regex_tags
-                .iter()
-                .any(|filter| span_matches_tag_regex_filter(span, filter));
-            if matches_reject_regex {
-                debug!(
-                    "Filtering out span '{}' - matches reject regex tags {}",
-                    span.name,
-                    reject_regex_tags.join(", ")
-                );
-                return true;
-            }
+    if let Some(reject_regex_tags) = &config.apm_filter_tags_regex_reject
+        && !reject_regex_tags.is_empty()
+    {
+        let matches_reject_regex = reject_regex_tags
+            .iter()
+            .any(|filter| span_matches_tag_regex_filter(span, filter));
+        if matches_reject_regex {
+            debug!(
+                "Filtering out span '{}' - matches reject regex tags {}",
+                span.name,
+                reject_regex_tags.join(", ")
+            );
+            return true;
         }
     }
 
@@ -189,10 +189,10 @@ fn span_matches_tag_regex_filter(span: &Span, filter: &str) -> bool {
 }
 
 fn span_matches_tag_exact(span: &Span, key: &str, value: &str) -> bool {
-    if let Some(span_value) = span.meta.get(key) {
-        if span_value == value {
-            return true;
-        }
+    if let Some(span_value) = span.meta.get(key)
+        && span_value == value
+    {
+        return true;
     }
 
     let span_property_value = match key {
@@ -203,10 +203,10 @@ fn span_matches_tag_exact(span: &Span, key: &str, value: &str) -> bool {
         _ => None,
     };
 
-    if let Some(prop_value) = span_property_value {
-        if prop_value == value {
-            return true;
-        }
+    if let Some(prop_value) = span_property_value
+        && prop_value == value
+    {
+        return true;
     }
 
     false
@@ -221,10 +221,10 @@ fn span_matches_tag_regex(span: &Span, key: &str, value: &str) -> bool {
         return false;
     };
 
-    if let Some(span_value) = span.meta.get(key) {
-        if regex.is_match(span_value) {
-            return true;
-        }
+    if let Some(span_value) = span.meta.get(key)
+        && regex.is_match(span_value)
+    {
+        return true;
     }
 
     let span_property_value = match key {
@@ -234,10 +234,10 @@ fn span_matches_tag_regex(span: &Span, key: &str, value: &str) -> bool {
         "type" => Some(&span.r#type),
         _ => None,
     };
-    if let Some(prop_value) = span_property_value {
-        if regex.is_match(prop_value) {
-            return true;
-        }
+    if let Some(prop_value) = span_property_value
+        && regex.is_match(prop_value)
+    {
+        return true;
     }
 
     false
@@ -257,13 +257,12 @@ fn span_has_key(span: &Span, key: &str) -> bool {
 }
 
 fn filter_span_from_lambda_library_or_runtime(span: &Span) -> bool {
-    if let Some(url) = span.meta.get("http.url") {
-        if url.starts_with(LAMBDA_RUNTIME_URL_PREFIX)
+    if let Some(url) = span.meta.get("http.url")
+        && (url.starts_with(LAMBDA_RUNTIME_URL_PREFIX)
             || url.starts_with(LAMBDA_EXTENSION_URL_PREFIX)
-            || url.starts_with(LAMBDA_STATSD_URL_PREFIX)
-        {
-            return true;
-        }
+            || url.starts_with(LAMBDA_STATSD_URL_PREFIX))
+    {
+        return true;
     }
 
     if let (Some(tcp_host), Some(tcp_port)) = (
@@ -281,13 +280,12 @@ fn filter_span_from_lambda_library_or_runtime(span: &Span) -> bool {
         }
     }
 
-    if let Some(dns_address) = span.meta.get("dns.address") {
-        if dns_address.starts_with(DNS_NON_ROUTABLE_ADDRESS_URL_PREFIX)
+    if let Some(dns_address) = span.meta.get("dns.address")
+        && (dns_address.starts_with(DNS_NON_ROUTABLE_ADDRESS_URL_PREFIX)
             || dns_address.starts_with(DNS_LOCAL_HOST_ADDRESS_URL_PREFIX)
-            || dns_address.starts_with(AWS_XRAY_DAEMON_ADDRESS_URL_PREFIX)
-        {
-            return true;
-        }
+            || dns_address.starts_with(AWS_XRAY_DAEMON_ADDRESS_URL_PREFIX))
+    {
+        return true;
     }
     if span.resource == INVOCATION_SPAN_RESOURCE {
         return true;


### PR DESCRIPTION
The Go (compatibility) agent supports both V1 and V2 naming conventions for OTLP traces, this PR adds V1 support in addition to the existing V2 support in the new agent.

## Motivation
[SLES-2391](https://datadoghq.atlassian.net/browse/SLES-2391)

## Notes
Lots of clippy changes in this one too

[SLES-2391]: https://datadoghq.atlassian.net/browse/SLES-2391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ