### PR TITLE
allow native certs

### DIFF
--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -97,7 +97,7 @@ opt-level = 3
 tikv-jemallocator = "0.5"
 
 [features]
-default = ["reqwest/rustls-tls-native-roots", "rustls-native-certs", "dogstatsd/default", "datadog-fips/default" ]
+default = ["reqwest/rustls-tls-native-roots", "dogstatsd/default", "datadog-fips/default" ]
 fips = [
     "ddcommon/fips",
     "datadog-trace-utils/fips",


### PR DESCRIPTION
This should allow customers using SSL_CERT_FILE env var or installing certs on the OS to be automatically used instead of the web public key infrastructure.

This supports a customer with a use case requiring them to decrypt telemetry data on their proxy.
