### PR TITLE
Support OpenTelemetry Trace Operation Name V1

### DIFF
--- a/bottlecap/src/otlp/transform.rs
+++ b/bottlecap/src/otlp/transform.rs
@@ -1,4 +1,6 @@
-use datadog_trace_normalization::normalize_utils::{normalize_service, normalize_tag};
+use datadog_trace_normalization::normalize_utils::{
+    normalize_name, normalize_service, normalize_tag,
+};
 use datadog_trace_protobuf::pb::Span as DatadogSpan;
 use hex;
 use lazy_static::lazy_static;
@@ -187,6 +189,15 @@ pub fn otel_span_id_to_u64(span_id: &[u8]) -> u64 {
     u64::from_be_bytes(span_id.try_into().unwrap_or_default())
 }
 
+// Checks if the new operation and resource name logic should be used
+fn otel_operation_and_resource_v2_enabled(config: Arc<Config>) -> bool {
+    !config.otlp_config_traces_span_name_as_resource_name
+        && config.otlp_config_traces_span_name_remappings.is_empty()
+        && !config
+            .apm_features
+            .contains(&"disable_operation_and_resource_name_logic_v2".to_string())
+}
+
 fn get_otel_service(otel_res: &OtelResource, normalize: bool) -> String {
     let mut service =
         get_otel_attribute_value_as_string(&otel_res.attributes, SERVICE_NAME, normalize);
@@ -202,7 +213,40 @@ fn get_otel_service(otel_res: &OtelResource, normalize: bool) -> String {
     service
 }
 
-fn get_otel_operation_name(otel_span: &OtelSpan) -> String {
+fn get_otel_operation_name_v1(
+    otel_span: &OtelSpan,
+    lib: &OtelInstrumentationScope,
+    span_name_as_resource_name: bool,
+    span_name_remappings: &HashMap<String, String>,
+    normalize: bool,
+) -> String {
+    let mut operation_name =
+        get_otel_attribute_value_as_string(&otel_span.attributes, "operation.name", false);
+    if operation_name.is_empty() {
+        if span_name_as_resource_name {
+            operation_name.clone_from(&otel_span.name);
+        } else {
+            let span_kind_name = get_dd_span_kind_from_otel_kind(otel_span);
+            if lib.name.is_empty() {
+                operation_name = format!("opentelemetry.{span_kind_name}");
+            } else {
+                operation_name = format!("{}.{}", lib.name, span_kind_name);
+            }
+        }
+    }
+
+    if let Some(remapping_name) = span_name_remappings.get(&operation_name) {
+        operation_name = remapping_name.clone();
+    }
+
+    if normalize {
+        normalize_name(&mut operation_name);
+    }
+
+    operation_name
+}
+
+fn get_otel_operation_name_v2(otel_span: &OtelSpan) -> String {
     let operation_name =
         get_otel_attribute_value_as_string(&otel_span.attributes, "operation.name", false);
     if !operation_name.is_empty() {
@@ -829,8 +873,16 @@ pub fn otel_span_to_dd_span(
             dd_span.service = get_otel_service(otel_res, true);
         }
 
-        if dd_span.name.is_empty() {
-            dd_span.name = get_otel_operation_name(otel_span);
+        if otel_operation_and_resource_v2_enabled(config.clone()) {
+            dd_span.name = get_otel_operation_name_v2(otel_span);
+        } else {
+            dd_span.name = get_otel_operation_name_v1(
+                otel_span,
+                lib,
+                config.otlp_config_traces_span_name_as_resource_name,
+                &config.otlp_config_traces_span_name_remappings,
+                true,
+            );
         }
 
         if dd_span.resource.is_empty() {
@@ -1244,5 +1296,26 @@ mod tests {
     fn test_otel_value_to_string_empty_kvlist() {
         let value = Value::KvlistValue(KeyValueList { values: vec![] });
         assert_eq!(otel_value_to_string(&value), "{}");
+    }
+
+    #[test]
+    fn test_otel_operation_name() {
+        let otel_span = OtelSpan {
+            name: "test-span".to_string(),
+            kind: SpanKind::Server as i32,
+            ..Default::default()
+        };
+        let lib = OtelInstrumentationScope {
+            name: "opentelemetry_instrumentation_aws_lambda".to_string(),
+            version: "".to_string(),
+            attributes: [].to_vec(),
+            dropped_attributes_count: 0,
+        };
+
+        assert_eq!(
+            get_otel_operation_name_v1(&otel_span, &lib, false, &HashMap::new(), true),
+            "opentelemetry_instrumentation_aws_lambda.server"
+        );
+        assert_eq!(get_otel_operation_name_v2(&otel_span), "server.request");
     }
 }


### PR DESCRIPTION
The Go (compatibility) agent supports both V1 and V2 naming conventions for OTLP traces, this PR adds V1 support in addition to the existing V2 support in the new agent.

## Motivation
[SLES-2391](https://datadoghq.atlassian.net/browse/SLES-2391)


[SLES-2391]: https://datadoghq.atlassian.net/browse/SLES-2391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