### PR TITLE
feat: lower zstd default compression

### DIFF
--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -378,13 +378,13 @@ impl Default for Config {
             version: None,
             tags: HashMap::new(),
 
-            compression_level: 6,
+            compression_level: 3,
 
             // Logs
             logs_config_logs_dd_url: String::default(),
             logs_config_processing_rules: None,
             logs_config_use_compression: true,
-            logs_config_compression_level: 6,
+            logs_config_compression_level: 3,
             logs_config_additional_endpoints: Vec::new(),
             observability_pipelines_worker_logs_enabled: false,
             observability_pipelines_worker_logs_url: String::default(),
@@ -395,7 +395,7 @@ impl Default for Config {
             apm_replace_tags: None,
             apm_config_obfuscation_http_remove_query_string: false,
             apm_config_obfuscation_http_remove_paths_with_digits: false,
-            apm_config_compression_level: 6,
+            apm_config_compression_level: 3,
             apm_features: vec![],
             apm_additional_endpoints: HashMap::new(),
             apm_filter_tags_require: None,
@@ -412,7 +412,7 @@ impl Default for Config {
             trace_propagation_http_baggage_enabled: false,
 
             // Metrics
-            metrics_config_compression_level: 6,
+            metrics_config_compression_level: 3,
 
             // OTLP
             otlp_config_traces_enabled: true,


### PR DESCRIPTION
A quick test run showed our max duration skews on smaller lambda sizes with lots of data setting the zstd compression level to 6. Looks like we start to block the CPU at around thi smark.

Gonna default it to 3, as tested below with 3 500k runs.
<img width="1293" height="319" alt="image" src="https://github.com/user-attachments/assets/d1224676-f14f-4a55-8440-089bb9ff91d0" />
