### PR TITLE
fix: Drop guard so we don't hold the lock when we may get traces at a…

### DIFF
--- a/bottlecap/src/traces/trace_flusher.rs
+++ b/bottlecap/src/traces/trace_flusher.rs
@@ -140,6 +140,7 @@ impl TraceFlusher for ServerlessTraceFlusher {
             trace_builders = guard.get_batch();
         }
 
+        drop(guard);
         while let Some(result) = batch_tasks.join_next().await {
             if let Ok(Some(mut failed)) = result {
                 failed_batch.append(&mut failed);


### PR DESCRIPTION
…ny time

Fixes an issue where in certain runtimes (go/java) which flush traces asynchronously, we may hold this lock too long. This causes tokio tasks at the API/trace aggr to pile up and cause a deadlock