### PR TITLE
chore: [Trace Stats] Rename env var DD_COMPUTE_TRACE_STATS

### DIFF
--- a/bottlecap/src/config/env.rs
+++ b/bottlecap/src/config/env.rs
@@ -358,13 +358,13 @@ pub struct EnvConfig {
     /// The maximum depth of the Lambda payload to capture.
     /// Default is `10`. Requires `capture_lambda_payload` to be `true`.
     pub capture_lambda_payload_max_depth: Option<u32>,
-    /// @env `DD_COMPUTE_TRACE_STATS`
+    /// @env `DD_COMPUTE_TRACE_STATS_ON_EXTENSION`
     ///
     /// If true, enable computation of trace stats on the extension side.
     /// If false, trace stats will be computed on the backend side.
     /// Default is `false`.
     #[serde(deserialize_with = "deserialize_optional_bool_from_anything")]
-    pub compute_trace_stats: Option<bool>,
+    pub compute_trace_stats_on_extension: Option<bool>,
     /// @env `DD_SERVERLESS_APPSEC_ENABLED`
     ///
     /// Enable Application and API Protection (AAP), previously known as AppSec/ASM, for AWS Lambda.
@@ -571,7 +571,7 @@ fn merge_config(config: &mut Config, env_config: &EnvConfig) {
     merge_option_to_value!(config, env_config, lambda_proc_enhanced_metrics);
     merge_option_to_value!(config, env_config, capture_lambda_payload);
     merge_option_to_value!(config, env_config, capture_lambda_payload_max_depth);
-    merge_option_to_value!(config, env_config, compute_trace_stats);
+    merge_option_to_value!(config, env_config, compute_trace_stats_on_extension);
     merge_option_to_value!(config, env_config, serverless_appsec_enabled);
     merge_option!(config, env_config, appsec_rules);
     merge_option_to_value!(config, env_config, appsec_waf_timeout);
@@ -765,7 +765,7 @@ mod tests {
             jail.set_env("DD_LAMBDA_PROC_ENHANCED_METRICS", "false");
             jail.set_env("DD_CAPTURE_LAMBDA_PAYLOAD", "true");
             jail.set_env("DD_CAPTURE_LAMBDA_PAYLOAD_MAX_DEPTH", "5");
-            jail.set_env("DD_COMPUTE_TRACE_STATS", "true");
+            jail.set_env("DD_COMPUTE_TRACE_STATS_ON_EXTENSION", "true");
             jail.set_env("DD_SERVERLESS_APPSEC_ENABLED", "true");
             jail.set_env("DD_APPSEC_RULES", "/path/to/rules.json");
             jail.set_env("DD_APPSEC_WAF_TIMEOUT", "1000000"); // Microseconds
@@ -915,7 +915,7 @@ mod tests {
                 lambda_proc_enhanced_metrics: false,
                 capture_lambda_payload: true,
                 capture_lambda_payload_max_depth: 5,
-                compute_trace_stats: true,
+                compute_trace_stats_on_extension: true,
                 serverless_appsec_enabled: true,
                 appsec_rules: Some("/path/to/rules.json".to_string()),
                 appsec_waf_timeout: Duration::from_secs(1),

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -343,7 +343,7 @@ pub struct Config {
     pub lambda_proc_enhanced_metrics: bool,
     pub capture_lambda_payload: bool,
     pub capture_lambda_payload_max_depth: u32,
-    pub compute_trace_stats: bool,
+    pub compute_trace_stats_on_extension: bool,
 
     pub serverless_appsec_enabled: bool,
     pub appsec_rules: Option<String>,
@@ -446,7 +446,7 @@ impl Default for Config {
             lambda_proc_enhanced_metrics: true,
             capture_lambda_payload: false,
             capture_lambda_payload_max_depth: 10,
-            compute_trace_stats: false,
+            compute_trace_stats_on_extension: false,
 
             serverless_appsec_enabled: false,
             appsec_rules: None,

--- a/bottlecap/src/config/yaml.rs
+++ b/bottlecap/src/config/yaml.rs
@@ -99,7 +99,7 @@ pub struct YamlConfig {
     pub capture_lambda_payload: Option<bool>,
     pub capture_lambda_payload_max_depth: Option<u32>,
     #[serde(deserialize_with = "deserialize_optional_bool_from_anything")]
-    pub compute_trace_stats: Option<bool>,
+    pub compute_trace_stats_on_extension: Option<bool>,
     #[serde(deserialize_with = "deserialize_optional_bool_from_anything")]
     pub serverless_appsec_enabled: Option<bool>,
     pub appsec_rules: Option<String>,
@@ -656,7 +656,7 @@ fn merge_config(config: &mut Config, yaml_config: &YamlConfig) {
     merge_option_to_value!(config, yaml_config, lambda_proc_enhanced_metrics);
     merge_option_to_value!(config, yaml_config, capture_lambda_payload);
     merge_option_to_value!(config, yaml_config, capture_lambda_payload_max_depth);
-    merge_option_to_value!(config, yaml_config, compute_trace_stats);
+    merge_option_to_value!(config, yaml_config, compute_trace_stats_on_extension);
     merge_option_to_value!(config, yaml_config, serverless_appsec_enabled);
     merge_option!(config, yaml_config, appsec_rules);
     merge_option_to_value!(config, yaml_config, appsec_waf_timeout);
@@ -826,7 +826,7 @@ enhanced_metrics: false
 lambda_proc_enhanced_metrics: false
 capture_lambda_payload: true
 capture_lambda_payload_max_depth: 5
-compute_trace_stats: true
+compute_trace_stats_on_extension: true
 serverless_appsec_enabled: true
 appsec_rules: "/path/to/rules.json"
 appsec_waf_timeout: 1000000 # Microseconds

--- a/bottlecap/src/config/yaml.rs
+++ b/bottlecap/src/config/yaml.rs
@@ -959,7 +959,7 @@ extension_version: "compatibility"
                 lambda_proc_enhanced_metrics: false,
                 capture_lambda_payload: true,
                 capture_lambda_payload_max_depth: 5,
-                compute_trace_stats: true,
+                compute_trace_stats_on_extension: true,
 
                 serverless_appsec_enabled: true,
                 appsec_rules: Some("/path/to/rules.json".to_string()),

--- a/bottlecap/src/otlp/agent.rs
+++ b/bottlecap/src/otlp/agent.rs
@@ -173,7 +173,7 @@ impl Agent {
                 .into_response();
         }
 
-        let compute_trace_stats = config.compute_trace_stats;
+        let compute_trace_stats_on_extension = config.compute_trace_stats_on_extension;
         let (send_data_builder, processed_traces) = trace_processor.process_traces(
             config,
             tags_provider,
@@ -198,7 +198,7 @@ impl Agent {
 
         // This needs to be after process_traces() because process_traces()
         // performs obfuscation, and we need to compute stats on the obfuscated traces.
-        if compute_trace_stats {
+        if compute_trace_stats_on_extension {
             if let Err(err) = stats_generator.send(&processed_traces) {
                 // Just log the error. We don't think trace stats are critical, so we don't want to
                 // return an error if only stats fail to send.

--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -127,10 +127,10 @@ fn tags_from_env(
         tags_map.extend(config.tags.clone());
     }
 
-    // The value of _dd.compute_stats is the opposite of config.compute_trace_stats.
-    // "config.compute_trace_stats == true" means computing stats on the extension side,
+    // The value of _dd.compute_stats is the opposite of config.compute_trace_stats_on_extension.
+    // "config.compute_trace_stats_on_extension == true" means computing stats on the extension side,
     // so we set _dd.compute_stats to 0 so stats won't be computed on the backend side.
-    let compute_stats = i32::from(!config.compute_trace_stats);
+    let compute_stats = i32::from(!config.compute_trace_stats_on_extension);
     tags_map.insert(COMPUTE_STATS_KEY.to_string(), compute_stats.to_string());
 
     tags_map

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -461,7 +461,7 @@ impl SendingTraceProcessor {
 
         // This needs to be after process_traces() because process_traces()
         // performs obfuscation, and we need to compute stats on the obfuscated traces.
-        if config.compute_trace_stats {
+        if config.compute_trace_stats_on_extension {
             if let Err(err) = self.stats_generator.send(&processed_traces) {
                 // Just log the error. We don't think trace stats are critical, so we don't want to
                 // return an error if only stats fail to send.


### PR DESCRIPTION
# This PR
As @apiarian-datadog suggested in https://github.com/DataDog/datadog-lambda-extension/pull/841#discussion_r2376111825, rename the feature flag `DD_COMPUTE_TRACE_STATS` to `DD_COMPUTE_TRACE_STATS_ON_EXTENSION` for clarity.

# Notes
Jira: https://datadoghq.atlassian.net/browse/SVLS-7593