### PR TITLE
fix: use None if propagation style is invalid

### DIFF
--- a/bottlecap/src/config/trace_propagation_style.rs
+++ b/bottlecap/src/config/trace_propagation_style.rs
@@ -23,8 +23,8 @@ impl FromStr for TracePropagationStyle {
             "tracecontext" => Ok(TracePropagationStyle::TraceContext),
             "none" => Ok(TracePropagationStyle::None),
             _ => {
-                error!("Trace propagation style is invalid: {:?}, using Datadog", s);
-                Ok(TracePropagationStyle::Datadog)
+                error!("Trace propagation style is invalid: {:?}, using None", s);
+                Ok(TracePropagationStyle::None)
             }
         }
     }


### PR DESCRIPTION
After internal discussion we determined that the tracing libraries use None of the trace propagation style is invalid or malformed.

This brings us into alignment.
