### PR TITLE
A temp to address the data loss due to a fundamental mismatch between synchronous signals and asynchronous effects

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -511,14 +511,19 @@ async fn extension_loop_active(
         .to_string();
     let tags_provider = setup_tag_provider(&Arc::clone(&aws_config), config, &account_id);
 
-    let (logs_agent_channel, logs_flusher, logs_agent_cancel_token, logs_aggregator_handle) =
-        start_logs_agent(
-            config,
-            Arc::clone(&api_key_factory),
-            &tags_provider,
-            event_bus_tx.clone(),
-            aws_config.is_managed_instance_mode(),
-        );
+    let (
+        logs_agent_channel,
+        logs_flusher,
+        logs_agent_cancel_token,
+        logs_aggregator_handle,
+        logs_agent_handle,
+    ) = start_logs_agent(
+        config,
+        Arc::clone(&api_key_factory),
+        &tags_provider,
+        event_bus_tx.clone(),
+        aws_config.is_managed_instance_mode(),
+    );
 
     let (metrics_flushers, metrics_aggregator_handle, dogstatsd_cancel_token) =
         start_dogstatsd(tags_provider.clone(), Arc::clone(&api_key_factory), config).await;
@@ -584,16 +589,16 @@ async fn extension_loop_active(
         }
     });
 
