### PR TITLE
[SVLS-7945] feat: Support TLS certificate for logs/proxy flusher

### DIFF
--- a/bottlecap/src/http.rs
+++ b/bottlecap/src/http.rs
@@ -90,12 +90,10 @@ fn load_custom_cert(cert_path: &str) -> Result<Vec<reqwest::Certificate>, Box<dy
     }
 
     // Convert all certificates found in the file
-    let mut reqwest_certs = Vec::new();
-    for cert in certs {
-        reqwest_certs.push(reqwest::Certificate::from_der(&cert)?);
-    }
-
-    Ok(reqwest_certs)
+    certs
+        .into_iter()
+        .map(|cert| reqwest::Certificate::from_der(&cert).map_err(Into::into))
+        .collect()
 }
 
 pub async fn handler_not_found() -> Response {


### PR DESCRIPTION
## Problem
A customer reported that their Lambda is behind a proxy, and the Rust-based extension encounters an error when sending logs and metrics to Datadog via the proxy.

A previous PR https://github.com/DataDog/datadog-lambda-extension/pull/961 fixed this for traces and stats, but not for other things because the customer and I didn't see any error with them at that time.

## This PR

Applies the env var `DD_TLS_CERT_FILE` to logs flusher and proxy flusher as well.
Example: `DD_TLS_CERT_FILE=/opt/ca-cert.pem`, so the when the extension flushes logs or proxied data to Datadog, the HTTP client created can load and use this cert, and connect the proxy properly.

## Testing
1. Create a Lambda in a VPC with a proxy EC2 instance.
2. Connect to the proxy instance. With the help of ChatGPT, set up a custom-build nginx with `ngx_http_proxy_connect_module`
3. Save the CA certificate from the proxy server to local machine
4. In the CDK stack, add a layer to the Lambda, which includes the CA certificate `ca-cert.pem`
5. Set env vars:
    - `DD_TLS_CERT_FILE=/opt/ca-cert.pem`
    - `DD_PROXY_HTTPS=http://10.0.0.30:3128`, where `10.0.0.30` is the private IP of the proxy EC2 instance
    - `DD_LOG_LEVEL=debug`
6. Invoke the Lambda

## Result
**Before:**
Log flushing failed:
> DD_EXTENSION | ERROR | LOGS | Failed to send request after 97 ms and 3 attempts: reqwest::Error { kind: Request, url: "https://http-intake.logs.datadoghq.com/api/v2/logs", source: hyper_util::client::legacy::Error(Connect, ConnectFailed(Custom { kind: Other, error: Custom { kind: InvalidData, error: InvalidCertificate(UnknownIssuer) } })) }

**After:**
No such error

## Next steps
Do the same thing for dogstatsd metric flusher. Metric flusher is in a separate repo https://github.com/DataDog/serverless-components, so let's create separate PRs for that change.

## Notes
Customer report issue: https://github.com/DataDog/datadog-lambda-extension/issues/919