### PR TITLE
feat: Support proxy for debugger endpoint v2

### DIFF
--- a/bottlecap/src/traces/trace_agent.rs
+++ b/bottlecap/src/traces/trace_agent.rs
@@ -447,6 +447,7 @@ impl TraceAgent {
                     LLM_OBS_SPANS_ENDPOINT_PATH,
                     V1_DEBUGGER_ENDPOINT_PATH,
                     V2_DEBUGGER_ENDPOINT_PATH,
+                    DEBUGGER_DIAGNOSTICS_ENDPOINT_PATH,
                 ],
                 "client_drop_p0s": true,
             }


### PR DESCRIPTION
Now we support proxying requests from `/debugger/v1/input`. This PR adds `/debugger/v2/input` and `/debugger/v1/diagnostics`.

https://github.com/DataDog/datadog-lambda-extension/issues/925

## Test

### Steps
1. Set up Exception Replay following https://docs.datadoghq.com/error_tracking/backend/exception_replay/
2. Build a test layer and install it on the Lambda
3. Set `DD_TRACE_DEBUG` to `true`
4. Change Lambda timeout from 3s to 30s. Seems Exception Replay dramatically increases the duration of the first invocation. It took 8–9s for my tests.

### Result
Before:
- In CloudWatch logs, see the error multiple times: `debugger::unsupported_agentUnsupported Datadog agent detected. Snapshots from Dynamic Instrumentation/Exception Replay/Code Origin for Spans will not be uploaded. Please upgrade to version 7.49.0 or later`

After:
- No such error. 
- See tracer debug log: `Detected /debugger/v2/input endpoint`
- See the error on Error Tracking page

<img width="486" height="166" alt="image" src="https://github.com/user-attachments/assets/3d48cb2b-0d5a-4806-97e1-e8146642ce64" />

## Notes
Thanks @nhulston @joeyzhao2018  @purple4reina for discussion and helping debug.