### PR TITLE
[SVLS-8179] add debug log for flush strategy

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -605,6 +605,7 @@ async fn extension_loop_active(
 
     // Validate and get the appropriate flush strategy for the current mode
     let flush_strategy = get_flush_strategy_for_mode(&aws_config, config.serverless_flush_strategy);
+    debug!("Flush strategy: {:?}", flush_strategy);
     let mut flush_control = FlushControl::new(flush_strategy, config.flush_timeout);
 
     debug!(

--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -88,6 +88,12 @@ impl LambdaProcessor {
     #[allow(clippy::too_many_lines)]
     async fn get_message(&mut self, event: TelemetryEvent) -> Result<Message, Box<dyn Error>> {
         let copy = event.clone();
+
+        // Log all non-Extension telemetry events to avoid infinite loop
+        if !matches!(event.record, TelemetryRecord::Extension(_)) {
+            debug!("LOGS | Incoming telemetry event: {:?}", event.record);
+        }
+
         match event.record {
             TelemetryRecord::Function(v) => {
                 let (request_id, message) = match v {


### PR DESCRIPTION
## Overview
* Add debug log for flush strategy.
* Add debug log for incoming telemetry records. This excludes Extension telemetry since that would lead to an infinite loop.

## Testing 
* Deployed and invoked function. Confirm we see flush strategy and incoming telemetry records.