### PR TITLE
fix(traces): downgrade handle_proxy body-read failure from ERROR to WARN

### DIFF
--- a/bottlecap/src/traces/trace_agent.rs
+++ b/bottlecap/src/traces/trace_agent.rs
@@ -659,7 +659,7 @@ impl TraceAgent {
         let (parts, body) = match extract_request_body(request).await {
             Ok(r) => r,
             Err(e) => {
-                return error_response(
+                return warn_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     format!("TRACE_AGENT | handle_proxy | Error extracting request body: {e}"),
                 );
@@ -718,6 +718,13 @@ fn handle_reparenting(reparenting_info: &mut VecDeque<ReparentingInfo>, span: &m
 
 fn error_response<E: std::fmt::Display>(status: StatusCode, error: E) -> Response {
     error!("{}", error);
+    (status, error.to_string()).into_response()
+}
+
+/// Like [`error_response`], but logs at WARN level. Use when the failure is caused by an
+/// external event (e.g. client disconnected) rather than a bug in the extension itself.
+fn warn_response<E: std::fmt::Display>(status: StatusCode, error: E) -> Response {
+    warn!("{}", error);
     (status, error.to_string()).into_response()
 }
 


### PR DESCRIPTION
JIRA: https://datadoghq.atlassian.net/browse/SLES-2729
Issue: https://github.com/DataDog/datadog-lambda-extension/issues/1000

**Overview**
When AWS Lambda freezes or terminates a function instance, the OS immediately closes all TCP sockets. The extension's proxy HTTP handler (handle_proxy) was mid-read on the request body — this read fails with error reading a body from connection and was logged at ERROR level, generating noise with no actionable signal.

This is expected Lambda lifecycle behaviour: the Lambda function completed successfully and nothing in the extension is broken. The ERROR level implies an extension fault, which misleads operators.

**Change**
Introduce a warn_response helper (mirroring the existing error_response / success_response trio) and use it for body-read failures in handle_proxy. The log message content is unchanged — only the severity is downgraded from ERROR to WARN.

Testing
- unit tests