### PR TITLE
 (feat) Add URL to proxy flusher error logs

### DIFF
--- a/bottlecap/src/traces/proxy_flusher.rs
+++ b/bottlecap/src/traces/proxy_flusher.rs
@@ -165,7 +165,9 @@ impl Flusher {
                             elapsed.as_millis()
                         );
                     } else {
-                        error!("PROXY_FLUSHER | Request failed with status {status}: {body:?}");
+                        error!(
+                            "PROXY_FLUSHER | Request failed with status {status} to {url}: {body:?}"
+                        );
                     }
 
                     return Ok(());


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/SVLS-8005

## Overview
Proxy flush doesn't log the URL in case of error. Need to add it to better investigate the issue.

## Testing 
n/a