### PR TITLE
fix: [SVLS-8072] run apt-get update and apt-get install in same layer

### DIFF
--- a/scripts/Dockerfile.alpine.build
+++ b/scripts/Dockerfile.alpine.build
@@ -54,8 +54,7 @@ RUN /usr/lib/go/bin/go tool nm datadog-agent | grep -w 'github.com/DataDog/datad
 FROM ubuntu:22.04 as compresser
 ARG CMD_PATH
 ARG DATADOG_WRAPPER=datadog_wrapper
-RUN apt-get update
-RUN apt-get install -y zip binutils
+RUN apt-get update && apt-get install -y zip binutils
 RUN mkdir /extensions
 WORKDIR /extensions
 COPY --from=builder /tmp/dd/datadog-agent/"${CMD_PATH}"/datadog-agent /extensions/datadog-agent

--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -57,8 +57,7 @@ FROM ubuntu:22.04 as compresser
 ARG CMD_PATH
 ARG DATADOG_WRAPPER=datadog_wrapper
 
-RUN apt-get update
-RUN apt-get install -y zip binutils
+RUN apt-get update && apt-get install -y zip binutils
 RUN mkdir /extensions
 WORKDIR /extensions
 COPY --from=builder /tmp/dd/datadog-agent/"${CMD_PATH}"/datadog-agent /extensions/datadog-agent

--- a/scripts/Dockerfile.race.build
+++ b/scripts/Dockerfile.race.build
@@ -43,8 +43,7 @@ RUN go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/ver
 
 # zip the extension
 FROM ubuntu:22.04 as compresser
-RUN apt-get update
-RUN apt-get install -y zip
+RUN apt-get update && apt-get install -y zip
 RUN mkdir /extensions
 WORKDIR /extensions
 COPY --from=builder /tmp/dd/datadog-agent/cmd/serverless/datadog-agent /extensions/datadog-agent


### PR DESCRIPTION
## Overview

Fixes below error:

https://github.com/DataDog/datadog-lambda-extension/actions/runs/19829559230/job/56812757592

```
#16 [compresser  3/10] RUN apt-get install -y zip binutils
#16 0.095 Reading package lists...
#16 1.033 Building dependency tree...
#16 1.217 Reading state information...
#16 1.357 The following additional packages will be installed:
#16 1.358   binutils-common binutils-x86-64-linux-gnu libbinutils libctf-nobfd0 libctf0
#16 1.358   unzip
#16 1.359 Suggested packages:
#16 1.359   binutils-doc
#16 1.392 The following NEW packages will be installed:
#16 1.392   binutils binutils-common binutils-x86-64-linux-gnu libbinutils libctf-nobfd0
#16 1.393   libctf0 unzip zip
#16 1.648 0 upgraded, 8 newly installed, 0 to remove and 0 not upgraded.
#16 1.648 Need to get 3769 kB of archives.
#16 1.648 After this operation, 15.7 MB of additional disk space will be used.
#16 1.648 Err:1 http://security.ubuntu.com/ubuntu jammy-security/main amd64 binutils-common amd64 2.38-4ubuntu2.11
#16 1.648   404  Not Found [IP: 91.189.91.82 80]
#16 1.727 Err:2 http://security.ubuntu.com/ubuntu jammy-security/main amd64 libbinutils amd64 2.38-4ubuntu2.11
#16 1.727   404  Not Found [IP: 91.189.91.82 80]
#16 1.727 Err:3 http://security.ubuntu.com/ubuntu jammy-security/main amd64 libctf-nobfd0 amd64 2.38-4ubuntu2.11
#16 1.727   404  Not Found [IP: 91.189.91.82 80]
#16 1.727 Err:4 http://security.ubuntu.com/ubuntu jammy-security/main amd64 libctf0 amd64 2.38-4ubuntu2.11
#16 1.727   404  Not Found [IP: 91.189.91.82 80]
#16 1.727 Err:5 http://security.ubuntu.com/ubuntu jammy-security/main amd64 binutils-x86-64-linux-gnu amd64 2.38-4ubuntu2.11
#16 1.727   404  Not Found [IP: 91.189.91.82 80]
#16 1.727 Err:6 http://security.ubuntu.com/ubuntu jammy-security/main amd64 binutils amd64 2.38-4ubuntu2.11
#16 1.727   404  Not Found [IP: 91.189.91.82 80]
#16 1.838 Get:7 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 unzip amd64 6.0-26ubuntu3.2 [175 kB]
#16 2.515 Get:8 http://archive.ubuntu.com/ubuntu jammy/main amd64 zip amd64 3.0-12build2 [176 kB]
#16 2.625 Fetched 350 kB in 1s (287 kB/s)
#16 2.625 E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/b/binutils/binutils-common_2.38-4ubuntu2.11_amd64.deb  404  Not Found [IP: 91.189.91.82 80]
#16 2.625 E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/b/binutils/libbinutils_2.38-4ubuntu2.11_amd64.deb  404  Not Found [IP: 91.189.91.82 80]
#16 2.625 E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/b/binutils/libctf-nobfd0_2.38-4ubuntu2.11_amd64.deb  404  Not Found [IP: 91.189.91.82 80]
#16 2.625 E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/b/binutils/libctf0_2.38-4ubuntu2.11_amd64.deb  404  Not Found [IP: 91.189.91.82 80]
#16 2.625 E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/b/binutils/binutils-x86-64-linux-gnu_2.38-4ubuntu2.11_amd64.deb  404  Not Found [IP: 91.189.91.82 80]
#16 2.625 E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/b/binutils/binutils_2.38-4ubuntu2.11_amd64.deb  404  Not Found [IP: 91.189.91.82 80]
#16 2.625 E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
#16 ERROR: process "/bin/sh -c apt-get install -y zip binutils" did not complete successfully: exit code: 100
```

## Testing 