### PR TITLE
remove extra log

### DIFF
--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -88,12 +88,6 @@ impl LambdaProcessor {
     #[allow(clippy::too_many_lines)]
     async fn get_message(&mut self, event: TelemetryEvent) -> Result<Message, Box<dyn Error>> {
         let copy = event.clone();
-
-        // Log all non-Extension telemetry events to avoid infinite loop
-        if !matches!(event.record, TelemetryRecord::Extension(_)) {
-            debug!("LOGS | Incoming telemetry event: {:?}", event.record);
-        }
-
         match event.record {
             TelemetryRecord::Function(v) => {
                 let (request_id, message) = match v {


### PR DESCRIPTION
## Overview
- Revert adding the unneeded log from https://github.com/DataDog/datadog-lambda-extension/commit/46e9e9c2808a2d51486204abff7ae11a117d4eab. 
