### PR TITLE
feat(tests): add span.kind=server assertion to integration tests

### DIFF
--- a/integration-tests/tests/base.test.ts
+++ b/integration-tests/tests/base.test.ts
@@ -56,7 +56,10 @@ describe('Base Integration Tests', () => {
         attributes: {
           operation_name: 'aws.lambda',
           custom: {
-            cold_start: 'true'
+            cold_start: 'true',
+            span: {
+              kind: 'server'
+            }
           }
         }
       });
@@ -109,7 +112,10 @@ describe('Base Integration Tests', () => {
         attributes: {
           operation_name: 'aws.lambda',
           custom: {
-            cold_start: 'true'
+            cold_start: 'true',
+            span: {
+              kind: 'server'
+            }
           }
         }
       });
@@ -166,7 +172,10 @@ describe('Base Integration Tests', () => {
         attributes: {
           operation_name: 'aws.lambda',
           custom: {
-            cold_start: 'true'
+            cold_start: 'true',
+            span: {
+              kind: 'server'
+            }
           }
         }
       });
@@ -208,7 +217,10 @@ describe('Base Integration Tests', () => {
         attributes: {
           operation_name: 'aws.lambda',
           custom: {
-            cold_start: 'true'
+            cold_start: 'true',
+            span: {
+              kind: 'server'
+            }
           }
         }
       });


### PR DESCRIPTION
## Summary
- Adds integration test assertions to verify `span.kind=server` is present on `aws.lambda` spans
- Tests all four runtimes: Node.js, Python, Java, and .NET

## Changes
- Updated `base.test.ts` to assert `custom.span.kind === 'server'` for all runtime tests

## Related PRs
- DataDog/datadog-lambda-python: Add span.kind=server to aws.lambda spans
- DataDog/datadog-lambda-js: Add span.kind=server to aws.lambda spans

## Test plan
- [x] All span.kind=server assertions pass for Node.js, Python, Java, and .NET runtimes
- [x] Tests run against deployed Lambda functions in sandbox environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)