### PR TITLE
refactor: Move metric namespace validation to dogstatsd util

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -778,7 +778,7 @@ dependencies = [
 [[package]]
 name = "datadog-fips"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=aa7961984f221ec3f1048ebf3379c4b94a33be0e#aa7961984f221ec3f1048ebf3379c4b94a33be0e"
+source = "git+https://github.com/DataDog/serverless-components?rev=502f005c56b8d51dee95424a9c1404df46e2aae4#502f005c56b8d51dee95424a9c1404df46e2aae4"
 dependencies = [
  "reqwest",
  "rustls",
@@ -994,7 +994,7 @@ dependencies = [
 [[package]]
 name = "dogstatsd"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=aa7961984f221ec3f1048ebf3379c4b94a33be0e#aa7961984f221ec3f1048ebf3379c4b94a33be0e"
+source = "git+https://github.com/DataDog/serverless-components?rev=502f005c56b8d51dee95424a9c1404df46e2aae4#502f005c56b8d51dee95424a9c1404df46e2aae4"
 dependencies = [
  "datadog-fips",
  "datadog-protos",

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -63,8 +63,8 @@ datadog-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "ba
 datadog-trace-normalization = { git = "https://github.com/DataDog/libdatadog",  rev = "ba8955394cf35cf24a1a508fbe6264ad84702567" }
 datadog-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "ba8955394cf35cf24a1a508fbe6264ad84702567"  }
 datadog-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "ba8955394cf35cf24a1a508fbe6264ad84702567"  }
-dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "aa7961984f221ec3f1048ebf3379c4b94a33be0e", default-features = false }
-datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "aa7961984f221ec3f1048ebf3379c4b94a33be0e", default-features = false }
+dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "502f005c56b8d51dee95424a9c1404df46e2aae4", default-features = false }
+datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "502f005c56b8d51dee95424a9c1404df46e2aae4", default-features = false }
 libddwaf = { version = "1.28.1", git = "https://github.com/DataDog/libddwaf-rust", rev = "d1534a158d976bd4f747bf9fcc58e0712d2d17fc", default-features = false, features = ["serde"] }
 
 [dev-dependencies]

--- a/bottlecap/src/config/env.rs
+++ b/bottlecap/src/config/env.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use datadog_trace_obfuscation::replacer::ReplaceRule;
+use dogstatsd::util::parse_metric_namespace;
 
 use crate::{
     config::{
@@ -527,7 +528,7 @@ fn merge_config(config: &mut Config, env_config: &EnvConfig) {
     merge_option_to_value!(config, env_config, metrics_config_compression_level);
 
     if let Some(namespace) = &env_config.statsd_metric_namespace {
-        config.statsd_metric_namespace = super::validate_metric_namespace(namespace);
+        config.statsd_metric_namespace = parse_metric_namespace(namespace);
     }
 
     // OTLP

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -701,39 +701,6 @@ where
     }
 }
 
-fn validate_metric_namespace(namespace: &str) -> Option<String> {
-    let trimmed = namespace.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-
-    let mut chars = trimmed.chars();
-
-    if let Some(first_char) = chars.next() {
-        if !first_char.is_ascii_alphabetic() {
-            error!(
-                "DD_STATSD_METRIC_NAMESPACE must start with a letter, got: '{}'. Ignoring namespace.",
-                trimmed
-            );
-            return None;
-        }
-    } else {
-        return None;
-    }
-
-    if let Some(invalid_char) =
-        chars.find(|&ch| !ch.is_ascii_alphanumeric() && ch != '_' && ch != '.')
-    {
-        error!(
-            "DD_STATSD_METRIC_NAMESPACE contains invalid character '{}' in '{}'. Only ASCII alphanumerics, underscores, and periods are allowed. Ignoring namespace.",
-            invalid_char, trimmed
-        );
-        return None;
-    }
-
-    Some(trimmed.to_string())
-}
-
 pub fn deserialize_option_lossless<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
 where
     D: Deserializer<'de>,
@@ -1510,54 +1477,5 @@ pub mod tests {
         let mut expected = HashMap::new();
         expected.insert("valid".to_string(), "tag".to_string());
         assert_eq!(result.tags, expected);
-    }
-
-    #[test]
-    fn test_validate_metric_namespace_valid() {
-        assert_eq!(
-            validate_metric_namespace("myapp"),
-            Some("myapp".to_string())
-        );
-        assert_eq!(
-            validate_metric_namespace("my_app"),
-            Some("my_app".to_string())
-        );
-        assert_eq!(
-            validate_metric_namespace("my.app"),
-            Some("my.app".to_string())
-        );
-        assert_eq!(
-            validate_metric_namespace("MyApp123"),
-            Some("MyApp123".to_string())
-        );
-        assert_eq!(
-            validate_metric_namespace("  myapp  "),
-            Some("myapp".to_string())
-        );
-    }
-
-    #[test]
-    fn test_validate_metric_namespace_empty() {
-        assert_eq!(validate_metric_namespace(""), None);
-        assert_eq!(validate_metric_namespace("   "), None);
-        assert_eq!(validate_metric_namespace("\t\n"), None);
-    }
-
-    #[test]
-    fn test_validate_metric_namespace_invalid_first_char() {
-        assert_eq!(validate_metric_namespace("1myapp"), None);
-        assert_eq!(validate_metric_namespace("_myapp"), None);
-        assert_eq!(validate_metric_namespace(".myapp"), None);
-        assert_eq!(validate_metric_namespace("-myapp"), None);
-    }
-
-    #[test]
-    fn test_validate_metric_namespace_invalid_chars() {
-        assert_eq!(validate_metric_namespace("my-app"), None);
-        assert_eq!(validate_metric_namespace("my app"), None);
-        assert_eq!(validate_metric_namespace("my@app"), None);
-        assert_eq!(validate_metric_namespace("my#app"), None);
-        assert_eq!(validate_metric_namespace("my$app"), None);
-        assert_eq!(validate_metric_namespace("my!app"), None);
     }
 }


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/SLES-2547

 - Updates dependency to use centralized parse_metric_namespace function. 
 - Removes duplicate code in favor of the shared implementation.


Test:
- Deploy the extension and config w/ [DD_STATSD_METRIC_NAMESPACE](https://us-east-1.console.aws.amazon.com/lambda/home?region=us-east-1#/functions/ltn-fullinstrument-bn-10bst-node22-lambda?subtab=envVars&tab=configure)
<img width="964" height="290" alt="image" src="https://github.com/user-attachments/assets/94836a3a-9905-44b4-9565-185745e47981" />
- Invoke the function and expect to see the metric using this custom prefix namespace
<img width="1170" height="516" alt="Screenshot 2025-11-11 at 4 59 57 PM" src="https://github.com/user-attachments/assets/0bf4ac5e-ac1c-4cfe-817e-89b004717caf" />

[Metric link](https://ddserverless.datadoghq.com/metric/explorer?fromUser=true&graph_layout=stacked&start=1762897808375&end=1762898083375&paused=true#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGABuMMhsaGg4YG5oUAB0WmiCLapS4m6iMMAAVDwgPAC6VBpyaDmg8hgzCAg5STgwTpmYGhoQmYloonBOcorK6QdQ+4dO9EzKIm4eaKP8EPaYWMcKKwciSuM8Pggd7iADCUmEMBQIjwdR4QA)