### PR TITLE
fix(bottlecap): run-time dependency on libgcc_s.so

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,17 +1,3 @@
 [alias]
 license = "dd-rust-license-tool check"
 format = "fmt --all && clippy --workspace --all-features --fix"
-
-# libddwaf's bindgen uses `clang-sys` which by default dynamically opens
-# `libclang.so`; however this is not supported on Alpine Linux (the usual musl
-# target).
-# Enabling the `static` feature of `bindgen`/`clang-sys` creates additional
-# build requirements (`libLLVM.a`), which Alpine's `llvm-static` does not
-# provide (it has its content presented as many `libLLVM*.a` files). Disabling
-# statically linking to the C runtime alleviates this issue, but can result in
-# `proc-macro` not being usable; which notably causes doc tests to fail with
-# a big linker error.
-[target.aarch64-unknown-linux-musl]
-rustflags = ["-C", "target-feature=-crt-static"]
-[target.x86_64-unknown-linux-musl]
-rustflags = ["-C", "target-feature=-crt-static"]

--- a/.cargo/musl.rustc-wrapper
+++ b/.cargo/musl.rustc-wrapper
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+
+###
+# This wrapper should be set to `RUSTC_WRAPPER` when building the `libddwaf-sys`
+# crate on musl-based platforms (e.g, Alpine), so that the build-script for it
+# is compiled with `-Ctarget-feature=-crt-static`, so that `bindgen` can
+# dynamically load `libclang` (musl static targets are unable to dynamically
+# load code), while continuing to build the surrounding code with the static
+# C runtime (ensuring it can be fully static).
+###
+
+if [ "${CARGO_CRATE_NAME}" != 'build_script_build' ]; then
+    exec "$@"
+fi
+
+if [ "${CARGO_PKG_NAME}" != 'libddwaf-sys' ]; then
+    exec "$@"
+fi
+
+exec "$@" "-Ctarget-feature=-crt-static"

