### PR TITLE
[SVLS-8150] fix(config): ensure logs intake URL is correctly prefixed

### DIFF
--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -217,7 +217,7 @@ impl ConfigBuilder {
         }
 
         // If Logs URL is not set, set it to the default
-        if self.config.logs_config_logs_dd_url.is_empty() {
+        if self.config.logs_config_logs_dd_url.trim().is_empty() {
             self.config.logs_config_logs_dd_url = build_fqdn_logs(self.config.site.clone());
         } else {
             self.config.logs_config_logs_dd_url =


### PR DESCRIPTION
## Overview

Ensures `DD_LOGS_CONFIG_LOGS_DD_URL` is correctly prefixed with `https://`

## Testing 

Manually tested that logs get sent to alternate logs intake