### PR TITLE
fix: setting last_flush to 0 makes us flush on the first invocation

### DIFF
--- a/bottlecap/src/lifecycle/flush_control.rs
+++ b/bottlecap/src/lifecycle/flush_control.rs
@@ -131,7 +131,7 @@ mod tests {
             60,
         );
         // Set last_flush to an older time to trigger flush
-        flush_control.last_flush = flush_control.last_flush - 2;
+        flush_control.last_flush -= 2;
         assert_eq!(flush_control.evaluate_flush_decision(), FlushDecision::End);
 
         let mut flush_control = FlushControl::new(FlushStrategy::End, 60);
@@ -142,7 +142,7 @@ mod tests {
             60,
         );
         // Set last_flush to an older time to trigger flush
-        flush_control.last_flush = flush_control.last_flush - 2;
+        flush_control.last_flush -= 2;
         assert_eq!(
             flush_control.evaluate_flush_decision(),
             FlushDecision::Periodic
@@ -163,7 +163,7 @@ mod tests {
             assert_eq!(flush_control.evaluate_flush_decision(), FlushDecision::End);
         }
         // Set last_flush to an older time to trigger flush after lookback threshold
-        flush_control.last_flush = flush_control.last_flush - 61;
+        flush_control.last_flush -= 61;
         assert_eq!(
             flush_control.evaluate_flush_decision(),
             FlushDecision::Continuous
@@ -177,7 +177,7 @@ mod tests {
             60,
         );
         // Set last_flush to an older time to trigger flush
-        flush_control.last_flush = flush_control.last_flush - 2;
+        flush_control.last_flush -= 2;
         assert_eq!(
             flush_control.evaluate_flush_decision(),
             FlushDecision::Periodic,


### PR DESCRIPTION
Setting the last flush time to 0 causes the logic for continuous flushing to always evaluate to `flush` on the first invocation.

This change fixes that, unless there is a proactive initialization or some other out-of-band cause.
