### PR TITLE
perf(logger): replace serde_json::json! with zero-allocation write! in logger

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -3785,16 +3785,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3803,14 +3793,11 @@ dependencies = [
  "matchers",
  "once_cell",
  "regex-automata",
- "serde",
- "serde_json",
  "sharded-slab",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -34,7 +34,7 @@ tokio = { version = "1.47", default-features = false, features = ["macros", "rt-
 tokio-util = { version = "0.7", default-features = false }
 tracing = { version = "0.1", default-features = false }
 tracing-core = { version = "0.1", default-features = false }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["std", "registry", "fmt", "env-filter", "tracing-log", "json"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["std", "registry", "fmt", "env-filter", "tracing-log"] }
 hmac = { version = "0.12", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["std"] }

--- a/bottlecap/LICENSE-3rdparty.csv
+++ b/bottlecap/LICENSE-3rdparty.csv
@@ -235,7 +235,6 @@ tracing,https://github.com/tokio-rs/tracing,MIT,"Eliza Weisman <eliza@buoyant.io
 tracing-attributes,https://github.com/tokio-rs/tracing,MIT,"Tokio Contributors <team@tokio.rs>, Eliza Weisman <eliza@buoyant.io>, David Barsky <dbarsky@amazon.com>"
 tracing-core,https://github.com/tokio-rs/tracing,MIT,Tokio Contributors <team@tokio.rs>
 tracing-log,https://github.com/tokio-rs/tracing,MIT,Tokio Contributors <team@tokio.rs>
-tracing-serde,https://github.com/tokio-rs/tracing,MIT,Tokio Contributors <team@tokio.rs>
 tracing-subscriber,https://github.com/tokio-rs/tracing,MIT,"Eliza Weisman <eliza@buoyant.io>, David Barsky <me@davidbarsky.com>, Tokio Contributors <team@tokio.rs>"
 try-lock,https://github.com/seanmonstar/try-lock,MIT,Sean McArthur <sean@seanmonstar.com>
 twoway,https://github.com/bluss/twoway,MIT OR Apache-2.0,bluss


### PR DESCRIPTION
## Summary 
Root cause: commit 3b533a0 introduced `serde_json::json!()` for JSON formatting, adding per-call heap pressure and a new crate dependency that contributes to Lambda init duration regression

JIRA: https://datadoghq.atlassian.net/browse/SVLS-8619

- Replaces `serde_json::json!()` in `logger.rs` with direct `write!`/`writeln!` calls to the tracing `Writer`, eliminating two heap allocations (a `Map` + `Value`) per log call
- Adds a `write_json_escaped` helper that handles all 6 mandatory JSON escape sequences inline (`"`, `\`, `\n`, `\r`, `\t`, U+0000–U+001F)
- Removes the `"json"` feature from `tracing-subscriber`, dropping `tracing-serde` as a transitive dependency and reducing binary size
- The JSON output format is **identical** — no observable behavior change


## Test plan
- unit tests
- self-monitoring tests