### PR TITLE
chore: Improve trace agent error message

### DIFF
--- a/bottlecap/src/traces/trace_agent.rs
+++ b/bottlecap/src/traces/trace_agent.rs
@@ -433,7 +433,12 @@ impl TraceAgent {
     ) -> Response {
         let (parts, body) = match extract_request_body(request).await {
             Ok(r) => r,
-            Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, e),
+            Err(e) => {
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("TRACE_AGENT | handle_traces | Error extracting request body: {e}"),
+                );
+            }
         };
 
         if let Some(content_length) = parts
@@ -551,7 +556,12 @@ impl TraceAgent {
         debug!("TRACE_AGENT | Proxied request for {context}");
         let (parts, body) = match extract_request_body(request).await {
             Ok(r) => r,
-            Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, e),
+            Err(e) => {
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("TRACE_AGENT | handle_proxy | Error extracting request body: {e}"),
+                );
+            }
         };
 
         let target_url = format!("https://{}.{}{}", backend_domain, config.site, backend_path);


### PR DESCRIPTION
# This PR
Add some details to trace agent error messages.

# Motivation
https://github.com/DataDog/datadog-lambda-extension/issues/899 mentions the error log:
```
DD_EXTENSION | ERROR | Failed to buffer the request body: length limit exceeded
```
This error message is probably from Rust, not from our extension, and it's hard to pinpoint where it's logged. My hypothesis is it's from the two places touched by this PR. Let's add details to the log messages so if someone sees the same error again, we know where it's from.