--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -1930,8 +1930,8 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libddwaf"
-version = "1.27.0"
-source = "git+https://github.com/DataDog/libddwaf-rust?rev=1d57bf0ca49782723e556ba327ee7f378978aaa7#1d57bf0ca49782723e556ba327ee7f378978aaa7"
+version = "1.28.1"
+source = "git+https://github.com/DataDog/libddwaf-rust?rev=d1534a158d976bd4f747bf9fcc58e0712d2d17fc#d1534a158d976bd4f747bf9fcc58e0712d2d17fc"
 dependencies = [
  "libddwaf-sys",
  "serde",
@@ -1939,8 +1939,8 @@ dependencies = [
 
 [[package]]
 name = "libddwaf-sys"
-version = "1.27.0"
-source = "git+https://github.com/DataDog/libddwaf-rust?rev=1d57bf0ca49782723e556ba327ee7f378978aaa7#1d57bf0ca49782723e556ba327ee7f378978aaa7"
+version = "1.28.1"
+source = "git+https://github.com/DataDog/libddwaf-rust?rev=d1534a158d976bd4f747bf9fcc58e0712d2d17fc#d1534a158d976bd4f747bf9fcc58e0712d2d17fc"
 dependencies = [
  "bindgen 0.72.0",
  "flate2",

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -63,7 +63,7 @@ datadog-trace-normalization = { git = "https://github.com/DataDog/libdatadog",  
 datadog-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "9405db9cb4ef733f3954c3ee77ce71a502e98e50"  }
 dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "b0b0cb9310d8d8f2038c00a46e3267e21dc3e287", default-features = false }
 datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "fa1d2f4ea2c4c2596144a1f362935e56cf0cb3c7", default-features = false }
-libddwaf = { version = "1.26.0", git = "https://github.com/DataDog/libddwaf-rust", rev = "1d57bf0ca49782723e556ba327ee7f378978aaa7", default-features = false, features = ["serde", "dynamic"] }
+libddwaf = { version = "1.28.1", git = "https://github.com/DataDog/libddwaf-rust", rev = "d1534a158d976bd4f747bf9fcc58e0712d2d17fc", default-features = false, features = ["serde", "dynamic"] }
 
 [dev-dependencies]
 figment = { version = "0.10", default-features = false, features = ["yaml", "env", "test"] }

--- a/images/Dockerfile.bottlecap.alpine.compile
+++ b/images/Dockerfile.bottlecap.alpine.compile
@@ -4,8 +4,8 @@ ARG PLATFORM
 ARG FIPS
 
 # Install dependencies
-RUN apk add --no-cache bash build-base clang-libclang cmake curl go \
-    linux-headers perl unzip
+RUN apk add --no-cache bash build-base clang clang-libclang compiler-rt cmake \
+                       curl go linux-headers perl unzip
 
 SHELL ["/bin/bash", "-c"]
 
@@ -24,12 +24,6 @@ ENV PATH="${PATH}:/root/.cargo/bin"
 
 # Build the binary
 ENV RUSTFLAGS="-Cpanic=abort"
-# Added -Ctarget-feature=-crt-static for alpine: the default MUSL target is
-# configured to produce fully static binaries, hence incapable of dynamically
-# loading libraries. The libddwaf crate uses `bindgen` which by default
-# dynamically loads `libclang`, and the `static` feature is tricky to get
-# working on alpine due to how it packages the static version of libLLVM.
-ENV RUSTFLAGS="${RUSTFLAGS} -Ctarget-feature=-crt-static"
 
 WORKDIR /tmp/dd/bottlecap
 RUN --mount=type=cache,target=/root/.cargo/git \
@@ -44,12 +38,15 @@ RUN --mount=type=cache,target=/root/.cargo/git \
     else \
         export FEATURES=default; \
     fi; \
-    # Explicitly NOT passing `--target` as this makes the `RUSTFLAGS` (from any
-    # source) not apply to `build.rs` compilation, which in turns means
-    # `libddwaf`'s builder fails to build because on MUSL platforms it can only
-    # work with `-Ctarget-feature=-crt-runtime` being specified. There is
-    # currently no way to set `RUSTFLAGS` for `build.rs` compilation if
-    # `--target` is passed (see: https://github.com/rust-lang/cargo/issues/4423).
+    if [ "${PLATFORM}" = "x86_64" ]; then \
+        # The `libddwaf` crate links against static objects that require `libclang_rt.builtins`, but
+        # this is not presented to the linker by default on this platform, so we force it in.
+        export RUSTFLAGS="${RUSTFLAGS:-} -Clinker=clang -L$(dirname $(clang --print-file-name="libclang_rt.builtins-$(uname -m).a")) -lclang_rt.builtins-$(uname -m)"; \
+    fi; \
+    # We use a wrapper to allow `libddwaf-sys`' build.rs to be compiled with
+    # -Ctarget-feature=-crt-static so that it is capable of dynamically loading
+    # libclang; while still building bottlecap with a static CRT.
+    RUSTC_WRAPPER=/tmp/dd/.cargo/musl.rustc-wrapper \
     cargo +stable build --verbose --locked --no-default-features \
         --features="${FEATURES}" \
         --profile="${PROFILE:-release}" && \


### PR DESCRIPTION
An unexpected dependency on `libgcc_s.so` is implied by building on `musl` platforms with the `-Ctarget-feature=-crt-runtime`, which causes breakage in some customer functions. Instead of disabling the static C runtime for the entire build, use a `RUSTC_WRAPPER` script to disable it only specifically for the build-script of `libddwaf-sys` which is where `bindgen` needs to be able to dynamically load `libclang.so`.

Additionally, present the `libcompiler-rt.builtins` object to the linker where necessary because `rust` passes `-nodefaultlibs` to the linker, but some objects in `libddwaf` depend on compiler intrinsics.

Fixes: https://github.com/DataDog/datadog-lambda-extension/issues/858
JIRA: APPSEC-59319