### PR TITLE
chore: Fix cargo-audit error

### DIFF
--- a/.github/workflows/rs_ci.yml
+++ b/.github/workflows/rs_ci.yml
@@ -171,6 +171,9 @@ jobs:
   cargo-audit:
     name: Audit
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6.0.2


### PR DESCRIPTION
## Overview
The `cargo-audit` job of `Bottlecap (Rust)` CI workflow fails on main.
https://github.com/DataDog/datadog-lambda-extension/actions/runs/20958766328/job/60229985867

This PR fixes it.

## Testing
The check `Bottlecap (Rust) / Audit (pull_request)` is successful for this PR.
https://github.com/DataDog/datadog-lambda-extension/actions/runs/20959299218/job/60231830563