### PR TITLE
John/refactor integ tests

### DIFF
--- a/integration-tests/lib/stacks/base.ts
+++ b/integration-tests/lib/stacks/base.ts
@@ -6,10 +6,14 @@ import {
   defaultDatadogEnvVariables,
   defaultDatadogSecretPolicy,
   getExtensionLayer,
-  getNode20Layer,
-  getPython313Layer,
-  getJava21Layer,
-  getDotnet8Layer
+  getDefaultNodeLayer,
+  getDefaultPythonLayer,
+  getDefaultJavaLayer,
+  getDefaultDotnetLayer,
+  defaultNodeRuntime,
+  defaultPythonRuntime,
+  defaultJavaRuntime,
+  defaultDotnetRuntime
 } from '../util';
 
 export class Base extends cdk.Stack {
@@ -18,15 +22,15 @@ export class Base extends cdk.Stack {
 
     // Get layers once for the entire stack
     const extensionLayer = getExtensionLayer(this);
-    const node20Layer = getNode20Layer(this);
-    const python313Layer = getPython313Layer(this);
-    const java21Layer = getJava21Layer(this);
-    const dotnet8Layer = getDotnet8Layer(this);
+    const nodeLayer = getDefaultNodeLayer(this);
+    const pythonLayer = getDefaultPythonLayer(this);
+    const javaLayer = getDefaultJavaLayer(this);
+    const dotnetLayer = getDefaultDotnetLayer(this);
 
     // Node.js Lambda
     const nodeFunctionName = `${id}-node-lambda`;
     const nodeFunction = new lambda.Function(this, nodeFunctionName, {
-      runtime: lambda.Runtime.NODEJS_20_X,
+      runtime: defaultNodeRuntime,
       architecture: lambda.Architecture.ARM_64,
       handler: '/opt/nodejs/node_modules/datadog-lambda-js/handler.handler',
       code: lambda.Code.fromAsset('./lambda/base-node'),
@@ -43,12 +47,12 @@ export class Base extends cdk.Stack {
     });
     nodeFunction.addToRolePolicy(defaultDatadogSecretPolicy);
     nodeFunction.addLayers(extensionLayer);
-    nodeFunction.addLayers(node20Layer);
+    nodeFunction.addLayers(nodeLayer);
 
     // Python Lambda
     const pythonFunctionName = `${id}-python-lambda`;
     const pythonFunction = new lambda.Function(this, pythonFunctionName, {
-      runtime: lambda.Runtime.PYTHON_3_13,
+      runtime: defaultPythonRuntime,
       architecture: lambda.Architecture.ARM_64,
       handler: 'datadog_lambda.handler.handler',
       code: lambda.Code.fromAsset('./lambda/base-python'),
@@ -68,12 +72,12 @@ export class Base extends cdk.Stack {
     });
     pythonFunction.addToRolePolicy(defaultDatadogSecretPolicy);
     pythonFunction.addLayers(extensionLayer);
-    pythonFunction.addLayers(python313Layer);
+    pythonFunction.addLayers(pythonLayer);
 
     // Java Lambda
     const javaFunctionName = `${id}-java-lambda`;
     const javaFunction = new lambda.Function(this, javaFunctionName, {
-      runtime: lambda.Runtime.JAVA_21,
+      runtime: defaultJavaRuntime,
       architecture: lambda.Architecture.ARM_64,
       handler: 'example.Handler::handleRequest',
       code: lambda.Code.fromAsset('./lambda/base-java/target/function.jar'),
@@ -90,12 +94,12 @@ export class Base extends cdk.Stack {
     });
     javaFunction.addToRolePolicy(defaultDatadogSecretPolicy);
     javaFunction.addLayers(extensionLayer);
-    javaFunction.addLayers(java21Layer);
+    javaFunction.addLayers(javaLayer);
 
     // .NET Lambda
     const dotnetFunctionName = `${id}-dotnet-lambda`;
     const dotnetFunction = new lambda.Function(this, dotnetFunctionName, {
-      runtime: lambda.Runtime.DOTNET_8,
+      runtime: defaultDotnetRuntime,
       architecture: lambda.Architecture.ARM_64,
       handler: 'Function::Function.Handler::FunctionHandler',
       code: lambda.Code.fromAsset('./lambda/base-dotnet/bin/function.zip'),
@@ -111,6 +115,6 @@ export class Base extends cdk.Stack {
     });
     dotnetFunction.addToRolePolicy(defaultDatadogSecretPolicy);
     dotnetFunction.addLayers(extensionLayer);
-    dotnetFunction.addLayers(dotnet8Layer);
+    dotnetFunction.addLayers(dotnetLayer);
   }
 }

--- a/integration-tests/lib/stacks/lmi.ts
+++ b/integration-tests/lib/stacks/lmi.ts
@@ -7,10 +7,14 @@ import {
   defaultDatadogEnvVariables,
   defaultDatadogSecretPolicy,
   getExtensionLayer,
-  getNode24Layer,
-  getPython313Layer,
-  getJava21Layer,
-  getDotnet8Layer
+  getDefaultNodeLayer,
+  getDefaultPythonLayer,
+  getDefaultJavaLayer,
+  getDefaultDotnetLayer,
+  defaultNodeRuntime,
+  defaultPythonRuntime,
+  defaultJavaRuntime,
+  defaultDotnetRuntime
 } from '../util';
 
 export class LambdaManagedInstancesStack extends cdk.Stack {
@@ -18,11 +22,14 @@ export class LambdaManagedInstancesStack extends cdk.Stack {
     super(scope, id, props);
 
     const extensionLayer = getExtensionLayer(this);
-    const node24Layer = getNode24Layer(this);
+    const nodeLayer = getDefaultNodeLayer(this);
+    const pythonLayer = getDefaultPythonLayer(this);
+    const javaLayer = getDefaultJavaLayer(this);
+    const dotnetLayer = getDefaultDotnetLayer(this);
 
     const nodeFunctionName = `${id}-node-lambda`;
     const nodeFunction = new lambda.Function(this, nodeFunctionName, {
-      runtime: lambda.Runtime.NODEJS_24_X,
+      runtime: defaultNodeRuntime,
       architecture: lambda.Architecture.ARM_64,
       handler: '/opt/nodejs/node_modules/datadog-lambda-js/handler.handler',
       code: lambda.Code.fromAsset('./lambda/lmi-node'),
@@ -40,7 +47,7 @@ export class LambdaManagedInstancesStack extends cdk.Stack {
     setCapacityProvider(nodeFunction);
     nodeFunction.addToRolePolicy(defaultDatadogSecretPolicy);
     nodeFunction.addLayers(extensionLayer);
-    nodeFunction.addLayers(node24Layer);
+    nodeFunction.addLayers(nodeLayer);
     const nodeAlias = new lambda.Alias(this, `${nodeFunctionName}-alias`, {
       aliasName: 'lmi',
       version: nodeFunction.currentVersion,
@@ -48,7 +55,7 @@ export class LambdaManagedInstancesStack extends cdk.Stack {
 
     const pythonFunctionName = `${id}-python-lambda`;
     const pythonFunction = new lambda.Function(this, pythonFunctionName, {
-      runtime: lambda.Runtime.PYTHON_3_13,
+      runtime: defaultPythonRuntime,
       architecture: lambda.Architecture.ARM_64,
       handler: 'datadog_lambda.handler.handler',
       code: lambda.Code.fromAsset('./lambda/lmi-python'),
@@ -67,7 +74,7 @@ export class LambdaManagedInstancesStack extends cdk.Stack {
     setCapacityProvider(pythonFunction);
     pythonFunction.addToRolePolicy(defaultDatadogSecretPolicy);
     pythonFunction.addLayers(extensionLayer);
-    pythonFunction.addLayers(getPython313Layer(this));
+    pythonFunction.addLayers(pythonLayer);
     const pythonAlias = new lambda.Alias(this, `${pythonFunctionName}-alias`, {
       aliasName: 'lmi',
       version: pythonFunction.currentVersion,
@@ -75,7 +82,7 @@ export class LambdaManagedInstancesStack extends cdk.Stack {
 
     const javaFunctionName = `${id}-java-lambda`;
     const javaFunction = new lambda.Function(this, javaFunctionName, {
-      runtime: lambda.Runtime.JAVA_21,
+      runtime: defaultJavaRuntime,
       architecture: lambda.Architecture.ARM_64,
       handler: 'example.Handler::handleRequest',
       code: lambda.Code.fromAsset('./lambda/lmi-java/target/function.jar'),
@@ -93,7 +100,7 @@ export class LambdaManagedInstancesStack extends cdk.Stack {
     setCapacityProvider(javaFunction);
     javaFunction.addToRolePolicy(defaultDatadogSecretPolicy);
     javaFunction.addLayers(extensionLayer);
-    javaFunction.addLayers(getJava21Layer(this));
+    javaFunction.addLayers(javaLayer);
     const javaAlias = new lambda.Alias(this, `${javaFunctionName}-alias`, {
       aliasName: 'lmi',
       version: javaFunction.currentVersion,
@@ -101,7 +108,7 @@ export class LambdaManagedInstancesStack extends cdk.Stack {
 
     const dotnetFunctionName = `${id}-dotnet-lambda`;
     const dotnetFunction = new lambda.Function(this, dotnetFunctionName, {
-      runtime: lambda.Runtime.DOTNET_8,
+      runtime: defaultDotnetRuntime,
       architecture: lambda.Architecture.ARM_64,
       handler: 'Function::Function.Handler::FunctionHandler',
       code: lambda.Code.fromAsset('./lambda/lmi-dotnet/bin/function.zip'),
@@ -119,7 +126,7 @@ export class LambdaManagedInstancesStack extends cdk.Stack {
     setCapacityProvider(dotnetFunction);
     dotnetFunction.addToRolePolicy(defaultDatadogSecretPolicy);
     dotnetFunction.addLayers(extensionLayer);
-    dotnetFunction.addLayers(getDotnet8Layer(this));
+    dotnetFunction.addLayers(dotnetLayer);
     const dotnetAlias = new lambda.Alias(this, `${dotnetFunctionName}-alias`, {
       aliasName: 'lmi',
       version: dotnetFunction.currentVersion,

--- a/integration-tests/lib/stacks/otlp.ts
+++ b/integration-tests/lib/stacks/otlp.ts
@@ -5,7 +5,11 @@ import {
   createLogGroup,
   defaultDatadogEnvVariables,
   defaultDatadogSecretPolicy,
-  getExtensionLayer
+  getExtensionLayer,
+  defaultNodeRuntime,
+  defaultPythonRuntime,
+  defaultJavaRuntime,
+  defaultDotnetRuntime
 } from '../util';
 
 export class Otlp extends cdk.Stack {
@@ -16,7 +20,7 @@ export class Otlp extends cdk.Stack {
 
     const nodeFunctionName = `${id}-node-lambda`;
     const nodeFunction = new lambda.Function(this, nodeFunctionName, {
-      runtime: lambda.Runtime.NODEJS_20_X,
+      runtime: defaultNodeRuntime,
       architecture: lambda.Architecture.ARM_64,
       handler: 'index.handler',
       code: lambda.Code.fromAsset('./lambda/otlp-node'),
@@ -38,7 +42,7 @@ export class Otlp extends cdk.Stack {
 
     const validationFunctionName = `${id}-response-validation-lambda`;
     const validationFunction = new lambda.Function(this, validationFunctionName, {
-      runtime: lambda.Runtime.NODEJS_20_X,
+      runtime: defaultNodeRuntime,
       architecture: lambda.Architecture.ARM_64,
       handler: 'response-validation.handler',
       code: lambda.Code.fromAsset('./lambda/otlp-node'),
@@ -58,7 +62,7 @@ export class Otlp extends cdk.Stack {
 
     const pythonFunctionName = `${id}-python-lambda`;
     const pythonFunction = new lambda.Function(this, pythonFunctionName, {
-      runtime: lambda.Runtime.PYTHON_3_12,
+      runtime: defaultPythonRuntime,
       architecture: lambda.Architecture.ARM_64,
       handler: 'lambda_function.handler',
       code: lambda.Code.fromAsset('./lambda/otlp-python/package'),
@@ -80,7 +84,7 @@ export class Otlp extends cdk.Stack {
 
     const javaFunctionName = `${id}-java-lambda`;
     const javaFunction = new lambda.Function(this, javaFunctionName, {
-      runtime: lambda.Runtime.JAVA_21,
+      runtime: defaultJavaRuntime,
       architecture: lambda.Architecture.ARM_64,
       handler: 'example.Handler::handleRequest',
       code: lambda.Code.fromAsset('./lambda/otlp-java/target/function.jar'),
@@ -102,7 +106,7 @@ export class Otlp extends cdk.Stack {
 
     const dotnetFunctionName = `${id}-dotnet-lambda`;
     const dotnetFunction = new lambda.Function(this, dotnetFunctionName, {
-      runtime: lambda.Runtime.DOTNET_8,
+      runtime: defaultDotnetRuntime,
       architecture: lambda.Architecture.ARM_64,
       handler: 'Function::Function.Handler::FunctionHandler',
       code: lambda.Code.fromAsset('./lambda/otlp-dotnet/bin/function.zip'),

--- a/integration-tests/lib/stacks/snapstart.ts
+++ b/integration-tests/lib/stacks/snapstart.ts
@@ -6,9 +6,12 @@ import {
   defaultDatadogEnvVariables,
   defaultDatadogSecretPolicy,
   getExtensionLayer,
-  getPython313Layer,
-  getJava21Layer,
-  getDotnet8Layer
+  getDefaultPythonLayer,
+  getDefaultJavaLayer,
+  getDefaultDotnetLayer,
+  defaultPythonRuntime,
+  defaultJavaRuntime,
+  defaultDotnetRuntime
 } from '../util';
 
 export class Snapstart extends cdk.Stack {
@@ -16,13 +19,13 @@ export class Snapstart extends cdk.Stack {
     super(scope, id, props);
 
     const extensionLayer = getExtensionLayer(this);
-    const python313Layer = getPython313Layer(this);
-    const java21Layer = getJava21Layer(this);
-    const dotnet8Layer = getDotnet8Layer(this);
+    const pythonLayer = getDefaultPythonLayer(this);
+    const javaLayer = getDefaultJavaLayer(this);
+    const dotnetLayer = getDefaultDotnetLayer(this);
 
     const javaFunctionName = `${id}-java-lambda`;
     const javaFunction = new lambda.Function(this, javaFunctionName, {
-      runtime: lambda.Runtime.JAVA_21,
+      runtime: defaultJavaRuntime,
       architecture: lambda.Architecture.ARM_64,
       handler: 'example.SnapstartHandler::handleRequest',
       code: lambda.Code.fromAsset('./lambda/snapstart-java/target/function.jar'),
@@ -40,7 +43,7 @@ export class Snapstart extends cdk.Stack {
     });
     javaFunction.addToRolePolicy(defaultDatadogSecretPolicy);
     javaFunction.addLayers(extensionLayer);
-    javaFunction.addLayers(java21Layer);
+    javaFunction.addLayers(javaLayer);
     const javaVersion = javaFunction.currentVersion;
     const javaAlias = new lambda.Alias(this, `${javaFunctionName}-snapstart-alias`, {
       aliasName: 'snapstart',
@@ -49,7 +52,7 @@ export class Snapstart extends cdk.Stack {
 
     const pythonFunctionName = `${id}-python-lambda`;
     const pythonFunction = new lambda.Function(this, pythonFunctionName, {
-      runtime: lambda.Runtime.PYTHON_3_13,
+      runtime: defaultPythonRuntime,
       architecture: lambda.Architecture.ARM_64,
       handler: 'datadog_lambda.handler.handler',
       code: lambda.Code.fromAsset('./lambda/snapstart-python'),
@@ -70,7 +73,7 @@ export class Snapstart extends cdk.Stack {
     });
     pythonFunction.addToRolePolicy(defaultDatadogSecretPolicy);
     pythonFunction.addLayers(extensionLayer);
-    pythonFunction.addLayers(python313Layer);
+    pythonFunction.addLayers(pythonLayer);
     const pythonVersion = pythonFunction.currentVersion;
     const pythonAlias = new lambda.Alias(this, `${pythonFunctionName}-snapstart-alias`, {
       aliasName: 'snapstart',
@@ -79,7 +82,7 @@ export class Snapstart extends cdk.Stack {
 
     const dotnetFunctionName = `${id}-dotnet-lambda`;
     const dotnetFunction = new lambda.Function(this, dotnetFunctionName, {
-      runtime: lambda.Runtime.DOTNET_8,
+      runtime: defaultDotnetRuntime,
       architecture: lambda.Architecture.ARM_64,
       handler: 'Function::Function.SnapstartHandler::FunctionHandler',
       code: lambda.Code.fromAsset('./lambda/snapstart-dotnet/bin/function.zip'),
@@ -96,7 +99,7 @@ export class Snapstart extends cdk.Stack {
     });
     dotnetFunction.addToRolePolicy(defaultDatadogSecretPolicy);
     dotnetFunction.addLayers(extensionLayer);
-    dotnetFunction.addLayers(dotnet8Layer);
+    dotnetFunction.addLayers(dotnetLayer);
     const dotnetVersion = dotnetFunction.currentVersion;
     const dotnetAlias = new lambda.Alias(this, `${dotnetFunctionName}-snapstart-alias`, {
       aliasName: 'snapstart',

--- a/integration-tests/lib/util.ts
+++ b/integration-tests/lib/util.ts
@@ -9,12 +9,15 @@ import {ACCOUNT, REGION} from "../config";
 export const datadogSecretArn = process.env.DATADOG_API_SECRET_ARN!;
 export const extensionLayerArn = process.env.EXTENSION_LAYER_ARN!;
 
+export const defaultNodeRuntime = lambda.Runtime.NODEJS_24_X;
+export const defaultPythonRuntime = lambda.Runtime.PYTHON_3_13;
+export const defaultJavaRuntime = lambda.Runtime.JAVA_21;
+export const defaultDotnetRuntime = lambda.Runtime.DOTNET_8;
 
-export const node20LayerArn = 'arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node20-x:130';
-export const node24LayerArn = 'arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node24-x:132';
-export const python313LayerArn = 'arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python313-ARM:117';
-export const java21LayerArn = 'arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-java:25';
-export const dotnet8LayerArn = 'arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-dotnet-ARM:23';
+export const defaultNodeLayerArn = 'arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node24-x:132';
+export const defaultPythonLayerArn = 'arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python313-ARM:117';
+export const defaultJavaLayerArn = 'arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-java:25';
+export const defaultDotnetLayerArn = 'arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-dotnet-ARM:23';
 
 export const defaultDatadogEnvVariables = {
     DD_API_KEY_SECRET_ARN: datadogSecretArn,
@@ -52,43 +55,35 @@ export const getExtensionLayer = (scope: Construct) => {
   );
 };
 
-export const getNode20Layer = (scope: Construct) => {
+export const getDefaultNodeLayer = (scope: Construct) => {
   return LayerVersion.fromLayerVersionArn(
     scope,
-    'DatadogNode20Layer',
-    node20LayerArn
+    'DatadogNodeLayer',
+    defaultNodeLayerArn
   );
 };
 
-export const getNode24Layer = (scope: Construct) => {
+export const getDefaultPythonLayer = (scope: Construct) => {
   return LayerVersion.fromLayerVersionArn(
     scope,
-    'DatadogNode24Layer',
-    node24LayerArn
+    'DatadogPythonLayer',
+    defaultPythonLayerArn
   );
 };
 
-export const getPython313Layer = (scope: Construct) => {
+export const getDefaultJavaLayer = (scope: Construct) => {
   return LayerVersion.fromLayerVersionArn(
     scope,
-    'DatadogPython313Layer',
-    python313LayerArn
+    'DatadogJavaLayer',
+    defaultJavaLayerArn
   );
 };
 
-export const getJava21Layer = (scope: Construct) => {
+export const getDefaultDotnetLayer = (scope: Construct) => {
   return LayerVersion.fromLayerVersionArn(
     scope,
-    'DatadogJava21Layer',
-    java21LayerArn
-  );
-};
-
-export const getDotnet8Layer = (scope: Construct) => {
-  return LayerVersion.fromLayerVersionArn(
-    scope,
-    'DatadogDotnet8Layer',
-    dotnet8LayerArn
+    'DatadogDotnetLayer',
+    defaultDotnetLayerArn
   );
 };
 
@@ -102,7 +97,7 @@ export function setCapacityProvider(lambdaFunction: lambda.Function) {
         }
     });
     cfnFunction.addPropertyOverride('FunctionScalingConfig', {
-        MinExecutionEnvironments: 3,
-        MaxExecutionEnvironments: 3
+        MinExecutionEnvironments: 1,
+        MaxExecutionEnvironments: 1
     });
 }

--- a/integration-tests/scripts/local_deploy.sh
+++ b/integration-tests/scripts/local_deploy.sh
@@ -21,7 +21,7 @@ if [ -n "$USERNAME" ]; then
 fi
 
 echo "Getting latest version of Datadog-Extension-ARM-$IDENTIFIER layer..."
-export EXTENSION_LAYER_ARN=$(aws-vault exec sso-serverless-sandbox-account-admin -- aws lambda list-layer-versions --layer-name Datadog-Extension-ARM-$IDENTIFIER --query 'LayerVersions[0].LayerVersionArn' --output text)
+export EXTENSION_LAYER_ARN=$(aws-vault exec sso-serverless-sandbox-account-admin -- aws lambda list-layer-versions --layer-name Datadog-Extension-ARM-$IDENTIFIER --query 'LayerVersions[0].LayerVersionArn' --output text | head -n 1)
 
 if [ -z "$EXTENSION_LAYER_ARN" ]; then
   echo "Error: Failed to retrieve extension layer ARN"


### PR DESCRIPTION
## Overview
- Refactoring integ tests so we have a default runtime. For our use case, and at least for now, we don't need to test against multiple runtime version. For instance, Node24 is fine and we don't need to test against Node22, Node20, Node18, etc.
- Fix the local_deploy script. When there are a lot of versions for a lambda layer, it is pulling 2 instead of just 1.
- Update LMI to just deploy 1 instance instead of 3.
- No functional changes.