### PR TITLE
[integration-test]Add configurable wait time for OTLP integration tests

### DIFF
--- a/integration-tests/tests/otlp.test.ts
+++ b/integration-tests/tests/otlp.test.ts
@@ -1,4 +1,4 @@
-import { invokeLambdaAndGetDatadogData, LambdaInvocationDatadogData } from './utils/util';
+import { invokeLambdaAndGetDatadogData, LambdaInvocationDatadogData, DATADOG_INDEXING_WAIT_5_MIN_MS } from './utils/util';
 import { getIdentifier } from '../config';
 import { LambdaClient, InvokeCommand } from '@aws-sdk/client-lambda';
 
@@ -16,12 +16,12 @@ describe('OTLP Integration Tests', () => {
 
     console.log('Invoking all OTLP Lambda functions in parallel...');
 
-    // Invoke all Lambdas in parallel
+    // Invoke all Lambdas in parallel (using 5 minute wait for OTLP indexing)
     const invocationResults = await Promise.all([
-      invokeLambdaAndGetDatadogData(functions.node, {}, true),
-      invokeLambdaAndGetDatadogData(functions.python, {}, true),
-      invokeLambdaAndGetDatadogData(functions.java, {}, true),
-      invokeLambdaAndGetDatadogData(functions.dotnet, {}, true),
+      invokeLambdaAndGetDatadogData(functions.node, {}, true, true, DATADOG_INDEXING_WAIT_5_MIN_MS),
+      invokeLambdaAndGetDatadogData(functions.python, {}, true, true, DATADOG_INDEXING_WAIT_5_MIN_MS),
+      invokeLambdaAndGetDatadogData(functions.java, {}, true, true, DATADOG_INDEXING_WAIT_5_MIN_MS),
+      invokeLambdaAndGetDatadogData(functions.dotnet, {}, true, true, DATADOG_INDEXING_WAIT_5_MIN_MS),
     ]);
 
     // Store results

--- a/integration-tests/tests/utils/util.ts
+++ b/integration-tests/tests/utils/util.ts
@@ -1,6 +1,12 @@
 import { DatadogLog, DatadogTrace, getTraces, getLogs } from "./datadog";
 import { invokeLambda } from "./lambda";
 
+// Default wait time for Datadog to index logs and traces after Lambda invocation
+const DEFAULT_DATADOG_INDEXING_WAIT_MS = 60 * 1000; // 60 seconds
+
+// Extended wait time for tests that need more time (e.g., OTLP tests)
+export const DATADOG_INDEXING_WAIT_5_MIN_MS = 5 * 60 * 1000; // 5 minutes
+
 export interface LambdaInvocationDatadogData {
     requestId: string;
     statusCode: number;
@@ -9,11 +15,17 @@ export interface LambdaInvocationDatadogData {
     logs?: DatadogLog[];
 }
 
-export async function invokeLambdaAndGetDatadogData(functionName: string, payload: any = {}, coldStart: boolean = false, useTailLogs: boolean = true): Promise<LambdaInvocationDatadogData> {
+export async function invokeLambdaAndGetDatadogData(
+    functionName: string,
+    payload: any = {},
+    coldStart: boolean = false,
+    useTailLogs: boolean = true,
+    datadogIndexingWaitMs: number = DEFAULT_DATADOG_INDEXING_WAIT_MS
+): Promise<LambdaInvocationDatadogData> {
     const result = await invokeLambda(functionName, payload, coldStart, useTailLogs);
 
-    console.log('Waiting for logs and traces to be indexed in Datadog...');
-    await new Promise(resolve => setTimeout(resolve, 60_000));
+    console.log(`Waiting ${datadogIndexingWaitMs / 1000}s for logs and traces to be indexed in Datadog...`);
+    await new Promise(resolve => setTimeout(resolve, datadogIndexingWaitMs));
 
     // Strip alias suffix (e.g., ":snapstart") for Datadog queries since service name doesn't include it
     const baseFunctionName = functionName.split(':')[0];


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/SVLS-8286

## Overview
We noticed OTLP integration tests were flaky. One speculation was we didn't wait long enough before retrieving the result. 

Hence we made Datadog indexing wait time configurable and use 5-minute wait for OTLP tests (instead of default 60s) to accommodate longer data propagation delays through OTLP collector pipeline.

## Testing 
Local test:
```
npm test -- otlp.test.ts
...
   Waiting 300s for logs and traces to be indexed in Datadog...
...
Test Suites: 1 passed, 1 total
Tests:       13 passed, 13 total
Snapshots:   0 total
Time:        318.945 s
``` 