### PR TITLE
feat: don't spawn tmp/proc tasks if one is still running

### DIFF
--- a/bottlecap/src/metrics/enhanced/lambda.rs
+++ b/bottlecap/src/metrics/enhanced/lambda.rs
@@ -20,7 +20,10 @@ use tokio::{
 };
 use tracing::debug;
 use tracing::error;
-
+// tmp/proc enhanced metrics tasks open and/or read files in the /proc directory using blocking I/O.
+// These tasks can block the async context the task is called under and thus delay other important work.
+// In rare cases, if the tasks start taking longer than the typical invocations take, these tasks can pile up and cause timeouts.
+// So we ensure only one task to measure these is ever running at the same time
 static TMP_TASK_RUNNING: AtomicBool = AtomicBool::new(false);
 static PROCESS_TASK_RUNNING: AtomicBool = AtomicBool::new(false);
 


### PR DESCRIPTION
tmp/proc enhanced metrics tasks open and/or read files in the /proc directory using blocking I/O. These tasks can block the async context the task is called under and thus delay other important work. In rare cases, if the tasks start taking longer than the typical invocations take, these tasks can pile up and cause timeouts.

This PR ensures no other tasks are running before respawning it.

There's likely room for improvement to this logic, which is well structured but likely not ever tested with very fast (rust/go) functions. Potentially instead of relying on locks for the invocation processor or using the invocation to signal begin points, we could detect discontinuous invocations and switch to a polling mechanism.