### PR TITLE
fix: use joinset for trace flushing

### DIFF
--- a/bottlecap/src/traces/trace_flusher.rs
+++ b/bottlecap/src/traces/trace_flusher.rs
@@ -125,13 +125,9 @@ impl TraceFlusher for ServerlessTraceFlusher {
                 .map(SendDataBuilder::build)
                 .collect();
 
-            tokio::task::yield_now().await;
             let traces_clone = traces.clone();
             let proxy_https = self.config.proxy_https.clone();
-            batch_tasks.spawn(async move {
-                
-                Self::send(traces_clone, None, &proxy_https).await
-            });
+            batch_tasks.spawn(async move { Self::send(traces_clone, None, &proxy_https).await });
 
             for endpoint in self.additional_endpoints.clone() {
                 let traces_clone = traces.clone();


### PR DESCRIPTION
Goof here - I applied the same logic from main (where we want ordered sequential futures) with this change. Reverting this to a joinset allows us to await whichever future returns first, which helps in rare cases where multiple flush requests are required.