### PR TITLE
feat: SendData may block, force it to yield.

### DIFF
--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -28,7 +28,7 @@ reqwest = { version = "0.12.11", features = ["json", "http2"], default-features 
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 thiserror = { version = "1.0", default-features = false }
-tokio = { version = "1.47", default-features = false, features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.47", default-features = false, features = ["macros", "rt-multi-thread", "time"] }
 tokio-util = { version = "0.7", default-features = false }
 tracing = { version = "0.1", default-features = false }
 tracing-core = { version = "0.1", default-features = false }

--- a/bottlecap/src/config/aws.rs
+++ b/bottlecap/src/config/aws.rs
@@ -1,4 +1,5 @@
-use std::{env, time::Instant};
+use std::env;
+use tokio::time::Instant;
 
 const AWS_DEFAULT_REGION: &str = "AWS_DEFAULT_REGION";
 const AWS_ACCESS_KEY_ID: &str = "AWS_ACCESS_KEY_ID";

--- a/bottlecap/src/lifecycle/flush_control.rs
+++ b/bottlecap/src/lifecycle/flush_control.rs
@@ -27,9 +27,13 @@ pub enum FlushDecision {
 impl FlushControl {
     #[must_use]
     pub fn new(flush_strategy: FlushStrategy, flush_timeout: u64) -> FlushControl {
+        let now = time::SystemTime::now()
+            .duration_since(time::UNIX_EPOCH)
+            .expect("unable to poll clock, unrecoverable")
+            .as_secs();
         FlushControl {
             flush_strategy,
-            last_flush: 0,
+            last_flush: now,
             invocation_times: InvocationTimes::new(),
             flush_timeout,
         }

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{HashMap, VecDeque},
     sync::Arc,
-    time::{Instant, SystemTime, UNIX_EPOCH},
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use chrono::{DateTime, Utc};
@@ -9,6 +9,7 @@ use datadog_trace_protobuf::pb::Span;
 use datadog_trace_utils::tracer_header_tags;
 use serde_json::Value;
 use tokio::sync::watch;
+use tokio::time::Instant;
 use tracing::{debug, warn};
 
 use crate::{

--- a/bottlecap/src/traces/stats_processor.rs
+++ b/bottlecap/src/traces/stats_processor.rs
@@ -41,7 +41,6 @@ impl StatsProcessor for ServerlessStatsProcessor {
         req: Request,
         tx: Sender<pb::ClientStatsPayload>,
     ) -> Result<Response, Box<dyn std::error::Error + Send + Sync>> {
-        debug!("Received trace stats to process");
         let (parts, body) = match extract_request_body(req).await {
             Ok(r) => r,
             Err(e) => {

--- a/bottlecap/src/traces/trace_flusher.rs
+++ b/bottlecap/src/traces/trace_flusher.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
+use tokio::time::{Duration, interval};
 use tracing::{debug, error};
 
 use datadog_trace_utils::{
@@ -164,7 +165,7 @@ impl TraceFlusher for ServerlessTraceFlusher {
         if traces.is_empty() {
             return None;
         }
-        let start = std::time::Instant::now();
+        let start = tokio::time::Instant::now();
         let coalesced_traces = trace_utils::coalesce_send_data(traces);
         tokio::task::yield_now().await;
         debug!("Flushing {} traces", coalesced_traces.len());
@@ -175,10 +176,23 @@ impl TraceFlusher for ServerlessTraceFlusher {
                 None => trace.clone(),
             };
 
-            let send_result = trace_with_endpoint
-                .send_proxy(proxy_https.as_deref())
-                .await
-                .last_result;
+            let mut counter = 0;
+            // TODO(astuyve) is 100ms the right amount here?
+            let mut tick_interval = interval(Duration::from_millis(100));
+            let send_future = trace_with_endpoint.send_proxy(proxy_https.as_deref());
+            tokio::pin!(send_future);
+            let send_result = loop {
+                tokio::select! {
+                    result = &mut send_future => {
+                        break result.last_result;
+                    }
+                    _ = tick_interval.tick() => {
+                        counter += 1;
+                        debug!("Waiting for trace send completion, tick #{}", counter);
+                        tokio::task::yield_now().await;
+                    }
+                }
+            };
 
             if let Err(e) = send_result {
                 error!("Error sending trace: {e:?}");


### PR DESCRIPTION
SendData appears to occasionally block until it receives a response. This can block other tasks from being scheduled, which may lead to timeouts in very rare circumstances. This tick counter allows the task to yield so tokio can schedule something else to run.
