### PR TITLE
fix(logs): remove sync mutex from logs

### DIFF
--- a/bottlecap/src/logs/agent.rs
+++ b/bottlecap/src/logs/agent.rs
@@ -1,5 +1,8 @@
-use std::sync::{Arc, Mutex};
-use tokio::sync::mpsc::{self, Sender};
+use std::sync::Arc;
+use tokio::sync::{
+    Mutex,
+    mpsc::{self, Sender},
+};
 
 use crate::event_bus::Event;
 use crate::logs::{aggregator::Aggregator, processor::LogsProcessor};

--- a/bottlecap/src/logs/flusher.rs
+++ b/bottlecap/src/logs/flusher.rs
@@ -8,13 +8,12 @@ use hyper::StatusCode;
 use reqwest::header::HeaderMap;
 use std::error::Error;
 use std::time::Instant;
-use std::{
-    io::Write,
-    sync::{Arc, Mutex},
-};
+use std::{io::Write, sync::Arc};
 use thiserror::Error as ThisError;
-use tokio::sync::OnceCell;
-use tokio::task::JoinSet;
+use tokio::{
+    sync::{Mutex, OnceCell},
+    task::JoinSet,
+};
 use tracing::{debug, error};
 use zstd::stream::write::Encoder;
 
@@ -247,7 +246,7 @@ impl LogsFlusher {
         } else {
             // Get batches from primary flusher's aggregator
             let logs_batches = Arc::new({
-                let mut guard = self.flushers[0].aggregator.lock().expect("lock poisoned");
+                let mut guard = self.flushers[0].aggregator.lock().await;
                 let mut batches = Vec::new();
                 let mut current_batch = guard.get_batch();
                 while !current_batch.is_empty() {

--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
-use std::sync::{Arc, Mutex};
-use tokio::sync::mpsc::Sender;
+use std::sync::Arc;
+use tokio::sync::{Mutex, mpsc::Sender};
 
 use tracing::{debug, error};
 
@@ -353,7 +353,7 @@ impl LambdaProcessor {
         if self.ready_logs.is_empty() {
             return;
         }
-        let mut aggregator = aggregator.lock().expect("lock poisoned");
+        let mut aggregator = aggregator.lock().await;
         aggregator.add_batch(std::mem::take(&mut self.ready_logs));
     }
 }
@@ -752,7 +752,7 @@ mod tests {
 
         processor.process(event.clone(), &aggregator).await;
 
-        let mut aggregator_lock = aggregator.lock().unwrap();
+        let mut aggregator_lock = aggregator.lock().await;
         let batch = aggregator_lock.get_batch();
         let log = IntakeLog {
             message: Message {
@@ -804,7 +804,7 @@ mod tests {
 
         processor.process(event.clone(), &aggregator).await;
 
-        let mut aggregator_lock = aggregator.lock().unwrap();
+        let mut aggregator_lock = aggregator.lock().await;
         let batch = aggregator_lock.get_batch();
         assert_eq!(batch.len(), 0);
     }
@@ -836,7 +836,7 @@ mod tests {
         processor.process(event.clone(), &aggregator).await;
         assert_eq!(processor.orphan_logs.len(), 1);
 
-        let mut aggregator_lock = aggregator.lock().unwrap();
+        let mut aggregator_lock = aggregator.lock().await;
         let batch = aggregator_lock.get_batch();
         assert!(batch.is_empty());
     }
@@ -884,7 +884,7 @@ mod tests {
         processor.process(event.clone(), &aggregator).await;
 
         // Verify aggregator logs
-        let mut aggregator_lock = aggregator.lock().unwrap();
+        let mut aggregator_lock = aggregator.lock().await;
         let batch = aggregator_lock.get_batch();
         let start_log = IntakeLog {
             message: Message {

--- a/bottlecap/src/logs/processor.rs
+++ b/bottlecap/src/logs/processor.rs
@@ -1,5 +1,5 @@
-use std::sync::{Arc, Mutex};
-use tokio::sync::mpsc::Sender;
+use std::sync::Arc;
+use tokio::sync::{Mutex, mpsc::Sender};
 
 use tracing::debug;
 


### PR DESCRIPTION
# What?

Removes the use of `sync::mutex` from logs agent and processor

# Why?

It's being used in an async context, we could potentially starve the async runtime