### PR TITLE
feat: [Trace Stats] Add feature flag DD_COMPUTE_TRACE_STATS

### DIFF
--- a/bottlecap/src/config/env.rs
+++ b/bottlecap/src/config/env.rs
@@ -349,10 +349,16 @@ pub struct EnvConfig {
     /// The maximum depth of the Lambda payload to capture.
     /// Default is `10`. Requires `capture_lambda_payload` to be `true`.
     pub capture_lambda_payload_max_depth: Option<u32>,
+    /// @env `DD_COMPUTE_TRACE_STATS`
+    ///
+    /// Enable computation of trace stats for AWS Lambda.
+    #[serde(deserialize_with = "deserialize_optional_bool_from_anything")]
+    pub compute_trace_stats: Option<bool>,
     /// @env `DD_SERVERLESS_APPSEC_ENABLED`
     ///
     /// Enable Application and API Protection (AAP), previously known as AppSec/ASM, for AWS Lambda.
     /// Default is `false`.
+    /// 
     #[serde(deserialize_with = "deserialize_optional_bool_from_anything")]
     pub serverless_appsec_enabled: Option<bool>,
     /// @env `DD_APPSEC_RULES`
@@ -548,6 +554,7 @@ fn merge_config(config: &mut Config, env_config: &EnvConfig) {
     merge_option_to_value!(config, env_config, lambda_proc_enhanced_metrics);
     merge_option_to_value!(config, env_config, capture_lambda_payload);
     merge_option_to_value!(config, env_config, capture_lambda_payload_max_depth);
+    merge_option_to_value!(config, env_config, compute_trace_stats);
     merge_option_to_value!(config, env_config, serverless_appsec_enabled);
     merge_option!(config, env_config, appsec_rules);
     merge_option_to_value!(config, env_config, appsec_waf_timeout);
@@ -741,6 +748,7 @@ mod tests {
             jail.set_env("DD_LAMBDA_PROC_ENHANCED_METRICS", "false");
             jail.set_env("DD_CAPTURE_LAMBDA_PAYLOAD", "true");
             jail.set_env("DD_CAPTURE_LAMBDA_PAYLOAD_MAX_DEPTH", "5");
+            jail.set_env("DD_COMPUTE_TRACE_STATS", "true");
             jail.set_env("DD_SERVERLESS_APPSEC_ENABLED", "true");
             jail.set_env("DD_APPSEC_RULES", "/path/to/rules.json");
             jail.set_env("DD_APPSEC_WAF_TIMEOUT", "1000000"); // Microseconds
@@ -888,6 +896,7 @@ mod tests {
                 lambda_proc_enhanced_metrics: false,
                 capture_lambda_payload: true,
                 capture_lambda_payload_max_depth: 5,
+                compute_trace_stats: true,
                 serverless_appsec_enabled: true,
                 appsec_rules: Some("/path/to/rules.json".to_string()),
                 appsec_waf_timeout: Duration::from_secs(1),

--- a/bottlecap/src/config/env.rs
+++ b/bottlecap/src/config/env.rs
@@ -360,7 +360,7 @@ pub struct EnvConfig {
     ///
     /// Enable Application and API Protection (AAP), previously known as AppSec/ASM, for AWS Lambda.
     /// Default is `false`.
-    /// 
+    ///
     #[serde(deserialize_with = "deserialize_optional_bool_from_anything")]
     pub serverless_appsec_enabled: Option<bool>,
     /// @env `DD_APPSEC_RULES`

--- a/bottlecap/src/config/env.rs
+++ b/bottlecap/src/config/env.rs
@@ -351,7 +351,9 @@ pub struct EnvConfig {
     pub capture_lambda_payload_max_depth: Option<u32>,
     /// @env `DD_COMPUTE_TRACE_STATS`
     ///
-    /// Enable computation of trace stats for AWS Lambda.
+    /// If true, enable computation of trace stats on the extension side.
+    /// If false, trace stats will be computed on the backend side.
+    /// Default is `false`.
     #[serde(deserialize_with = "deserialize_optional_bool_from_anything")]
     pub compute_trace_stats: Option<bool>,
     /// @env `DD_SERVERLESS_APPSEC_ENABLED`

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -341,6 +341,7 @@ pub struct Config {
     pub lambda_proc_enhanced_metrics: bool,
     pub capture_lambda_payload: bool,
     pub capture_lambda_payload_max_depth: u32,
+    pub compute_trace_stats: bool,
 
     pub serverless_appsec_enabled: bool,
     pub appsec_rules: Option<String>,
@@ -441,6 +442,7 @@ impl Default for Config {
             lambda_proc_enhanced_metrics: true,
             capture_lambda_payload: false,
             capture_lambda_payload_max_depth: 10,
+            compute_trace_stats: false,
 
             serverless_appsec_enabled: false,
             appsec_rules: None,

--- a/bottlecap/src/config/yaml.rs
+++ b/bottlecap/src/config/yaml.rs
@@ -99,6 +99,8 @@ pub struct YamlConfig {
     pub capture_lambda_payload: Option<bool>,
     pub capture_lambda_payload_max_depth: Option<u32>,
     #[serde(deserialize_with = "deserialize_optional_bool_from_anything")]
+    pub compute_trace_stats: Option<bool>,
+    #[serde(deserialize_with = "deserialize_optional_bool_from_anything")]
     pub serverless_appsec_enabled: Option<bool>,
     pub appsec_rules: Option<String>,
     #[serde(deserialize_with = "deserialize_optional_duration_from_microseconds")]
@@ -654,6 +656,7 @@ fn merge_config(config: &mut Config, yaml_config: &YamlConfig) {
     merge_option_to_value!(config, yaml_config, lambda_proc_enhanced_metrics);
     merge_option_to_value!(config, yaml_config, capture_lambda_payload);
     merge_option_to_value!(config, yaml_config, capture_lambda_payload_max_depth);
+    merge_option_to_value!(config, yaml_config, compute_trace_stats);
     merge_option_to_value!(config, yaml_config, serverless_appsec_enabled);
     merge_option!(config, yaml_config, appsec_rules);
     merge_option_to_value!(config, yaml_config, appsec_waf_timeout);
@@ -823,6 +826,7 @@ enhanced_metrics: false
 lambda_proc_enhanced_metrics: false
 capture_lambda_payload: true
 capture_lambda_payload_max_depth: 5
+compute_trace_stats: true
 serverless_appsec_enabled: true
 appsec_rules: "/path/to/rules.json"
 appsec_waf_timeout: 1000000 # Microseconds
@@ -953,6 +957,7 @@ extension_version: "compatibility"
                 lambda_proc_enhanced_metrics: false,
                 capture_lambda_payload: true,
                 capture_lambda_payload_max_depth: 5,
+                compute_trace_stats: true,
 
                 serverless_appsec_enabled: true,
                 appsec_rules: Some("/path/to/rules.json".to_string()),

--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -40,8 +40,6 @@ const SERVICE_KEY: &str = "service";
 
 // ComputeStatsKey is the tag key indicating whether trace stats should be computed
 const COMPUTE_STATS_KEY: &str = "_dd.compute_stats";
-// ComputeStatsValue is the tag value indicating trace stats should be computed
-const COMPUTE_STATS_VALUE: &str = "1";
 // FunctionTagsKey is the tag key for a function's tags to be set on the top level tracepayload
 const FUNCTION_TAGS_KEY: &str = "_dd.tags.function";
 // TODO(astuyve) decide what to do with the version
@@ -129,10 +127,11 @@ fn tags_from_env(
         tags_map.extend(config.tags.clone());
     }
 
-    tags_map.insert(
-        COMPUTE_STATS_KEY.to_string(),
-        COMPUTE_STATS_VALUE.to_string(),
-    );
+    // "config.compute_trace_stats == true" means computing stats on the extension side,
+    // so we set _dd.compute_stats to 0 so stats won't be computed on the backend side.
+    let compute_stats = i32::from(!config.compute_trace_stats);
+    tags_map.insert(COMPUTE_STATS_KEY.to_string(), compute_stats.to_string());
+
     tags_map
 }
 
@@ -295,7 +294,7 @@ mod tests {
         assert_eq!(tags.tags_map.len(), 3);
         assert_eq!(
             tags.tags_map.get(COMPUTE_STATS_KEY).unwrap(),
-            COMPUTE_STATS_VALUE
+            "1"
         );
         let arch = arch_to_platform();
         assert_eq!(

--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -127,6 +127,7 @@ fn tags_from_env(
         tags_map.extend(config.tags.clone());
     }
 
+    // The value of _dd.compute_stats is the opposite of config.compute_trace_stats.
     // "config.compute_trace_stats == true" means computing stats on the extension side,
     // so we set _dd.compute_stats to 0 so stats won't be computed on the backend side.
     let compute_stats = i32::from(!config.compute_trace_stats);

--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -293,10 +293,7 @@ mod tests {
         let metadata = HashMap::new();
         let tags = Lambda::new_from_config(Arc::new(Config::default()), &metadata);
         assert_eq!(tags.tags_map.len(), 3);
-        assert_eq!(
-            tags.tags_map.get(COMPUTE_STATS_KEY).unwrap(),
-            "1"
-        );
+        assert_eq!(tags.tags_map.get(COMPUTE_STATS_KEY).unwrap(), "1");
         let arch = arch_to_platform();
         assert_eq!(
             tags.tags_map.get(ARCHITECTURE_KEY).unwrap(),


### PR DESCRIPTION
## This PR

Adds a feature flag `DD_COMPUTE_TRACE_STATS`.
- If true, trace stats will be computed from the extension side. In this case, we set `_dd.compute_stats` to `0`, so trace stats won't be computed on the backend.
- If false, trace stats will NOT be computed from the extension side. In this case, we set `_dd.compute_stats` to `1`, so trace stats will be computed on the backend.
- Defaults to false for now, so `_dd.compute_stats` still defaults to `1`, i.e. default behavior is not changed.
- After we fully support computing trace stats on extension side, I will change the default to true then delete the flag.

Jira: https://datadoghq.atlassian.net/browse/SVLS-7593