-    let telemetry_listener_cancel_token = setup_telemetry_client(
-        client,
-        &r.extension_id,
-        &aws_config.runtime_api,
-        logs_agent_channel,
-        event_bus_tx.clone(),
-        config.serverless_logs_enabled,
-        aws_config.is_managed_instance_mode(),
-    )
-    .await?;
+    let (telemetry_listener_cancel_token, telemetry_listener, telemetry_listener_handle) =
+        setup_telemetry_client(
+            client,
+            &r.extension_id,
+            &aws_config.runtime_api,
+            logs_agent_channel,
+            config.serverless_logs_enabled,
+            aws_config.is_managed_instance_mode(),
+        )
+        .await?;
 
     let otlp_cancel_token = start_otlp_agent(
         config,
@@ -780,8 +785,43 @@ async fn extension_loop_active(
         // Shutdown sequence
         debug!("Initiating shutdown sequence");
 
-        // Wait for tombstone event from telemetry listener to ensure all events are processed
-        // This is the result of code refactoring which is shared by OnDemand mode as well.
+        // Step 1: Cancel TelemetryListener HTTP server
+        debug!("SHUTDOWN | Step 1: Cancelling TelemetryListener");
+        telemetry_listener_cancel_token.cancel();
+
+        // Step 2: Await TelemetryListener HTTP server to fully shut down
+        // This ensures all in-flight HTTP requests are completed and logs_tx channel receives all messages
+        debug!("SHUTDOWN | Step 2: Awaiting TelemetryListener HTTP server shutdown");
+        if let Err(e) = telemetry_listener_handle.await {
+            error!("Error waiting for telemetry listener to shut down: {e:?}");
+        }
+
+        // Step 3: Drop TelemetryListener to close logs_tx channel
+        debug!("SHUTDOWN | Step 3: Dropping TelemetryListener to close logs_tx channel");
+        drop(telemetry_listener);
+
+        // Step 4: Cancel LogsAgent
+        debug!("SHUTDOWN | Step 4: Cancelling LogsAgent");
+        logs_agent_cancel_token.cancel();
+
+        // Step 5: Await LogsAgent to finish draining all logs from logs_tx channel
+        debug!("SHUTDOWN | Step 5: Awaiting LogsAgent to drain all logs");
+        if let Err(e) = logs_agent_handle.await {
+            error!("Error waiting for logs agent to shut down: {e:?}");
+        }
+
+        // Step 6: Send tombstone event to signal no more telemetry events
+        debug!("SHUTDOWN | Step 6: Sending tombstone event");
+        if let Err(e) = event_bus_tx.send(Event::Tombstone).await {
+            error!("Failed to send tombstone event: {e:?}");
+        }
+
+        // Step 7: Drop event_bus_tx to allow the event_bus channel to close
+        debug!("SHUTDOWN | Step 7: Dropping event_bus_tx");
+        drop(event_bus_tx);
+
+        // Step 8: Wait for tombstone event to be processed from event_bus
+        debug!("SHUTDOWN | Step 8: Waiting for tombstone event to be processed");
         wait_for_tombstone_event(
             &mut event_bus,
             &invocation_processor_handle,
@@ -794,13 +834,14 @@ async fn extension_loop_active(
         )
         .await;
 
-        // Cancel background tasks
+        // Step 9: Cancel other background services
+        debug!("SHUTDOWN | Step 9: Cancelling other background services");
         cancel_background_services(
             api_runtime_proxy_shutdown_signal.as_ref(),
             otlp_cancel_token.as_ref(),
             &trace_agent_shutdown_token,
             &dogstatsd_cancel_token,
-            &telemetry_listener_cancel_token,
+            &telemetry_listener_cancel_token, // Already cancelled, but included for completeness
             &lifecycle_listener_shutdown_token,
         );
 
@@ -1023,18 +1064,9 @@ async fn extension_loop_active(
         }
 
         if let NextEventResponse::Shutdown { .. } = maybe_shutdown_event {
-            // Cancel Telemetry API listener
-            // Important to do this first, so we can receive the Tombstone event which signals
-            // that there are no more Telemetry events to process
-            telemetry_listener_cancel_token.cancel();
+            debug!("OnDemand mode: Initiating shutdown sequence");
 
-            // Cancel Logs Agent which might have Telemetry API events to process
-            logs_agent_cancel_token.cancel();
-
-            // Drop the event bus sender to allow the channel to close properly
-            drop(event_bus_tx);
-
-            // Redrive/block on any failed payloads
+            // Redrive/block on any failed payloads before starting shutdown
             let tf = trace_flusher.clone();
             pending_flush_handles
                 .await_flush_handles(
@@ -1044,7 +1076,44 @@ async fn extension_loop_active(
                     &proxy_flusher,
                 )
                 .await;
-            // Wait for tombstone event from telemetry listener to ensure all events are processed
+
+            // Step 1: Cancel TelemetryListener HTTP server
+            debug!("SHUTDOWN | Step 1: Cancelling TelemetryListener");
+            telemetry_listener_cancel_token.cancel();
+
+            // Step 2: Await TelemetryListener HTTP server to fully shut down
+            // This ensures all in-flight HTTP requests are completed and logs_tx channel receives all messages
+            debug!("SHUTDOWN | Step 2: Awaiting TelemetryListener HTTP server shutdown");
+            if let Err(e) = telemetry_listener_handle.await {
+                error!("Error waiting for telemetry listener to shut down: {e:?}");
+            }
+
+            // Step 3: Drop TelemetryListener to close logs_tx channel
+            debug!("SHUTDOWN | Step 3: Dropping TelemetryListener to close logs_tx channel");
+            drop(telemetry_listener);
+
+            // Step 4: Cancel LogsAgent
+            debug!("SHUTDOWN | Step 4: Cancelling LogsAgent");
+            logs_agent_cancel_token.cancel();
+
+            // Step 5: Await LogsAgent to finish draining all logs from logs_tx channel
+            debug!("SHUTDOWN | Step 5: Awaiting LogsAgent to drain all logs");
+            if let Err(e) = logs_agent_handle.await {
+                error!("Error waiting for logs agent to shut down: {e:?}");
+            }
+
+            // Step 6: Send tombstone event to signal no more telemetry events
+            debug!("SHUTDOWN | Step 6: Sending tombstone event");
+            if let Err(e) = event_bus_tx.send(Event::Tombstone).await {
+                error!("Failed to send tombstone event: {e:?}");
+            }
+
+            // Step 7: Drop event_bus_tx to allow the event_bus channel to close
+            debug!("SHUTDOWN | Step 7: Dropping event_bus_tx");
+            drop(event_bus_tx);
+
+            // Step 8: Wait for tombstone event to be processed from event_bus
+            debug!("SHUTDOWN | Step 8: Waiting for tombstone event to be processed");
             wait_for_tombstone_event(
                 &mut event_bus,
                 &invocation_processor_handle,
@@ -1057,13 +1126,14 @@ async fn extension_loop_active(
             )
             .await;
 
-            // Cancel background services
+            // Step 9: Cancel other background services
+            debug!("SHUTDOWN | Step 9: Cancelling other background services");
             cancel_background_services(
                 api_runtime_proxy_shutdown_signal.as_ref(),
                 otlp_cancel_token.as_ref(),
                 &trace_agent_shutdown_token,
                 &dogstatsd_cancel_token,
-                &telemetry_listener_cancel_token,
+                &telemetry_listener_cancel_token, // Already cancelled, but included for completeness
                 &lifecycle_listener_shutdown_token,
             );
 
@@ -1410,6 +1480,7 @@ fn start_logs_agent(
     LogsFlusher,
     CancellationToken,
     LogsAggregatorHandle,
+    JoinHandle<()>,
 ) {
     let (aggregator_service, aggregator_handle) = LogsAggregatorService::default();
     // Start service in background
@@ -1425,8 +1496,8 @@ fn start_logs_agent(
         is_managed_instance_mode,
     );
     let cancel_token = agent.cancel_token();
-    // Start logs agent in background
-    tokio::spawn(async move {
+    // Start logs agent in background and return JoinHandle for awaitable completion
+    let logs_agent_handle = tokio::spawn(async move {
         agent.spin().await;
 
         debug!("LOGS_AGENT | Shutting down...");
@@ -1434,7 +1505,13 @@ fn start_logs_agent(
     });
 
     let flusher = LogsFlusher::new(api_key_factory, aggregator_handle.clone(), config.clone());
-    (tx, flusher, cancel_token, aggregator_handle)
+    (
+        tx,
+        flusher,
+        cancel_token,
+        aggregator_handle,
+        logs_agent_handle,
+    )
 }
 
 #[allow(clippy::type_complexity)]
@@ -1665,22 +1742,13 @@ async fn setup_telemetry_client(
     extension_id: &str,
     runtime_api: &str,
     logs_tx: Sender<TelemetryEvent>,
-    event_bus_tx: Sender<Event>,
     logs_enabled: bool,
     managed_instance_mode: bool,
-) -> anyhow::Result<CancellationToken> {
-    let listener = TelemetryListener::new(EXTENSION_HOST_IP, TELEMETRY_PORT, logs_tx, event_bus_tx);
+) -> anyhow::Result<(CancellationToken, TelemetryListener, JoinHandle<()>)> {
+    let listener = TelemetryListener::new(EXTENSION_HOST_IP, TELEMETRY_PORT, logs_tx);
 
     let cancel_token = listener.cancel_token();
-    match listener.start() {
-        Ok(()) => {
-            // Drop the listener, so event_bus_tx is closed
-            drop(listener);
-        }
-        Err(e) => {
-            error!("Error starting telemetry listener: {e:?}");
-        }
-    }
+    let telemetry_handle = listener.start();
 
     telemetry::subscribe(
         client,
@@ -1693,7 +1761,7 @@ async fn setup_telemetry_client(
     .await
     .map_err(|e| anyhow::anyhow!("Failed to subscribe to telemetry: {e:?}"))?;
 
-    Ok(cancel_token)
+    Ok((cancel_token, listener, telemetry_handle))
 }
 
 fn start_otlp_agent(

--- a/bottlecap/src/extension/telemetry/listener.rs
+++ b/bottlecap/src/extension/telemetry/listener.rs
@@ -1,5 +1,4 @@
 use crate::{
-    event_bus,
     extension::telemetry::events::TelemetryEvent,
     http::{extract_request_body, handler_not_found},
 };
@@ -12,7 +11,7 @@ use axum::{
     routing::post,
 };
 use std::net::SocketAddr;
-use tokio::{net::TcpListener, sync::mpsc::Sender};
+use tokio::{net::TcpListener, sync::mpsc::Sender, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
@@ -23,24 +22,17 @@ pub struct TelemetryListener {
     port: u16,
     cancel_token: CancellationToken,
     logs_tx: Sender<TelemetryEvent>,
-    event_bus_tx: Sender<event_bus::Event>,
 }
 
 impl TelemetryListener {
     #[must_use]
-    pub fn new(
-        host: [u8; 4],
-        port: u16,
-        logs_tx: Sender<TelemetryEvent>,
-        event_bus_tx: Sender<event_bus::Event>,
-    ) -> Self {
+    pub fn new(host: [u8; 4], port: u16, logs_tx: Sender<TelemetryEvent>) -> Self {
         let cancel_token = CancellationToken::new();
         Self {
             host,
             port,
             cancel_token,
             logs_tx,
-            event_bus_tx,
         }
     }
 
@@ -49,24 +41,26 @@ impl TelemetryListener {
         self.cancel_token.clone()
     }
 
-    pub fn start(&self) -> Result<(), Box<dyn std::error::Error>> {
+    /// Starts the telemetry listener HTTP server.
+    /// Returns a `JoinHandle` that completes when the server has fully shut down,
+    /// ensuring all in-flight HTTP requests have been processed.
+    #[must_use]
+    pub fn start(&self) -> JoinHandle<()> {
         let socket = SocketAddr::from((self.host, self.port));
         let router = self.make_router();
 
         let cancel_token_clone = self.cancel_token();
-        let event_bus_tx = self.event_bus_tx.clone();
         tokio::spawn(async move {
             let listener = TcpListener::bind(&socket)
                 .await
                 .expect("Failed to bind socket");
             debug!("TELEMETRY API | Starting listener on {}", socket);
             axum::serve(listener, router)
-                .with_graceful_shutdown(Self::graceful_shutdown(cancel_token_clone, event_bus_tx))
+                .with_graceful_shutdown(Self::graceful_shutdown(cancel_token_clone))
                 .await
                 .expect("Failed to start telemetry listener");
-        });
-
-        Ok(())
+            debug!("TELEMETRY API | HTTP server fully shut down");
+        })
     }
 
     fn make_router(&self) -> Router {
@@ -78,19 +72,13 @@ impl TelemetryListener {
             .with_state(logs_tx)
     }
 
-    async fn graceful_shutdown(
-        cancel_token: CancellationToken,
-        event_bus_tx: Sender<event_bus::Event>,
-    ) {
+    async fn graceful_shutdown(cancel_token: CancellationToken) {
         cancel_token.cancelled().await;
-        debug!("TELEMETRY API | Shutdown signal received, sending tombstone event");
-
-        // Send tombstone event to signal shutdown
-        if let Err(e) = event_bus_tx.send(event_bus::Event::Tombstone).await {
-            debug!("TELEMETRY API |Failed to send tombstone event: {:?}", e);
-        }
-
-        debug!("TELEMETRY API | Shutting down");
+        debug!(
+            "TELEMETRY API | Shutdown signal received, initiating graceful HTTP server shutdown"
+        );
+        // Note: Tombstone event is now sent by the main shutdown sequence
+        // after all telemetry messages have been processed
     }
 
     async fn handle(State(logs_tx): State<Sender<TelemetryEvent>>, request: Request) -> Response {
@@ -170,5 +158,77 @@ mod tests {
             runtime_version: Some("nodejs:20.v22".to_string()),
             runtime_version_arn: Some("arn:aws:lambda:us-east-1::runtime:da57c20c4b965d5b75540f6865a35fc8030358e33ec44ecfed33e90901a27a72".to_string()),
         });
+    }
+
+    #[tokio::test]
+    #[allow(clippy::unwrap_used)]
+    async fn test_start_returns_joinhandle() {
+        // Test that start() returns a JoinHandle that can be awaited
+        let (logs_tx, _logs_rx) = tokio::sync::mpsc::channel(10);
+        let listener = TelemetryListener::new([127, 0, 0, 1], 0, logs_tx);
+
+        let join_handle = listener.start();
+
+        // Cancel immediately and await completion
+        listener.cancel_token().cancel();
+
+        // The JoinHandle should complete without hanging
+        let result = tokio::time::timeout(std::time::Duration::from_secs(5), join_handle).await;
+
+        assert!(result.is_ok(), "JoinHandle should complete within timeout");
+        assert!(result.unwrap().is_ok(), "Server task should not panic");
+    }
+
+    #[tokio::test]
+    #[allow(clippy::unwrap_used)]
+    async fn test_graceful_shutdown_completes() {
+        // Test that graceful shutdown completes when cancel token is triggered
+        let (logs_tx, _logs_rx) = tokio::sync::mpsc::channel(10);
+        let listener = TelemetryListener::new([127, 0, 0, 1], 0, logs_tx);
+
+        let cancel_token = listener.cancel_token();
+        let join_handle = listener.start();
+
+        // Give the server a moment to start
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // Cancel and verify shutdown completes
+        cancel_token.cancel();
+
+        // Wait for shutdown to complete (should not hang)
+        let result = tokio::time::timeout(std::time::Duration::from_secs(5), join_handle).await;
+
+        assert!(
+            result.is_ok(),
+            "Graceful shutdown should complete within timeout"
+        );
+    }
+
+    #[tokio::test]
+    #[allow(clippy::unwrap_used)]
+    async fn test_no_tombstone_sent_on_shutdown() {
+        // This test verifies that TelemetryListener no longer sends tombstone
+        // The tombstone is now sent by main.rs after all messages are processed
+        let (logs_tx, mut logs_rx) = tokio::sync::mpsc::channel(10);
+        let listener = TelemetryListener::new([127, 0, 0, 1], 0, logs_tx);
+
+        let cancel_token = listener.cancel_token();
+        let join_handle = listener.start();
+
+        // Give the server a moment to start
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // Cancel the listener
+        cancel_token.cancel();
+
+        // Wait for shutdown
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), join_handle).await;
+
+        // Verify no messages were sent to logs_rx (no tombstone)
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert!(
+            logs_rx.try_recv().is_err(),
+            "No messages should be sent during shutdown (tombstone is sent by main.rs)"
+        );
     }
 }


### PR DESCRIPTION
A temp to address the data loss due to a fundamental mismatch between synchronous signals and asynchronous effects

How It Works:

The new shutdown sequence ensures messages are not lost by:
1. Cancelling TelemetryListener and awaiting HTTP server shutdown
2. Dropping TelemetryListener to close logs_tx channel
3. Cancelling LogsAgent and awaiting its completion (ensuring all logs are drained)
4. Sending tombstone event only after all messages are processed
5. Dropping event_bus_tx and waiting for tombstone to be processed

====
Justification: instead of hoping async work completes in time, we now enforce the order:

1. Cancel TelemetryListener → await HTTP shutdown (guarantees no new messages)
2. Drop TelemetryListener → closes logs_tx (signals end of input)
3. Cancel LogsAgent → await draining completion (guarantees all messages forwarded)
4. Send tombstone → now we know all messages are processed
5. Drop event_bus_tx → safe because no more senders

Each await transforms an asynchronous cancellation into a synchronous completion guarantee.


