### PR TITLE
chore: bump extension version to 93-next

### DIFF
--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -45,7 +45,7 @@ const FUNCTION_TAGS_KEY: &str = "_dd.tags.function";
 // TODO(astuyve) decide what to do with the version
 const EXTENSION_VERSION_KEY: &str = "dd_extension_version";
 // TODO(duncanista) figure out a better way to not hardcode this
-pub const EXTENSION_VERSION: &str = "92-next";
+pub const EXTENSION_VERSION: &str = "93-next";
 
 const REGION_KEY: &str = "region";
 const ACCOUNT_ID_KEY: &str = "account_id";


### PR DESCRIPTION
## Summary
- Bumps `EXTENSION_VERSION` from `"92-next"` to `"93-next"` in `bottlecap/src/tags/lambda/tags.rs` in preparation for the v93 release

Relates to: https://datadoghq.atlassian.net/browse/SVLS-8605

## Test plan
- [ ] Verify extension version tag is reported as `93-next` in Lambda invocation metadata