### PR TITLE
chore(extension): allow register with name

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -253,7 +253,7 @@ async fn main() -> anyhow::Result<()> {
         .build()
         .map_err(|e| anyhow::anyhow!("Failed to create client: {e:?}"))?;
 
-    let r = extension::register(&client, &aws_config.runtime_api)
+    let r = extension::register(&client, &aws_config.runtime_api, extension::EXTENSION_NAME)
         .await
         .map_err(|e| anyhow::anyhow!("Failed to register extension: {e:?}"))?;
 

--- a/bottlecap/src/extension/mod.rs
+++ b/bottlecap/src/extension/mod.rs
@@ -83,6 +83,7 @@ pub fn base_url(route: &str, runtime_api: &str) -> String {
 pub async fn register(
     client: &Client,
     runtime_api: &str,
+    extension_name: &str,
 ) -> Result<RegisterResponse, ExtensionError> {
     let events_to_subscribe_to = serde_json::json!({
         "events": ["INVOKE", "SHUTDOWN"]
@@ -93,7 +94,7 @@ pub async fn register(
 
     let response = client
         .post(&url)
-        .header(EXTENSION_NAME_HEADER, EXTENSION_NAME)
+        .header(EXTENSION_NAME_HEADER, extension_name)
         .header(EXTENSION_ACCEPT_FEATURE_HEADER, EXTENSION_FEATURES)
         .json(&events_to_subscribe_to)
         .send()


### PR DESCRIPTION
# What?

Allows registering extension with name from parameter

# Why?

Want to reuse it for another extension