### PR TITLE
feat: Add support for DD_LOGS_ENABLED as alias for DD_SERVERLESS_LOGS_ENABLED

### DIFF
--- a/bottlecap/src/config/yaml.rs
+++ b/bottlecap/src/config/yaml.rs
@@ -101,6 +101,8 @@ pub struct YamlConfig {
     pub kms_api_key: Option<String>,
     #[serde(deserialize_with = "deserialize_optional_bool_from_anything")]
     pub serverless_logs_enabled: Option<bool>,
+    #[serde(deserialize_with = "deserialize_optional_bool_from_anything")]
+    pub logs_enabled: Option<bool>,
     pub serverless_flush_strategy: Option<FlushStrategy>,
     #[serde(deserialize_with = "deserialize_optional_bool_from_anything")]
     pub enhanced_metrics: Option<bool>,
@@ -671,7 +673,13 @@ fn merge_config(config: &mut Config, yaml_config: &YamlConfig) {
     // AWS Lambda
     merge_string!(config, yaml_config, api_key_secret_arn);
     merge_string!(config, yaml_config, kms_api_key);
-    merge_option_to_value!(config, yaml_config, serverless_logs_enabled);
+
+    // Handle serverless_logs_enabled with OR logic: if either logs_enabled or serverless_logs_enabled is true, enable logs
+    if yaml_config.serverless_logs_enabled.is_some() || yaml_config.logs_enabled.is_some() {
+        config.serverless_logs_enabled = yaml_config.serverless_logs_enabled.unwrap_or(false)
+            || yaml_config.logs_enabled.unwrap_or(false);
+    }
+
     merge_option_to_value!(config, yaml_config, serverless_flush_strategy);
     merge_option_to_value!(config, yaml_config, enhanced_metrics);
     merge_option_to_value!(config, yaml_config, lambda_proc_enhanced_metrics);


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/SVLS-7818

  ## Overview
Add DD_LOGS_ENABLED environment variable and YAML config option as an alias for DD_SERVERLESS_LOGS_ENABLED. Both variables now use OR logic, meaning logs are enabled if either variable is set to true.

  Changes:
  - Add logs_enabled field to EnvConfig and YamlConfig structs
  - Implement OR logic in merge_config functions: logs are enabled if either DD_LOGS_ENABLED or DD_SERVERLESS_LOGS_ENABLED is true
  - Add comprehensive test coverage with 9 test cases covering all combinations of the two variables
  - Maintain backward compatibility with existing configurations
  - Default value remains true when neither variable is set


## Testing 
Set DD_LOGS_ENABLED and DD_SERVERLESS_LOGS_ENABLED to false and expect:
- [Log can be found in AWS console](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fltn-fullinstrument-bn-cold-node22-lambda/log-events/2025$252F11$252F13$252F$255B$2524LATEST$255D455478dcbc944055b5be933e2e099f6a$3FfilterPattern$3DREPORT+RequestId)
- [Log could NOT be found in DD console](https://ddserverless.datadoghq.com/logs?query=source%3Alambda%20%40lambda.arn%3A%22arn%3Aaws%3Alambda%3Aus-east-1%3A425362996713%3Afunction%3Altn-fullinstrument-bn-cold-node22-lambda%22%20AND%20%22REPORT%20RequestId%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40lambda.request_id&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1763063694206&to_ts=1763065424700&live=false)

Otherwise the log should be available in DD console.