### PR TITLE
fix: Guard against negative CPU utilization metrics

### DIFF
--- a/bottlecap/src/metrics/enhanced/lambda.rs
+++ b/bottlecap/src/metrics/enhanced/lambda.rs
@@ -370,6 +370,15 @@ impl Lambda {
         let uptime = uptime_data_end - uptime_data_offset;
         let total_idle_time = cpu_data_end.total_idle_time_ms - cpu_data_offset.total_idle_time_ms;
 
+        // Validation: uptime should be positive and meaningful
+        if uptime <= 0.0 {
+            debug!(
+                "Invalid uptime delta: {}, skipping CPU utilization metrics",
+                uptime
+            );
+            return;
+        }
+
         let mut max_idle_time = 0.0;
         let mut min_idle_time = f64::MAX;
         let now = std::time::UNIX_EPOCH
@@ -383,6 +392,9 @@ impl Lambda {
                 cpu_data_offset.individual_cpu_idle_times.get(cpu_name)
             {
                 let idle_time = cpu_idle_time - cpu_idle_time_offset;
+                // Prevent negative values but allow overflow
+                let idle_time = idle_time.max(0.0);
+
                 if idle_time < min_idle_time {
                     min_idle_time = idle_time;
                 }
@@ -394,15 +406,18 @@ impl Lambda {
 
         // Maximally utilized CPU is the one with the least time spent in the idle process
         // Multiply by 100 to report as percentage
-        let cpu_max_utilization = ((uptime - min_idle_time) / uptime) * 100.0;
+        // Prevent negative values but allow overflow
+        let cpu_max_utilization = (((uptime - min_idle_time) / uptime) * 100.0).max(0.0);
 
         // Minimally utilized CPU is the one with the most time spent in the idle process
         // Multiply by 100 to report as percentage
-        let cpu_min_utilization = ((uptime - max_idle_time) / uptime) * 100.0;
+        // Prevent negative values but allow overflow
+        let cpu_min_utilization = (((uptime - max_idle_time) / uptime) * 100.0).max(0.0);
 
         // CPU total utilization is the proportion of total non-idle time to the total uptime across all cores
+        // Prevent negative values but allow overflow
         let cpu_total_utilization_decimal =
-            ((uptime * num_cores) - total_idle_time) / (uptime * num_cores);
+            (((uptime * num_cores) - total_idle_time) / (uptime * num_cores)).max(0.0);
         // Multiply by 100 to report as percentage
         let cpu_total_utilization_pct = cpu_total_utilization_decimal * 100.0;
         // Multiply by num_cores to report in terms of cores
@@ -1329,5 +1344,377 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
+    }
+
+    #[tokio::test]
+    async fn test_cpu_utilization_with_negative_uptime() {
+        let (metrics_aggr, my_config) = setup();
+        let _lambda = Lambda::new(metrics_aggr.clone(), my_config);
+        let now: i64 = std::time::UNIX_EPOCH
+            .elapsed()
+            .expect("unable to poll clock, unrecoverable")
+            .as_secs()
+            .try_into()
+            .unwrap_or_default();
+
+        let mut individual_cpu_idle_times = HashMap::new();
+        individual_cpu_idle_times.insert("cpu0".to_string(), 10.0);
+        let cpu_offset = CPUData {
+            total_user_time_ms: 50.0,
+            total_system_time_ms: 10.0,
+            total_idle_time_ms: 10.0,
+            individual_cpu_idle_times: individual_cpu_idle_times.clone(),
+        };
+        let cpu_data = CPUData {
+            total_user_time_ms: 100.0,
+            total_system_time_ms: 20.0,
+            total_idle_time_ms: 20.0,
+            individual_cpu_idle_times,
+        };
+
+        // Negative uptime (end < offset) - should skip metrics
+        let uptime_offset = 1000.0;
+        let uptime_data = 500.0;
+
+        Lambda::generate_cpu_utilization_enhanced_metrics(
+            &cpu_offset,
+            &cpu_data,
+            uptime_offset,
+            uptime_data,
+            &metrics_aggr,
+            None,
+        );
+
+        // No metrics should be created
+        assert!(
+            metrics_aggr
+                .get_entry_by_id(constants::CPU_MAX_UTILIZATION_METRIC.into(), None, now)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cpu_utilization_with_zero_uptime() {
+        let (metrics_aggr, my_config) = setup();
+        let _lambda = Lambda::new(metrics_aggr.clone(), my_config);
+        let now: i64 = std::time::UNIX_EPOCH
+            .elapsed()
+            .expect("unable to poll clock, unrecoverable")
+            .as_secs()
+            .try_into()
+            .unwrap_or_default();
+
+        let mut individual_cpu_idle_times = HashMap::new();
+        individual_cpu_idle_times.insert("cpu0".to_string(), 10.0);
+        let cpu_offset = CPUData {
+            total_user_time_ms: 50.0,
+            total_system_time_ms: 10.0,
+            total_idle_time_ms: 10.0,
+            individual_cpu_idle_times: individual_cpu_idle_times.clone(),
+        };
+        let cpu_data = CPUData {
+            total_user_time_ms: 100.0,
+            total_system_time_ms: 20.0,
+            total_idle_time_ms: 20.0,
+            individual_cpu_idle_times,
+        };
+
+        // Zero uptime - should skip metrics
+        let uptime_offset = 1000.0;
+        let uptime_data = 1000.0;
+
+        Lambda::generate_cpu_utilization_enhanced_metrics(
+            &cpu_offset,
+            &cpu_data,
+            uptime_offset,
+            uptime_data,
+            &metrics_aggr,
+            None,
+        );
+
+        // No metrics should be created
+        assert!(
+            metrics_aggr
+                .get_entry_by_id(constants::CPU_MAX_UTILIZATION_METRIC.into(), None, now)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cpu_utilization_with_excessive_idle_time() {
+        let (metrics_aggr, my_config) = setup();
+        let _lambda = Lambda::new(metrics_aggr.clone(), my_config);
+        let now: i64 = std::time::UNIX_EPOCH
+            .elapsed()
+            .expect("unable to poll clock, unrecoverable")
+            .as_secs()
+            .try_into()
+            .unwrap_or_default();
+
+        let mut individual_cpu_idle_time_offsets = HashMap::new();
+        individual_cpu_idle_time_offsets.insert("cpu0".to_string(), 10.0);
+        individual_cpu_idle_time_offsets.insert("cpu1".to_string(), 20.0);
+        let cpu_offset = CPUData {
+            total_user_time_ms: 50.0,
+            total_system_time_ms: 10.0,
+            total_idle_time_ms: 30.0,
+            individual_cpu_idle_times: individual_cpu_idle_time_offsets,
+        };
+
+        // Per-CPU idle times that exceed uptime but get clamped
+        // cpu0: 1010 - 10 = 1000 (exceeds uptime of 800, will be clamped to 800)
+        // cpu1: 1020 - 20 = 1000 (exceeds uptime of 800, will be clamped to 800)
+        let mut individual_cpu_idle_times_end = HashMap::new();
+        individual_cpu_idle_times_end.insert("cpu0".to_string(), 1010.0);
+        individual_cpu_idle_times_end.insert("cpu1".to_string(), 1020.0);
+        let cpu_data = CPUData {
+            total_user_time_ms: 200.0,
+            total_system_time_ms: 100.0,
+            total_idle_time_ms: 2030.0, // delta = 2000
+            individual_cpu_idle_times: individual_cpu_idle_times_end,
+        };
+
+        let uptime_offset = 1_000_000.0;
+        let uptime_data = 1_000_800.0; // delta = 800
+
+        Lambda::generate_cpu_utilization_enhanced_metrics(
+            &cpu_offset,
+            &cpu_data,
+            uptime_offset,
+            uptime_data,
+            &metrics_aggr,
+            None,
+        );
+
+        // Metrics should be created with clamped idle times
+        // Both CPUs have idle time clamped to 800 (the uptime)
+        // cpu_max_utilization = ((800 - 800) / 800) * 100 = 0%
+        // cpu_min_utilization = ((800 - 800) / 800) * 100 = 0%
+        assert_sketch(
+            &metrics_aggr,
+            constants::CPU_MAX_UTILIZATION_METRIC,
+            0.0,
+            now,
+        )
+        .await;
+        assert_sketch(
+            &metrics_aggr,
+            constants::CPU_MIN_UTILIZATION_METRIC,
+            0.0,
+            now,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_cpu_utilization_with_idle_time_exceeding_uptime() {
+        let (metrics_aggr, my_config) = setup();
+        let _lambda = Lambda::new(metrics_aggr.clone(), my_config);
+        let now: i64 = std::time::UNIX_EPOCH
+            .elapsed()
+            .expect("unable to poll clock, unrecoverable")
+            .as_secs()
+            .try_into()
+            .unwrap_or_default();
+
+        // This test simulates the bug scenario where per-CPU idle time > uptime
+        // The fix should clamp idle_time to [0, uptime] and produce valid metrics
+        let mut individual_cpu_idle_time_offsets = HashMap::new();
+        individual_cpu_idle_time_offsets.insert("cpu0".to_string(), 10.0);
+        individual_cpu_idle_time_offsets.insert("cpu1".to_string(), 20.0);
+        let cpu_offset = CPUData {
+            total_user_time_ms: 50.0,
+            total_system_time_ms: 10.0,
+            total_idle_time_ms: 30.0,
+            individual_cpu_idle_times: individual_cpu_idle_time_offsets,
+        };
+
+        // Per-CPU idle times that would exceed uptime without clamping
+        // cpu0: 1010 - 10 = 1000 (which equals uptime, ok)
+        // cpu1: 1050 - 20 = 1030 (which exceeds uptime of 1000, will be clamped)
+        let mut individual_cpu_idle_times_end = HashMap::new();
+        individual_cpu_idle_times_end.insert("cpu0".to_string(), 1010.0);
+        individual_cpu_idle_times_end.insert("cpu1".to_string(), 1050.0);
+        let cpu_data = CPUData {
+            total_user_time_ms: 200.0,
+            total_system_time_ms: 100.0,
+            total_idle_time_ms: 1100.0, // delta = 1070, within tolerance for 2 cores
+            individual_cpu_idle_times: individual_cpu_idle_times_end,
+        };
+
+        let uptime_offset = 1_000_000.0;
+        let uptime_data = 1_001_000.0; // delta = 1000
+
+        Lambda::generate_cpu_utilization_enhanced_metrics(
+            &cpu_offset,
+            &cpu_data,
+            uptime_offset,
+            uptime_data,
+            &metrics_aggr,
+            None,
+        );
+
+        // Metrics should be created with clamped values
+        // cpu1 idle time is clamped to 1000, so:
+        // min_idle_time = 1000 (cpu0)
+        // max_idle_time = 1000 (cpu1, clamped from 1030)
+        // cpu_max_utilization = ((1000 - 1000) / 1000) * 100 = 0%
+        // cpu_min_utilization = ((1000 - 1000) / 1000) * 100 = 0%
+        assert_sketch(
+            &metrics_aggr,
+            constants::CPU_MAX_UTILIZATION_METRIC,
+            0.0,
+            now,
+        )
+        .await;
+        assert_sketch(
+            &metrics_aggr,
+            constants::CPU_MIN_UTILIZATION_METRIC,
+            0.0,
+            now,
+        )
+        .await;
+
+        // Total utilization should also be valid (clamped to [0, 100])
+        let total_util_entry = metrics_aggr
+            .get_entry_by_id(
+                constants::CPU_TOTAL_UTILIZATION_PCT_METRIC.into(),
+                None,
+                (now / 10) * 10,
+            )
+            .await
+            .unwrap();
+        assert!(total_util_entry.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_cpu_utilization_with_negative_idle_time() {
+        let (metrics_aggr, my_config) = setup();
+        let _lambda = Lambda::new(metrics_aggr.clone(), my_config);
+        let now: i64 = std::time::UNIX_EPOCH
+            .elapsed()
+            .expect("unable to poll clock, unrecoverable")
+            .as_secs()
+            .try_into()
+            .unwrap_or_default();
+
+        // Test case where idle time decreases (negative delta)
+        // This can happen due to measurement timing issues
+        let mut individual_cpu_idle_time_offsets = HashMap::new();
+        individual_cpu_idle_time_offsets.insert("cpu0".to_string(), 1000.0);
+        let cpu_offset = CPUData {
+            total_user_time_ms: 50.0,
+            total_system_time_ms: 10.0,
+            total_idle_time_ms: 1000.0,
+            individual_cpu_idle_times: individual_cpu_idle_time_offsets,
+        };
+
+        // Idle time decreased - should be clamped to 0
+        let mut individual_cpu_idle_times_end = HashMap::new();
+        individual_cpu_idle_times_end.insert("cpu0".to_string(), 900.0);
+        let cpu_data = CPUData {
+            total_user_time_ms: 100.0,
+            total_system_time_ms: 20.0,
+            total_idle_time_ms: 900.0,
+            individual_cpu_idle_times: individual_cpu_idle_times_end,
+        };
+
+        let uptime_offset = 1_000_000.0;
+        let uptime_data = 1_000_500.0; // delta = 500
+
+        Lambda::generate_cpu_utilization_enhanced_metrics(
+            &cpu_offset,
+            &cpu_data,
+            uptime_offset,
+            uptime_data,
+            &metrics_aggr,
+            None,
+        );
+
+        // Metrics should be created with idle_time clamped to 0
+        // This results in 100% utilization
+        assert_sketch(
+            &metrics_aggr,
+            constants::CPU_MAX_UTILIZATION_METRIC,
+            100.0,
+            now,
+        )
+        .await;
+        assert_sketch(
+            &metrics_aggr,
+            constants::CPU_MIN_UTILIZATION_METRIC,
+            100.0,
+            now,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_cpu_utilization_boundary_values() {
+        let (metrics_aggr, my_config) = setup();
+        let _lambda = Lambda::new(metrics_aggr.clone(), my_config);
+        let now: i64 = std::time::UNIX_EPOCH
+            .elapsed()
+            .expect("unable to poll clock, unrecoverable")
+            .as_secs()
+            .try_into()
+            .unwrap_or_default();
+
+        // Test with very small uptime delta (edge case for fast invocations)
+        let mut individual_cpu_idle_time_offsets = HashMap::new();
+        individual_cpu_idle_time_offsets.insert("cpu0".to_string(), 0.0);
+        individual_cpu_idle_time_offsets.insert("cpu1".to_string(), 0.0);
+        let cpu_offset = CPUData {
+            total_user_time_ms: 0.0,
+            total_system_time_ms: 0.0,
+            total_idle_time_ms: 0.0,
+            individual_cpu_idle_times: individual_cpu_idle_time_offsets,
+        };
+
+        // Small but valid uptime delta
+        let mut individual_cpu_idle_times_end = HashMap::new();
+        individual_cpu_idle_times_end.insert("cpu0".to_string(), 0.5);
+        individual_cpu_idle_times_end.insert("cpu1".to_string(), 0.8);
+        let cpu_data = CPUData {
+            total_user_time_ms: 0.2,
+            total_system_time_ms: 0.1,
+            total_idle_time_ms: 1.3,
+            individual_cpu_idle_times: individual_cpu_idle_times_end,
+        };
+
+        let uptime_offset = 1_000_000.0;
+        let uptime_data = 1_000_001.0; // delta = 1.0 ms
+
+        Lambda::generate_cpu_utilization_enhanced_metrics(
+            &cpu_offset,
+            &cpu_data,
+            uptime_offset,
+            uptime_data,
+            &metrics_aggr,
+            None,
+        );
+
+        // Should produce valid metrics
+        // min_idle = 0.5, max_idle = 0.8
+        // max_util = (1.0 - 0.5) / 1.0 * 100 = 50%
+        // min_util = (1.0 - 0.8) / 1.0 * 100 = 20%
+        assert_sketch(
+            &metrics_aggr,
+            constants::CPU_MAX_UTILIZATION_METRIC,
+            50.0,
+            now,
+        )
+        .await;
+        assert_sketch(
+            &metrics_aggr,
+            constants::CPU_MIN_UTILIZATION_METRIC,
+            20.0,
+            now,
+        )
+        .await;
     }
 }


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/SVLS-7991

  ## Overview

  PR #894 introduced an asynchronous message-passing architecture that changed
  the timing of CPU metrics collection. This timing difference exposed a
  pre-existing issue where per-CPU idle time measurements could exceed the
  wall-clock uptime delta, resulting in negative CPU utilization values being
  reported to customers.

  The root cause is a fundamental mismatch between measurement domains:
  - `/proc/uptime` measures wall-clock system uptime (single value)
  - `/proc/stat` measures per-CPU cumulative idle time (one value per core)

  When these measurements are taken at slightly different times (especially in
  the async processing model), the per-CPU idle time delta can exceed the uptime
  delta, causing the formula `((uptime - idle_time) / uptime) * 100` to produce
  negative results.

  ## Solution

  Implemented defensive validation and enforce in the CPU utilization
  calculation to ensure metrics are always within valid ranges:

  1. **Uptime Validation**: Skip metrics if uptime delta is invalid (≤ 0)
     - Prevents division by zero
     - Catches timing anomalies early

  2. **Per-CPU Idle Time Check**: Enforce each CPU's idle time to non-negative value
     - Handles cases where idle_time > uptime due to measurement timing
     - Handles negative idle_time from measurement errors

  3. **Utilization Calculation**: Force all utilization values to be non-negative value

PS: Since this is a complex issue without a definitive solution yet, this fix serves only as a temporary measure to unblock our release commitment. We’ll continue investigating a long-term solution as a follow-up.

## Test
- Deployed the layer w/ the change and applied them to [these stacks](https://docs.google.com/spreadsheets/d/1oF60PBhYvwdOfFn6yz3zBUhZCZUP7Z43VVE6XE2QGWQ/edit?gid=0#gid=0) as they were the main contributors of the negative stats
- Observe the stats and expect [no more negative stats](https://ddserverless.datadoghq.com/dashboard/35c-u5f-8jm?fromUser=true&fullscreen_end_ts=1763142342127&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=overview&fullscreen_start_ts=1763138742127&fullscreen_widget=2129549723517146&refresh_mode=paused&tpl_var_runtime%5B0%5D=python3.10&tpl_var_runtime%5B1%5D=dotnet8&tpl_var_runtime%5B2%5D=java11&tpl_var_runtime%5B3%5D=nodejs20.x&tpl_var_runtime%5B4%5D=python3.13&tpl_var_runtime%5B5%5D=ruby3.2&tpl_var_service%5B0%5D=d1&from_ts=1763136901167&to_ts=1763137625000&live=false) are reported 
<img width="2262" height="1698" alt="image" src="https://github.com/user-attachments/assets/a4482590-64ac-4322-8169-103f82706ddf" />
