### PR TITLE
[SVLS-7945] chore: Upgrade serverless-components and saluki

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -727,7 +727,7 @@ dependencies = [
 [[package]]
 name = "datadog-fips"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=502f005c56b8d51dee95424a9c1404df46e2aae4#502f005c56b8d51dee95424a9c1404df46e2aae4"
+source = "git+https://github.com/DataDog/serverless-components?rev=fd8b7a9bcec2f19b305bb74b7195ca3910538e5b#fd8b7a9bcec2f19b305bb74b7195ca3910538e5b"
 dependencies = [
  "reqwest",
  "rustls",
@@ -738,20 +738,21 @@ dependencies = [
 [[package]]
 name = "datadog-protos"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/saluki/?rev=c89b58e5784b985819baf11f13f7d35876741222#c89b58e5784b985819baf11f13f7d35876741222"
+source = "git+https://github.com/DataDog/saluki/?rev=f863626dbfe3c59bb390985fa6530b0621c2a0a2#f863626dbfe3c59bb390985fa6530b0621c2a0a2"
 dependencies = [
  "bytes",
  "prost",
+ "prost-types",
  "protobuf",
  "protobuf-codegen",
- "tonic",
+ "tonic 0.13.1",
  "tonic-build",
 ]
 
 [[package]]
 name = "ddsketch-agent"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/saluki/?rev=c89b58e5784b985819baf11f13f7d35876741222#c89b58e5784b985819baf11f13f7d35876741222"
+source = "git+https://github.com/DataDog/saluki/?rev=f863626dbfe3c59bb390985fa6530b0621c2a0a2#f863626dbfe3c59bb390985fa6530b0621c2a0a2"
 dependencies = [
  "datadog-protos",
  "float-cmp",
@@ -835,7 +836,7 @@ dependencies = [
 [[package]]
 name = "dogstatsd"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=502f005c56b8d51dee95424a9c1404df46e2aae4#502f005c56b8d51dee95424a9c1404df46e2aae4"
+source = "git+https://github.com/DataDog/serverless-components?rev=fd8b7a9bcec2f19b305bb74b7195ca3910538e5b#fd8b7a9bcec2f19b305bb74b7195ca3910538e5b"
 dependencies = [
  "datadog-fips",
  "datadog-protos",
@@ -2154,7 +2155,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "serde",
- "tonic",
+ "tonic 0.12.3",
  "tracing",
 ]
 
@@ -3609,10 +3610,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic-build"
-version = "0.12.3"
+name = "tonic"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -3630,7 +3652,7 @@ checksum = "0081d8ee0847d01271392a5aebe960a4600f5d4da6c67648a6382a0940f8b367"
 dependencies = [
  "prost",
  "prost-types",
- "tonic",
+ "tonic 0.12.3",
 ]
 
 [[package]]

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -63,16 +63,16 @@ indexmap = {version = "2.11.0", default-features = false}
 # method in favor of our
 # datadog_fips::reqwest_adapter::create_reqwest_client_builder. An example can
 # be found in the clippy.toml file adjacent to this Cargo.toml.
-datadog-protos = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "c89b58e5784b985819baf11f13f7d35876741222"}
-ddsketch-agent = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "c89b58e5784b985819baf11f13f7d35876741222"}
+datadog-protos = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "f863626dbfe3c59bb390985fa6530b0621c2a0a2"}
+ddsketch-agent = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "f863626dbfe3c59bb390985fa6530b0621c2a0a2"}
 libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "73c675b79f81978ee1190be6af0c5abec997e3b0" }
 libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "73c675b79f81978ee1190be6af0c5abec997e3b0"  }
 libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "73c675b79f81978ee1190be6af0c5abec997e3b0" , features = ["mini_agent"] }
 libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog",  rev = "73c675b79f81978ee1190be6af0c5abec997e3b0" }
 libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "73c675b79f81978ee1190be6af0c5abec997e3b0"  }
 libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "73c675b79f81978ee1190be6af0c5abec997e3b0"  }
-dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "502f005c56b8d51dee95424a9c1404df46e2aae4", default-features = false }
-datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "502f005c56b8d51dee95424a9c1404df46e2aae4", default-features = false }
+dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "fd8b7a9bcec2f19b305bb74b7195ca3910538e5b", default-features = false }
+datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "fd8b7a9bcec2f19b305bb74b7195ca3910538e5b", default-features = false }
 libddwaf = { version = "1.28.1", git = "https://github.com/DataDog/libddwaf-rust", rev = "d1534a158d976bd4f747bf9fcc58e0712d2d17fc", default-features = false, features = ["serde"] }
 
 [dev-dependencies]


### PR DESCRIPTION
## Overview
Upgrade the packages that are in the repository `serverless-components` and `saluki`.

## Why
I need to patch my changes from `serverless-components`, but upgrading `serverless-components` requires also upgrading `saluki` from a 2-year-old SHA to a 2-month-old SHA. I think it's better to make this upgrade a separate PR in case anything goes wrong.

## Testing
None.