### PR TITLE
chore: Add a space in debug log for duration

### DIFF
--- a/bottlecap/src/secrets/decrypt.rs
+++ b/bottlecap/src/secrets/decrypt.rs
@@ -87,7 +87,7 @@ pub async fn resolve_secrets(config: Arc<Config>, aws_config: Arc<AwsConfig>) ->
                 .await
             };
 
-            debug!("Decrypt took {}ms", before_decrypt.elapsed().as_millis());
+            debug!("Decrypt took {} ms", before_decrypt.elapsed().as_millis());
 
             match decrypted_key {
                 Ok(key) => Some(key),

--- a/bottlecap/src/traces/stats_flusher.rs
+++ b/bottlecap/src/traces/stats_flusher.rs
@@ -105,7 +105,7 @@ impl StatsFlusher for ServerlessStatsFlusher {
             stats_utils::send_stats_payload(serialized_stats_payload, endpoint, api_key).await;
         let elapsed = start.elapsed();
         debug!(
-            "Stats request to {} took {}ms",
+            "Stats request to {} took {} ms",
             stats_url,
             elapsed.as_millis()
         );

--- a/bottlecap/src/traces/trace_flusher.rs
+++ b/bottlecap/src/traces/trace_flusher.rs
@@ -185,7 +185,7 @@ impl TraceFlusher for ServerlessTraceFlusher {
             }
         }
 
-        debug!("Flushing traces took {}ms", start.elapsed().as_millis());
+        debug!("Flushing traces took {} ms", start.elapsed().as_millis());
         None
     }
 }


### PR DESCRIPTION
Right now we have debug log like `Flushing traces took 50ms`. This PR adds a space between `50` and `ms` so it's easier to process the log. For example, we can use `echo 'Flushing traces took 50 ms' | awk '{print $4}'` to extract the `50`.