### PR TITLE
fix: tombstone event to be sent properly

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -378,7 +378,7 @@ async fn extension_loop_active(
     api_key_factory: Arc<ApiKeyFactory>,
     start_time: Instant,
 ) -> anyhow::Result<()> {
-    let mut event_bus = EventBus::run();
+    let (mut event_bus, event_bus_tx) = EventBus::run();
 
     let account_id = r
         .account_id
@@ -387,11 +387,11 @@ async fn extension_loop_active(
         .to_string();
     let tags_provider = setup_tag_provider(&Arc::clone(&aws_config), config, &account_id);
 
-    let (logs_agent_channel, logs_flusher) = start_logs_agent(
+    let (logs_agent_channel, logs_flusher, logs_agent_cancel_token) = start_logs_agent(
         config,
         Arc::clone(&api_key_factory),
         &tags_provider,
-        event_bus.get_sender_copy(),
+        event_bus_tx.clone(),
     );
 
     let (metrics_flushers, metrics_aggregator_handle, dogstatsd_cancel_token) =
@@ -457,7 +457,7 @@ async fn extension_loop_active(
         &r.extension_id,
         &aws_config.runtime_api,
         logs_agent_channel,
-        event_bus.get_sender_copy(),
+        event_bus_tx.clone(),
         config.serverless_logs_enabled,
     )
     .await?;
@@ -655,6 +655,12 @@ async fn extension_loop_active(
             // that there are no more Telemetry events to process
             telemetry_listener_cancel_token.cancel();
 
+            // Cancel Logs Agent which might have Telemetry API events to process
+            logs_agent_cancel_token.cancel();
+
+            // Drop the event bus sender to allow the channel to close properly
+            drop(event_bus_tx);
+
             // Redrive/block on any failed payloads
             let tf = trace_flusher.clone();
             pending_flush_handles
@@ -666,25 +672,31 @@ async fn extension_loop_active(
                 )
                 .await;
             // Wait for tombstone event from telemetry listener to ensure all events are processed
-            let mut tombstone_received = false;
             'shutdown: loop {
                 tokio::select! {
                     Some(event) = event_bus.rx.recv() => {
                         if let Event::Tombstone = event {
-                            debug!("Received tombstone event, continuing to drain remaining events");
-                            tombstone_received = true;
-                            // Continue processing to drain any remaining events after tombstone
+                            debug!("Received tombstone event, draining remaining events");
+                            // Drain without waiting
+                            loop {
+                                match event_bus.rx.try_recv() {
+                                    Ok(event) => {
+                                        handle_event_bus_event(event, invocation_processor.clone(), appsec_processor.clone(), tags_provider.clone(), trace_processor.clone(), trace_agent_channel.clone(), stats_concentrator.clone()).await;
+                                    },
+                                    Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => break 'shutdown,
+                                    // Empty signals there are still outstanding senders
+                                    Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {
+                                        debug!("No more events to process but still have senders, continuing to drain...");
+                                    },
+                                }
+                            }
                         } else {
                             handle_event_bus_event(event, invocation_processor.clone(), appsec_processor.clone(), tags_provider.clone(), trace_processor.clone(), trace_agent_channel.clone(), stats_concentrator.clone()).await;
                         }
                     }
                     // Add timeout to prevent hanging indefinitely
                     () = tokio::time::sleep(tokio::time::Duration::from_millis(300)) => {
-                        if tombstone_received {
-                            debug!("Timeout after tombstone event, all remaining events processed");
-                        } else {
-                            debug!("Timeout waiting for tombstone event, proceeding with shutdown");
-                        }
+                        debug!("Timeout waiting for teardown, proceeding with shutdown");
                         break 'shutdown;
                     }
                 }
@@ -905,28 +917,30 @@ fn start_logs_agent(
     api_key_factory: Arc<ApiKeyFactory>,
     tags_provider: &Arc<TagProvider>,
     event_bus: Sender<Event>,
-) -> (Sender<TelemetryEvent>, LogsFlusher) {
+) -> (Sender<TelemetryEvent>, LogsFlusher, CancellationToken) {
     let (aggregator_service, aggregator_handle) = LogsAggregatorService::default();
     // Start service in background
     tokio::spawn(async move {
         aggregator_service.run().await;
     });
 
-    let mut agent = LogsAgent::new(
+    let (mut agent, tx) = LogsAgent::new(
         Arc::clone(tags_provider),
         Arc::clone(config),
         event_bus,
         aggregator_handle.clone(),
     );
-    let tx = agent.get_sender_copy();
-
+    let cancel_token = agent.cancel_token();
     // Start logs agent in background
     tokio::spawn(async move {
         agent.spin().await;
+
+        debug!("LOGS_AGENT | Shutting down...");
+        drop(agent);
     });
 
     let flusher = LogsFlusher::new(api_key_factory, aggregator_handle, config.clone());
-    (tx, flusher)
+    (tx, flusher, cancel_token)
 }
 
 #[allow(clippy::type_complexity)]
@@ -1154,8 +1168,14 @@ async fn setup_telemetry_client(
     let listener = TelemetryListener::new(EXTENSION_HOST_IP, TELEMETRY_PORT, logs_tx, event_bus_tx);
 
     let cancel_token = listener.cancel_token();
-    if let Err(e) = listener.start() {
-        error!("Error starting telemetry listener: {e:?}");
+    match listener.start() {
+        Ok(()) => {
+            // Drop the listener, so event_bus_tx is closed
+            drop(listener);
+        }
+        Err(e) => {
+            error!("Error starting telemetry listener: {e:?}");
+        }
     }
 
     telemetry::subscribe(

--- a/bottlecap/src/event_bus/mod.rs
+++ b/bottlecap/src/event_bus/mod.rs
@@ -13,19 +13,14 @@ pub enum Event {
 
 #[allow(clippy::module_name_repetitions)]
 pub struct EventBus {
-    tx: Sender<Event>,
     pub rx: mpsc::Receiver<Event>,
 }
 
 impl EventBus {
     #[must_use]
-    pub fn run() -> EventBus {
+    pub fn run() -> (EventBus, Sender<Event>) {
         let (tx, rx) = mpsc::channel(MAX_EVENTS);
-        EventBus { tx, rx }
-    }
-
-    #[must_use]
-    pub fn get_sender_copy(&self) -> Sender<Event> {
-        self.tx.clone()
+        let event_bus = EventBus { rx };
+        (event_bus, tx)
     }
 }

--- a/bottlecap/src/event_bus/mod.rs
+++ b/bottlecap/src/event_bus/mod.rs
@@ -8,6 +8,7 @@ mod constants;
 pub enum Event {
     Telemetry(TelemetryEvent),
     OutOfMemory(i64),
+    Tombstone,
 }
 
 #[allow(clippy::module_name_repetitions)]

--- a/bottlecap/src/extension/telemetry/events.rs
+++ b/bottlecap/src/extension/telemetry/events.rs
@@ -150,10 +150,6 @@ pub enum TelemetryRecord {
         /// When unsuccessful, the `error_type` describes what kind of error occurred
         error_type: Option<String>,
     },
-
-    /// Tombstone event to signal shutdown
-    #[serde(rename = "platform.tombstone")]
-    PlatformTombstone,
 }
 
 /// Type of Initialization

--- a/bottlecap/src/extension/telemetry/listener.rs
+++ b/bottlecap/src/extension/telemetry/listener.rs
@@ -59,7 +59,7 @@ impl TelemetryListener {
             let listener = TcpListener::bind(&socket)
                 .await
                 .expect("Failed to bind socket");
-            debug!("Telemetry API | Starting listener on {}", socket);
+            debug!("TELEMETRY API | Starting listener on {}", socket);
             axum::serve(listener, router)
                 .with_graceful_shutdown(Self::graceful_shutdown(cancel_token_clone, event_bus_tx))
                 .await
@@ -83,14 +83,14 @@ impl TelemetryListener {
         event_bus_tx: Sender<event_bus::Event>,
     ) {
         cancel_token.cancelled().await;
-        debug!("Telemetry API | Shutdown signal received, sending tombstone event");
+        debug!("TELEMETRY API | Shutdown signal received, sending tombstone event");
 
         // Send tombstone event to signal shutdown
         if let Err(e) = event_bus_tx.send(event_bus::Event::Tombstone).await {
-            debug!("Telemetry API |Failed to send tombstone event: {:?}", e);
+            debug!("TELEMETRY API |Failed to send tombstone event: {:?}", e);
         }
 
-        debug!("Telemetry API | Shutting down");
+        debug!("TELEMETRY API | Shutting down");
     }
 
     async fn handle(State(logs_tx): State<Sender<TelemetryEvent>>, request: Request) -> Response {

--- a/bottlecap/src/traces/trace_agent.rs
+++ b/bottlecap/src/traces/trace_agent.rs
@@ -184,9 +184,9 @@ impl TraceAgent {
         let socket = SocketAddr::from(([127, 0, 0, 1], port));
         let listener = tokio::net::TcpListener::bind(&socket).await?;
 
-        debug!("Trace Agent started: listening on port {TRACE_AGENT_PORT}");
+        debug!("TRACE AGENT | Listening on port {TRACE_AGENT_PORT}");
         debug!(
-            "Time taken start the Trace Agent: {} ms",
+            "TRACE AGENT | Time taken to start: {} ms",
             now.elapsed().as_millis()
         );
 
@@ -268,7 +268,7 @@ impl TraceAgent {
 
     async fn graceful_shutdown(shutdown_token: CancellationToken) {
         shutdown_token.cancelled().await;
-        debug!("Trace Agent | Shutdown signal received, shutting down");
+        debug!("TRACE_AGENT | Shutdown signal received, shutting down");
     }
 
     async fn v04_traces(State(state): State<TraceState>, request: Request) -> Response {
@@ -548,7 +548,7 @@ impl TraceAgent {
         backend_path: &str,
         context: &str,
     ) -> Response {
-        debug!("Trace Agent | Proxied request for {context}");
+        debug!("TRACE_AGENT | Proxied request for {context}");
         let (parts, body) = match extract_request_body(request).await {
             Ok(r) => r,
             Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, e),

--- a/bottlecap/tests/logs_integration_test.rs
+++ b/bottlecap/tests/logs_integration_test.rs
@@ -54,7 +54,7 @@ async fn test_logs() {
         &HashMap::from([("function_arn".to_string(), "test-arn".to_string())]),
     ));
 
-    let bus = EventBus::run();
+    let (_, bus_tx) = EventBus::run();
 
     let (logs_aggr_service, logs_aggr_handle) =
         bottlecap::logs::aggregator_service::AggregatorService::default();
@@ -62,10 +62,10 @@ async fn test_logs() {
         logs_aggr_service.run().await;
     });
 
-    let mut logs_agent = LogsAgent::new(
+    let (mut logs_agent, logs_agent_tx) = LogsAgent::new(
         tags_provider,
         Arc::clone(&arc_conf),
-        bus.get_sender_copy(),
+        bus_tx.clone(),
         logs_aggr_handle.clone(),
     );
     let api_key_factory = Arc::new(ApiKeyFactory::new(dd_api_key));
@@ -75,7 +75,7 @@ async fn test_logs() {
         r#"[{"time":"2022-10-21T14:05:03.165Z","type":"platform.start","record":{"requestId":"459921b5-681c-4a96-beb0-81e0aa586026","version":"$LATEST","tracing":{"spanId":"24cd7d670fa455f0","type":"X-Amzn-Trace-Id","value":"Root=1-6352a70e-1e2c502e358361800241fd45;Parent=35465b3a9e2f7c6a;Sampled=1"}}}]"#)
         .map_err(|e| e.to_string()).expect("Failed parsing telemetry events");
 
-    let sender = logs_agent.get_sender_copy();
+    let sender = logs_agent_tx.clone();
 
     for an_event in telemetry_events {
         sender


### PR DESCRIPTION
# What?

The Telemetry API needs to signal the main event loop that it stopped processing events. The order of how this operations occurred could have been busted before. This fixes it and moves the code around so the cancel token can trigger the Tombstone signal.

# Why?

Reduces time spent on shutdown when processing

# Notes

Also makes the Tombstone event to be a main event as opposed to a Telemetry API event

### Before

<img width="2776" height="836" alt="image" src="https://github.com/user-attachments/assets/6a298d77-d3b5-420c-83d4-b77b08d3e44d" />

### After

<img width="1665" height="515" alt="Screenshot 2025-10-03 at 3 46 34 PM" src="https://github.com/user-attachments/assets/376c0ea5-5ede-48f4-ac1b-39e7dff76519" />

