### PR TITLE
feat: [Trace Stats] Handle tracer lang, tracer version and runtime_id

### DIFF
--- a/bottlecap/src/traces/stats_concentrator.rs
+++ b/bottlecap/src/traces/stats_concentrator.rs
@@ -43,6 +43,9 @@ pub struct Stats {
 #[derive(Clone, Debug, Default)]
 pub struct TracerMetadata {
     pub language: String,
+    pub tracer_version: String,
+    pub runtime_id: String,
+    pub hostname: String,
 }
 
 pub struct StatsConcentrator {
@@ -71,7 +74,6 @@ impl StatsConcentrator {
             config,
             buckets: HashMap::new(),
             tracer_metadata: TracerMetadata::default(), // to be set when a trace is processed
-            function_arn,
         }
     }
 
@@ -117,7 +119,6 @@ impl StatsConcentrator {
                         timestamp,
                         aggregation_key,
                         *stats,
-                        &self.function_arn,
                         &self.tracer_metadata,
                     ));
                 }
@@ -142,20 +143,16 @@ impl StatsConcentrator {
         timestamp: u64,
         aggregation_key: &AggregationKey,
         stats: Stats,
-        function_arn: &str,
         tracer_metadata: &TracerMetadata,
     ) -> pb::ClientStatsPayload {
         pb::ClientStatsPayload {
-            // TODO: handle this
-            hostname: String::new(),
+            hostname: tracer_metadata.hostname.clone(),
             env: aggregation_key.env.clone(),
             // Version is not in the trace payload. Need to read it from config.
             version: config.version.clone().unwrap_or_default(),
             lang: tracer_metadata.language.clone(),
-            // TODO: handle this
-            tracer_version: String::new(),
-            // TODO: handle this
-            runtime_id: String::new(),
+            tracer_version: tracer_metadata.tracer_version.clone(),
+            runtime_id: tracer_metadata.runtime_id.clone(),
             // TODO: handle this
             sequence: 0,
             // TODO: handle this

--- a/bottlecap/src/traces/stats_concentrator.rs
+++ b/bottlecap/src/traces/stats_concentrator.rs
@@ -42,6 +42,7 @@ pub struct Stats {
 
 pub struct StatsConcentrator {
     config: Arc<Config>,
+    tracer_language: String,
     buckets: HashMap<u64, Bucket>,
 }
 
@@ -65,6 +66,10 @@ impl StatsConcentrator {
             config,
             buckets: HashMap::new(),
         }
+    }
+
+    pub fn set_language(&mut self, language: &str) {
+        self.tracer_language = language.to_string();
     }
 
     pub fn add(&mut self, stats_event: StatsEvent) {
@@ -105,6 +110,7 @@ impl StatsConcentrator {
                         timestamp,
                         aggregation_key,
                         *stats,
+                        &self.tracer_metadata,
                     ));
                 }
                 false
@@ -128,6 +134,7 @@ impl StatsConcentrator {
         timestamp: u64,
         aggregation_key: &AggregationKey,
         stats: Stats,
+        tracer_metadata: &TracerMetadata,
     ) -> pb::ClientStatsPayload {
         pb::ClientStatsPayload {
             // TODO: handle this
@@ -135,8 +142,7 @@ impl StatsConcentrator {
             env: aggregation_key.env.clone(),
             // Version is not in the trace payload. Need to read it from config.
             version: config.version.clone().unwrap_or_default(),
-            // TODO: handle this
-            lang: "rust".to_string(),
+            lang: tracer_language.to_string(),
             // TODO: handle this
             tracer_version: String::new(),
             // TODO: handle this

--- a/bottlecap/src/traces/stats_concentrator.rs
+++ b/bottlecap/src/traces/stats_concentrator.rs
@@ -42,10 +42,12 @@ pub struct Stats {
 
 #[derive(Clone, Debug, Default)]
 pub struct TracerMetadata {
+    // e.g. "python"
     pub language: String,
+    // e.g. "3.11.0"
     pub tracer_version: String,
+    // e.g. "f45568ad09d5480b99087d86ebda26e6"
     pub runtime_id: String,
-    pub hostname: String,
 }
 
 pub struct StatsConcentrator {
@@ -146,7 +148,8 @@ impl StatsConcentrator {
         tracer_metadata: &TracerMetadata,
     ) -> pb::ClientStatsPayload {
         pb::ClientStatsPayload {
-            hostname: tracer_metadata.hostname.clone(),
+            // TODO: handle this
+            hostname: String::new(),
             env: aggregation_key.env.clone(),
             // Version is not in the trace payload. Need to read it from config.
             version: config.version.clone().unwrap_or_default(),

--- a/bottlecap/src/traces/stats_generator.rs
+++ b/bottlecap/src/traces/stats_generator.rs
@@ -3,12 +3,13 @@ use crate::traces::stats_concentrator_service::StatsConcentratorHandle;
 use datadog_trace_utils::tracer_payload::TracerPayloadCollection;
 use tracing::error;
 
-use tokio::sync::mpsc::error::SendError;
-
 use crate::traces::stats_concentrator_service::ConcentratorCommand;
+use std::sync::atomic::{AtomicBool, Ordering};
+use tokio::sync::mpsc::error::SendError;
 
 pub struct StatsGenerator {
     stats_concentrator: StatsConcentratorHandle,
+    is_language_set: AtomicBool,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -23,12 +24,26 @@ pub enum StatsGeneratorError {
 impl StatsGenerator {
     #[must_use]
     pub fn new(stats_concentrator: StatsConcentratorHandle) -> Self {
-        Self { stats_concentrator }
+        Self {
+            stats_concentrator,
+            is_language_set: AtomicBool::new(false),
+        }
     }
 
     pub fn send(&self, traces: &TracerPayloadCollection) -> Result<(), StatsGeneratorError> {
         if let TracerPayloadCollection::V07(traces) = traces {
             for trace in traces {
+                // Set the tracer language only once for the first trace because
+                // it is the same for all traces.
+                if !self.is_language_set.load(Ordering::Acquire) {
+                    self.is_language_set.store(true, Ordering::Release);
+                    if let Err(err) = self.stats_concentrator.set_language(&trace.language_name) {
+                        error!("Failed to set tracer language: {err}");
+                        return Err(StatsGeneratorError::ConcentratorCommandError(err));
+                    }
+                }
+
+                // Generate stats for each span in the trace
                 for chunk in &trace.chunks {
                     for span in &chunk.spans {
                         let stats = StatsEvent {

--- a/bottlecap/src/traces/stats_generator.rs
+++ b/bottlecap/src/traces/stats_generator.rs
@@ -40,6 +40,9 @@ impl StatsGenerator {
                     self.is_tracer_metadata_set.store(true, Ordering::Release);
                     let tracer_metadata = TracerMetadata {
                         language: trace.language_name.clone(),
+                        tracer_version: trace.tracer_version.clone(),
+                        runtime_id: trace.runtime_id.clone(),
+                        hostname: trace.hostname.clone(),
                     };
                     if let Err(err) = self
                         .stats_concentrator

--- a/bottlecap/src/traces/stats_generator.rs
+++ b/bottlecap/src/traces/stats_generator.rs
@@ -42,7 +42,6 @@ impl StatsGenerator {
                         language: trace.language_name.clone(),
                         tracer_version: trace.tracer_version.clone(),
                         runtime_id: trace.runtime_id.clone(),
-                        hostname: trace.hostname.clone(),
                     };
                     if let Err(err) = self
                         .stats_concentrator


### PR DESCRIPTION
## This PR
Set these fields on trace stats:
- `lang`
- `tracer_version`
- `runtime_id`

## Notes
Jira: https://datadoghq.atlassian.net/browse/SVLS-7593