### PR TITLE
chore: Set 10m timeout and retries for a GitLab job

### DIFF
--- a/.gitlab/templates/pipeline.yaml.tpl
+++ b/.gitlab/templates/pipeline.yaml.tpl
@@ -51,7 +51,7 @@ bottlecap ({{ $flavor.name }}):
   image: registry.ddbuild.io/images/docker:20.10
   tags: ["arch:{{ $flavor.arch }}"]
   needs: []
-  # This job sometimes times out on GitLab runner 17227436 for unclear reason.
+  # This job sometimes times out on GitLab for unclear reason.
   # Set a short timeout with retries to work around this.
   timeout: 10m
   retry:


### PR DESCRIPTION
## Problem
The `bottlecap` GitLab job usually takes < 10 minutes, but it sometimes gets stuck and times out at 1 hour. This failure signal causes confusion in PRs and blocks PR merge. As a result, engineers often need to rerun this job.

## This PR

For this job, add:
1. timeout of 10 minutes
2. a retry in case of `stuck_or_timeout_failure` or `runner_system_failure`

## Testing
Will merge and see if these errors become less frequent.