### PR TITLE
feat(aap): report `_dd.runtime_family` when AAP is enabled

### DIFF
--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -23,6 +23,8 @@ const FUNCTION_NAME_KEY: &str = "functionname";
 const EXECUTED_VERSION_KEY: &str = "executedversion";
 // RuntimeKey is the tag key for a function's runtime (e.g. node, python)
 const RUNTIME_KEY: &str = "runtime";
+// The identified runtime family, set only if serverless AAP is enabled.
+const RUNTIME_FAMILY_KEY: &str = "_dd.runtime_family";
 // MemorySizeKey is the tag key for a function's allocated memory size
 const MEMORY_SIZE_KEY: &str = "memorysize";
 // TODO(astuyve): fetch architecture from the runtime
@@ -109,6 +111,11 @@ fn tags_from_env(
         tags_map.insert(MEMORY_SIZE_KEY.to_string(), memory_size);
     }
     if let Ok(runtime) = std::env::var(RUNTIME_VAR) {
+        if config.serverless_appsec_enabled {
+            if let Some(runtime_family) = identify_runtime_family(&runtime) {
+                tags_map.insert(RUNTIME_FAMILY_KEY.to_string(), runtime_family.to_string());
+            }
+        }
         tags_map.insert(RUNTIME_KEY.to_string(), runtime);
     }
 
@@ -247,6 +254,26 @@ impl Lambda {
             .collect::<Vec<String>>()
             .join(",");
         HashMap::from_iter([(FUNCTION_TAGS_KEY.to_string(), tags)])
+    }
+}
+
+/// Identify the runtime family for a given runtime identifier (as provided by the [`RUNTIME_VAR`] environment
+/// variable). This is used by Serverless AAP to categorize the technology used by the client application, and is one of
+/// the following values: `nodejs`, `ruby`, `jvm`, `dotnet`, `go`, `php`, or `python`. Note that some of these we cannot
+/// identify here (i.e, `go` as it uses the `provided` runtime).
+fn identify_runtime_family(runtime: &str) -> Option<&'static str> {
+    if runtime.starts_with("nodejs") {
+        Some("nodejs")
+    } else if runtime.starts_with("python") {
+        Some("python")
+    } else if runtime.starts_with("java") {
+        Some("jvm") // And not "java", intentionally.
+    } else if runtime.starts_with("dotnet") {
+        Some("dotnet")
+    } else if runtime.starts_with("ruby") {
+        Some("ruby")
+    } else {
+        None
     }
 }
 
@@ -390,6 +417,48 @@ mod tests {
             ]),
             env: Some("test".to_string()),
             version: Some("1.0.0".to_string()),
+            ..Config::default()
+        });
+        let tags = Lambda::new_from_config(config, &metadata);
+        let function_tags = tags.get_function_tags_map();
+        assert_eq!(function_tags.len(), 1);
+        let fn_tags_map: HashMap<String, String> = function_tags
+            .get(FUNCTION_TAGS_KEY)
+            .unwrap()
+            .split(',')
+            .map(|tag| {
+                let parts = tag.split(':').collect::<Vec<&str>>();
+                (parts[0].to_string(), parts[1].to_string())
+            })
+            .collect();
+        assert_eq!(fn_tags_map.len(), 14);
+        assert_eq!(fn_tags_map.get("key1").unwrap(), "value1");
+        assert_eq!(fn_tags_map.get("key2").unwrap(), "value2");
+        assert_eq!(fn_tags_map.get(ACCOUNT_ID_KEY).unwrap(), "123456789012");
+        assert_eq!(fn_tags_map.get(ENV_KEY).unwrap(), "test");
+        assert_eq!(fn_tags_map.get(FUNCTION_ARN_KEY).unwrap(), "arn");
+        assert_eq!(fn_tags_map.get(FUNCTION_NAME_KEY).unwrap(), "my-function");
+        assert_eq!(fn_tags_map.get(REGION_KEY).unwrap(), "us-west-2");
+        assert_eq!(fn_tags_map.get(SERVICE_KEY).unwrap(), "my-service");
+        assert_eq!(fn_tags_map.get(VERSION_KEY).unwrap(), "1.0.0");
+    }
+
+    #[test]
+    fn test_get_function_tags_map_with_appsec_enabled() {
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            FUNCTION_ARN_KEY.to_string(),
+            "arn:aws:lambda:us-west-2:123456789012:function:my-function".to_string(),
+        );
+        let config = Arc::new(Config {
+            service: Some("my-service".to_string()),
+            tags: HashMap::from([
+                ("key1".to_string(), "value1".to_string()),
+                ("key2".to_string(), "value2".to_string()),
+            ]),
+            env: Some("test".to_string()),
+            version: Some("1.0.0".to_string()),
+            serverless_appsec_enabled: true,
             ..Config::default()
         });
         let tags = Lambda::new_from_config(config, &metadata);


### PR DESCRIPTION
Leverage the runtime identifier information once it becomes available.