### PR TITLE
[SVLS-8002] fix: collect CPU metric offsets on PlatformStart

### DIFF
--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -22,7 +22,8 @@ use crate::{
     },
     metrics::enhanced::lambda::{EnhancedMetricData, Lambda as EnhancedMetrics},
     proc::{
-        self, CPUData, NetworkData, constants::{ETC_PATH, PROC_PATH}
+        self, CPUData, NetworkData,
+        constants::{ETC_PATH, PROC_PATH},
     },
     tags::{lambda::tags::resolve_runtime_from_proc, provider},
     traces::{
@@ -314,7 +315,7 @@ impl Processor {
             .try_into()
             .unwrap_or_default();
         self.context_buffer.add_start_time(&request_id, start_time);
-        
+
         if self.config.lambda_proc_enhanced_metrics {
             let cpu_offset: Option<CPUData> = proc::get_cpu_data().ok();
             let uptime_offset: Option<f64> = proc::get_uptime().ok();

--- a/bottlecap/src/metrics/enhanced/lambda.rs
+++ b/bottlecap/src/metrics/enhanced/lambda.rs
@@ -369,7 +369,7 @@ impl Lambda {
         let num_cores = cpu_data_end.individual_cpu_idle_times.len() as f64;
         let uptime = uptime_data_end - uptime_data_offset;
         let total_idle_time = cpu_data_end.total_idle_time_ms - cpu_data_offset.total_idle_time_ms;
-        
+
         // Change in uptime should be positive and greater than total idle time across all cores
         if uptime <= 0.0 || (uptime * num_cores) < total_idle_time {
             debug!("Invalid uptime, skipping CPU utilization metrics");
@@ -390,7 +390,7 @@ impl Lambda {
             {
                 let idle_time = cpu_idle_time - cpu_idle_time_offset;
                 let idle_time = idle_time.max(0.0); // Ensure idle time is non-negative
-                
+
                 if idle_time < min_idle_time {
                     min_idle_time = idle_time;
                 }


### PR DESCRIPTION
## Overview

Collect CPU metric offsets on receiving the PlatformStart instead of the Invoke event to avoid accounting for additional idle time while calculating utilization. Also, guard uptime and idle time to be non-negative for edge-cases.

Maintains collecting network offsets on the Invoke event to match with Lambda Insights.

## Testing 

Tested with self-monitoring

<img width="2620" height="904" alt="image" src="https://github.com/user-attachments/assets/6960e9f3-2f35-40d2-9c49-3560e8ebd295" />
