### PR TITLE
fix(crypto): switch to ring for non-FIPS builds, bump libdatadog

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -468,6 +468,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bottlecap"
 version = "0.1.0"
 dependencies = [
@@ -498,12 +504,12 @@ dependencies = [
  "indexmap",
  "itertools 0.14.0",
  "lazy_static",
- "libdd-common 1.1.0",
- "libdd-trace-normalization 1.0.0",
+ "libdd-common 3.0.1",
+ "libdd-trace-normalization 1.0.3",
  "libdd-trace-obfuscation",
- "libdd-trace-protobuf 1.0.0",
- "libdd-trace-stats 1.0.0",
- "libdd-trace-utils 1.0.0",
+ "libdd-trace-protobuf 3.0.0",
+ "libdd-trace-stats 1.0.4",
+ "libdd-trace-utils 3.0.0",
  "libddwaf",
  "log",
  "mime",
@@ -1065,6 +1071,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
 ]
 
 [[package]]
@@ -1855,8 +1872,39 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libdd-common"
-version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09#c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e5593b91f61eee38cddc9fdcbc99c9fad697b5d925e226bd500d86b4295380b"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "cc",
+ "const_format",
+ "futures",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "libc",
+ "nix 0.29.0",
+ "pin-project",
+ "regex",
+ "serde",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "tokio",
+ "tower-service",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "libdd-common"
+version = "3.0.1"
+source = "git+https://github.com/DataDog/libdatadog?rev=13b8202371d99753c0f84d20e2245a3cef917ddf#13b8202371d99753c0f84d20e2245a3cef917ddf"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1888,37 +1936,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libdd-common"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e5593b91f61eee38cddc9fdcbc99c9fad697b5d925e226bd500d86b4295380b"
-dependencies = [
- "anyhow",
- "bytes",
- "cc",
- "const_format",
- "futures",
- "futures-core",
- "futures-util",
- "hex",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.8.1",
- "hyper-util",
- "libc",
- "nix 0.29.0",
- "pin-project",
- "regex",
- "serde",
- "static_assertions",
- "thiserror 1.0.69",
- "tokio",
- "tower-service",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "libdd-data-pipeline"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1931,7 +1948,7 @@ dependencies = [
  "http 1.4.0",
  "http-body-util",
  "libdd-common 2.0.1",
- "libdd-ddsketch 1.0.1",
+ "libdd-ddsketch 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-dogstatsd-client",
  "libdd-telemetry",
  "libdd-tinybytes 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1950,8 +1967,9 @@ dependencies = [
 
 [[package]]
 name = "libdd-ddsketch"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09#c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b31b2435e2e8eaba0e35a96df3e1407b68f8ef76055383ceb2ba5a09e5a1bb5"
 dependencies = [
  "prost 0.14.3",
 ]
@@ -1959,8 +1977,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b31b2435e2e8eaba0e35a96df3e1407b68f8ef76055383ceb2ba5a09e5a1bb5"
+source = "git+https://github.com/DataDog/libdatadog?rev=13b8202371d99753c0f84d20e2245a3cef917ddf#13b8202371d99753c0f84d20e2245a3cef917ddf"
 dependencies = [
  "prost 0.14.3",
 ]
@@ -1993,7 +2010,7 @@ dependencies = [
  "http-body-util",
  "libc",
  "libdd-common 2.0.1",
- "libdd-ddsketch 1.0.1",
+ "libdd-ddsketch 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_json",
  "sys-info",
@@ -2016,18 +2033,9 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09#c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09"
+source = "git+https://github.com/DataDog/libdatadog?rev=13b8202371d99753c0f84d20e2245a3cef917ddf#13b8202371d99753c0f84d20e2245a3cef917ddf"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "libdd-trace-normalization"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09#c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09"
-dependencies = [
- "anyhow",
- "libdd-trace-protobuf 1.0.0",
 ]
 
 [[package]]
@@ -2041,30 +2049,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "libdd-trace-obfuscation"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09#c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09"
+name = "libdd-trace-normalization"
+version = "1.0.3"
+source = "git+https://github.com/DataDog/libdatadog?rev=13b8202371d99753c0f84d20e2245a3cef917ddf#13b8202371d99753c0f84d20e2245a3cef917ddf"
 dependencies = [
  "anyhow",
- "libdd-common 1.1.0",
- "libdd-trace-protobuf 1.0.0",
- "libdd-trace-utils 1.0.0",
+ "libdd-trace-protobuf 3.0.0",
+]
+
+[[package]]
+name = "libdd-trace-obfuscation"
+version = "1.0.1"
+source = "git+https://github.com/DataDog/libdatadog?rev=13b8202371d99753c0f84d20e2245a3cef917ddf#13b8202371d99753c0f84d20e2245a3cef917ddf"
+dependencies = [
+ "anyhow",
+ "fluent-uri",
+ "libdd-common 3.0.1",
+ "libdd-trace-protobuf 3.0.0",
+ "libdd-trace-utils 3.0.0",
  "log",
  "percent-encoding",
  "regex",
  "serde",
  "serde_json",
- "url",
-]
-
-[[package]]
-name = "libdd-trace-protobuf"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09#c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09"
-dependencies = [
- "prost 0.14.3",
- "serde",
- "serde_bytes",
 ]
 
 [[package]]
@@ -2079,14 +2086,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "libdd-trace-stats"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09#c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09"
+name = "libdd-trace-protobuf"
+version = "3.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=13b8202371d99753c0f84d20e2245a3cef917ddf#13b8202371d99753c0f84d20e2245a3cef917ddf"
 dependencies = [
- "hashbrown 0.15.5",
- "libdd-ddsketch 1.0.0",
- "libdd-trace-protobuf 1.0.0",
- "libdd-trace-utils 1.0.0",
+ "prost 0.14.3",
+ "serde",
+ "serde_bytes",
 ]
 
 [[package]]
@@ -2096,38 +2102,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea447dc8a5d84c6b5eb6ea877c4fea4149fd29f6b45fcfc5cfd7edf82a18e056"
 dependencies = [
  "hashbrown 0.15.5",
- "libdd-ddsketch 1.0.1",
+ "libdd-ddsketch 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-trace-protobuf 2.0.0",
  "libdd-trace-utils 2.0.2",
 ]
 
 [[package]]
-name = "libdd-trace-utils"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09#c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09"
+name = "libdd-trace-stats"
+version = "1.0.4"
+source = "git+https://github.com/DataDog/libdatadog?rev=13b8202371d99753c0f84d20e2245a3cef917ddf#13b8202371d99753c0f84d20e2245a3cef917ddf"
 dependencies = [
- "anyhow",
- "bytes",
- "flate2",
- "futures",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "indexmap",
- "libdd-common 1.1.0",
- "libdd-tinybytes 1.1.0 (git+https://github.com/DataDog/libdatadog?rev=c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09)",
- "libdd-trace-normalization 1.0.0",
- "libdd-trace-protobuf 1.0.0",
- "prost 0.14.3",
- "rand 0.8.5",
- "rmp",
- "rmp-serde",
- "rmpv",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "zstd",
+ "hashbrown 0.15.5",
+ "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=13b8202371d99753c0f84d20e2245a3cef917ddf)",
+ "libdd-trace-protobuf 3.0.0",
+ "libdd-trace-utils 3.0.0",
 ]
 
 [[package]]
@@ -2156,6 +2144,36 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "libdd-trace-utils"
+version = "3.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=13b8202371d99753c0f84d20e2245a3cef917ddf#13b8202371d99753c0f84d20e2245a3cef917ddf"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bytes",
+ "flate2",
+ "futures",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "indexmap",
+ "libdd-common 3.0.1",
+ "libdd-tinybytes 1.1.0 (git+https://github.com/DataDog/libdatadog?rev=13b8202371d99753c0f84d20e2245a3cef917ddf)",
+ "libdd-trace-normalization 1.0.3",
+ "libdd-trace-protobuf 3.0.0",
+ "prost 0.14.3",
+ "rand 0.8.5",
+ "rmp",
+ "rmp-serde",
+ "rmpv",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "zstd",
 ]
 
 [[package]]
@@ -3059,6 +3077,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3457,6 +3495,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -43,9 +43,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "async-signal"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
 dependencies = [
  "async-io",
  "async-lock",
@@ -273,9 +273,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-fips-sys"
-version = "0.13.13"
+version = "0.13.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bce4948d2520386c6d92a6ea2d472300257702242e5a1d01d6add52bd2e7c1"
+checksum = "d3d619165468401dec3caa3366ebffbcb83f2f31883e5b3932f8e2dec2ddc568"
 dependencies = [
  "bindgen",
  "cc",
@@ -298,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -321,7 +321,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -497,19 +497,19 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "httpmock",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-http-proxy",
  "hyper-rustls",
  "hyper-util",
  "indexmap",
  "itertools 0.14.0",
  "lazy_static",
- "libdd-common 3.0.1",
- "libdd-trace-normalization 1.0.3",
+ "libdd-common 3.0.2",
+ "libdd-trace-normalization 2.0.0",
  "libdd-trace-obfuscation",
- "libdd-trace-protobuf 3.0.0",
- "libdd-trace-stats 1.0.4",
- "libdd-trace-utils 3.0.0",
+ "libdd-trace-protobuf 3.0.1",
+ "libdd-trace-stats 2.0.0",
+ "libdd-trace-utils 3.0.1",
  "libddwaf",
  "log",
  "mime",
@@ -596,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -795,7 +795,7 @@ dependencies = [
  "foldhash 0.1.5",
  "hashbrown 0.15.5",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "libdd-common 2.0.1",
  "libdd-data-pipeline",
@@ -1005,9 +1005,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "figment"
@@ -1337,6 +1337,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "headers"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1516,9 +1522,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1531,7 +1537,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1547,7 +1552,7 @@ dependencies = [
  "futures-util",
  "headers",
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
@@ -1564,7 +1569,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
@@ -1581,7 +1586,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1600,7 +1605,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -1613,12 +1618,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1626,9 +1632,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1639,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1653,15 +1659,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1673,15 +1679,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1721,12 +1727,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1745,9 +1751,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -1798,10 +1804,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1866,9 +1874,31 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libdd-capabilities"
+version = "0.1.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=487fccca4910bf7bd3cfa7ed586e1fc5879ca180#487fccca4910bf7bd3cfa7ed586e1fc5879ca180"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "http 1.4.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "libdd-capabilities-impl"
+version = "0.1.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=487fccca4910bf7bd3cfa7ed586e1fc5879ca180#487fccca4910bf7bd3cfa7ed586e1fc5879ca180"
+dependencies = [
+ "bytes",
+ "http 1.4.0",
+ "libdd-capabilities",
+ "libdd-common 3.0.2",
+]
 
 [[package]]
 name = "libdd-common"
@@ -1887,7 +1917,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "libc",
  "nix 0.29.0",
@@ -1903,8 +1933,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-common"
-version = "3.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=13b8202371d99753c0f84d20e2245a3cef917ddf#13b8202371d99753c0f84d20e2245a3cef917ddf"
+version = "3.0.2"
+source = "git+https://github.com/DataDog/libdatadog?rev=487fccca4910bf7bd3cfa7ed586e1fc5879ca180#487fccca4910bf7bd3cfa7ed586e1fc5879ca180"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1917,10 +1947,11 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-rustls",
  "hyper-util",
  "libc",
+ "libdd-capabilities",
  "nix 0.29.0",
  "pin-project",
  "regex",
@@ -1977,7 +2008,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=13b8202371d99753c0f84d20e2245a3cef917ddf#13b8202371d99753c0f84d20e2245a3cef917ddf"
+source = "git+https://github.com/DataDog/libdatadog?rev=487fccca4910bf7bd3cfa7ed586e1fc5879ca180#487fccca4910bf7bd3cfa7ed586e1fc5879ca180"
 dependencies = [
  "prost 0.14.3",
 ]
@@ -2033,7 +2064,7 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=13b8202371d99753c0f84d20e2245a3cef917ddf#13b8202371d99753c0f84d20e2245a3cef917ddf"
+source = "git+https://github.com/DataDog/libdatadog?rev=487fccca4910bf7bd3cfa7ed586e1fc5879ca180#487fccca4910bf7bd3cfa7ed586e1fc5879ca180"
 dependencies = [
  "serde",
 ]
@@ -2050,23 +2081,23 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-normalization"
-version = "1.0.3"
-source = "git+https://github.com/DataDog/libdatadog?rev=13b8202371d99753c0f84d20e2245a3cef917ddf#13b8202371d99753c0f84d20e2245a3cef917ddf"
+version = "2.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=487fccca4910bf7bd3cfa7ed586e1fc5879ca180#487fccca4910bf7bd3cfa7ed586e1fc5879ca180"
 dependencies = [
  "anyhow",
- "libdd-trace-protobuf 3.0.0",
+ "libdd-trace-protobuf 3.0.1",
 ]
 
 [[package]]
 name = "libdd-trace-obfuscation"
-version = "1.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=13b8202371d99753c0f84d20e2245a3cef917ddf#13b8202371d99753c0f84d20e2245a3cef917ddf"
+version = "2.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=487fccca4910bf7bd3cfa7ed586e1fc5879ca180#487fccca4910bf7bd3cfa7ed586e1fc5879ca180"
 dependencies = [
  "anyhow",
  "fluent-uri",
- "libdd-common 3.0.1",
- "libdd-trace-protobuf 3.0.0",
- "libdd-trace-utils 3.0.0",
+ "libdd-common 3.0.2",
+ "libdd-trace-protobuf 3.0.1",
+ "libdd-trace-utils 3.0.1",
  "log",
  "percent-encoding",
  "regex",
@@ -2087,8 +2118,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-protobuf"
-version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=13b8202371d99753c0f84d20e2245a3cef917ddf#13b8202371d99753c0f84d20e2245a3cef917ddf"
+version = "3.0.1"
+source = "git+https://github.com/DataDog/libdatadog?rev=487fccca4910bf7bd3cfa7ed586e1fc5879ca180#487fccca4910bf7bd3cfa7ed586e1fc5879ca180"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -2109,13 +2140,13 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-stats"
-version = "1.0.4"
-source = "git+https://github.com/DataDog/libdatadog?rev=13b8202371d99753c0f84d20e2245a3cef917ddf#13b8202371d99753c0f84d20e2245a3cef917ddf"
+version = "2.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=487fccca4910bf7bd3cfa7ed586e1fc5879ca180#487fccca4910bf7bd3cfa7ed586e1fc5879ca180"
 dependencies = [
  "hashbrown 0.15.5",
- "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=13b8202371d99753c0f84d20e2245a3cef917ddf)",
- "libdd-trace-protobuf 3.0.0",
- "libdd-trace-utils 3.0.0",
+ "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=487fccca4910bf7bd3cfa7ed586e1fc5879ca180)",
+ "libdd-trace-protobuf 3.0.1",
+ "libdd-trace-utils 3.0.1",
 ]
 
 [[package]]
@@ -2148,22 +2179,25 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-utils"
-version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=13b8202371d99753c0f84d20e2245a3cef917ddf#13b8202371d99753c0f84d20e2245a3cef917ddf"
+version = "3.0.1"
+source = "git+https://github.com/DataDog/libdatadog?rev=487fccca4910bf7bd3cfa7ed586e1fc5879ca180#487fccca4910bf7bd3cfa7ed586e1fc5879ca180"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "bytes",
  "flate2",
  "futures",
+ "getrandom 0.2.17",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "indexmap",
- "libdd-common 3.0.1",
- "libdd-tinybytes 1.1.0 (git+https://github.com/DataDog/libdatadog?rev=13b8202371d99753c0f84d20e2245a3cef917ddf)",
- "libdd-trace-normalization 1.0.3",
- "libdd-trace-protobuf 3.0.0",
+ "libdd-capabilities",
+ "libdd-capabilities-impl",
+ "libdd-common 3.0.2",
+ "libdd-tinybytes 1.1.0 (git+https://github.com/DataDog/libdatadog?rev=487fccca4910bf7bd3cfa7ed586e1fc5879ca180)",
+ "libdd-trace-normalization 2.0.0",
+ "libdd-trace-protobuf 3.0.1",
  "prost 0.14.3",
  "rand 0.8.5",
  "rmp",
@@ -2212,14 +2246,14 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2236,9 +2270,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -2328,9 +2362,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -2682,9 +2716,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -3058,9 +3092,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -3140,7 +3174,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -3211,9 +3245,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -3308,9 +3342,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3412,9 +3446,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -3624,9 +3658,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "similar"
@@ -3900,9 +3934,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3925,9 +3959,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -3941,9 +3975,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4019,7 +4053,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -4278,9 +4312,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -4359,9 +4393,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4372,23 +4406,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4396,9 +4426,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4409,9 +4439,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -4452,9 +4482,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4867,9 +4897,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xattr"
@@ -4889,9 +4919,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4900,9 +4930,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4912,18 +4942,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4932,18 +4962,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4959,9 +4989,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4970,9 +5000,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4981,9 +5011,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -71,12 +71,12 @@ indexmap = {version = "2.11.0", default-features = false}
 # be found in the clippy.toml file adjacent to this Cargo.toml.
 datadog-protos = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "f863626dbfe3c59bb390985fa6530b0621c2a0a2"}
 ddsketch-agent = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "f863626dbfe3c59bb390985fa6530b0621c2a0a2"}
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "13b8202371d99753c0f84d20e2245a3cef917ddf" }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "13b8202371d99753c0f84d20e2245a3cef917ddf"  }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "13b8202371d99753c0f84d20e2245a3cef917ddf" , features = ["mini_agent"] }
-libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog",  rev = "13b8202371d99753c0f84d20e2245a3cef917ddf" }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "13b8202371d99753c0f84d20e2245a3cef917ddf"  }
-libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "13b8202371d99753c0f84d20e2245a3cef917ddf"  }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "487fccca4910bf7bd3cfa7ed586e1fc5879ca180" }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "487fccca4910bf7bd3cfa7ed586e1fc5879ca180"  }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "487fccca4910bf7bd3cfa7ed586e1fc5879ca180" , features = ["mini_agent"] }
+libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog",  rev = "487fccca4910bf7bd3cfa7ed586e1fc5879ca180" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "487fccca4910bf7bd3cfa7ed586e1fc5879ca180"  }
+libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "487fccca4910bf7bd3cfa7ed586e1fc5879ca180"  }
 datadog-opentelemetry = { git = "https://github.com/DataDog/dd-trace-rs", rev = "f51cefc4ad24bec81b38fb2f36b1ed93f21ae913", default-features = false }
 dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "28f796bf767fff56caf08153ade5cd80c8e8f705", default-features = false }
 datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "28f796bf767fff56caf08153ade5cd80c8e8f705", default-features = false }

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -39,7 +39,7 @@ hmac = { version = "0.12", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["std"] }
 base64 = { version = "0.22", default-features = false }
-rustls = { version = "0.23.18", default-features = false, features = ["aws-lc-rs"] }
+rustls = { version = "0.23.18", default-features = false, features = ["ring"] }
 rustls-pemfile = { version = "2.0", default-features = false, features = ["std"] }
 rustls-pki-types = { version = "1.0", default-features = false }
 hyper-rustls = { version = "0.27.7", default-features = false }
@@ -71,12 +71,12 @@ indexmap = {version = "2.11.0", default-features = false}
 # be found in the clippy.toml file adjacent to this Cargo.toml.
 datadog-protos = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "f863626dbfe3c59bb390985fa6530b0621c2a0a2"}
 ddsketch-agent = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "f863626dbfe3c59bb390985fa6530b0621c2a0a2"}
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09" }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09"  }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09" , features = ["mini_agent"] }
-libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog",  rev = "c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09" }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09"  }
-libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09"  }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "13b8202371d99753c0f84d20e2245a3cef917ddf" }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "13b8202371d99753c0f84d20e2245a3cef917ddf"  }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "13b8202371d99753c0f84d20e2245a3cef917ddf" , features = ["mini_agent"] }
+libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog",  rev = "13b8202371d99753c0f84d20e2245a3cef917ddf" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "13b8202371d99753c0f84d20e2245a3cef917ddf"  }
+libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "13b8202371d99753c0f84d20e2245a3cef917ddf"  }
 datadog-opentelemetry = { git = "https://github.com/DataDog/dd-trace-rs", rev = "f51cefc4ad24bec81b38fb2f36b1ed93f21ae913", default-features = false }
 dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "28f796bf767fff56caf08153ade5cd80c8e8f705", default-features = false }
 datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "28f796bf767fff56caf08153ade5cd80c8e8f705", default-features = false }

--- a/bottlecap/LICENSE-3rdparty.csv
+++ b/bottlecap/LICENSE-3rdparty.csv
@@ -159,7 +159,6 @@ percent-encoding,https://github.com/servo/rust-url,MIT OR Apache-2.0,The rust-ur
 pin-project,https://github.com/taiki-e/pin-project,Apache-2.0 OR MIT,The pin-project Authors
 pin-project-internal,https://github.com/taiki-e/pin-project,Apache-2.0 OR MIT,The pin-project-internal Authors
 pin-project-lite,https://github.com/taiki-e/pin-project-lite,Apache-2.0 OR MIT,The pin-project-lite Authors
-pin-utils,https://github.com/rust-lang-nursery/pin-utils,MIT OR Apache-2.0,Josef Brandl <mail@josefbrandl.de>
 potential_utf,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
 powerfmt,https://github.com/jhpratt/powerfmt,MIT OR Apache-2.0,Jacob Pratt <jacob@jhpratt.dev>
 ppv-lite86,https://github.com/cryptocorrosion/cryptocorrosion,MIT OR Apache-2.0,The CryptoCorrosion Contributors

--- a/bottlecap/LICENSE-3rdparty.csv
+++ b/bottlecap/LICENSE-3rdparty.csv
@@ -111,6 +111,8 @@ js-sys,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys,MI
 lazy_static,https://github.com/rust-lang-nursery/lazy-static.rs,MIT OR Apache-2.0,Marvin Löbel <loebel.marvin@gmail.com>
 leb128fmt,https://github.com/bluk/leb128fmt,MIT OR Apache-2.0,Bryant Luk <code@bryantluk.com>
 libc,https://github.com/rust-lang/libc,MIT OR Apache-2.0,The Rust Project Developers
+libdd-capabilities,https://github.com/DataDog/libdatadog/tree/main/libdd-capabilities,Apache-2.0,The libdd-capabilities Authors
+libdd-capabilities-impl,https://github.com/DataDog/libdatadog/tree/main/libdd-capabilities-impl,Apache-2.0,The libdd-capabilities-impl Authors
 libdd-common,https://github.com/DataDog/libdatadog/tree/main/datadog-common,Apache-2.0,The libdd-common Authors
 libdd-data-pipeline,https://github.com/DataDog/libdatadog/tree/main/libdd-data-pipeline,Apache-2.0,The libdd-data-pipeline Authors
 libdd-ddsketch,https://github.com/DataDog/libdatadog/tree/main/libdd-ddsketch,Apache-2.0,The libdd-ddsketch Authors

--- a/bottlecap/LICENSE-3rdparty.csv
+++ b/bottlecap/LICENSE-3rdparty.csv
@@ -19,6 +19,7 @@ bit-set,https://github.com/contain-rs/bit-set,Apache-2.0 OR MIT,Alexis Beingessn
 bit-vec,https://github.com/contain-rs/bit-vec,Apache-2.0 OR MIT,Alexis Beingessner <a.beingessner@gmail.com>
 bitflags,https://github.com/bitflags/bitflags,MIT OR Apache-2.0,The Rust Project Developers
 block-buffer,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developers
+borrow-or-share,https://github.com/yescallop/borrow-or-share,MIT-0,Scallop Ye <yescallop@gmail.com>
 buf_redux,https://github.com/abonander/buf_redux,MIT OR Apache-2.0,Austin Bonander <austin.bonander@gmail.com>
 bumpalo,https://github.com/fitzgen/bumpalo,MIT OR Apache-2.0,Nick Fitzgerald <fitzgen@gmail.com>
 bytemuck,https://github.com/Lokathor/bytemuck,Zlib OR Apache-2.0 OR MIT,Lokathor <zefria@gmail.com>
@@ -57,6 +58,7 @@ figment,https://github.com/SergioBenitez/Figment,MIT OR Apache-2.0,Sergio Benite
 find-msvc-tools,https://github.com/rust-lang/cc-rs,MIT OR Apache-2.0,The find-msvc-tools Authors
 flate2,https://github.com/rust-lang/flate2-rs,MIT OR Apache-2.0,"Alex Crichton <alex@alexcrichton.com>, Josh Triplett <josh@joshtriplett.org>"
 float-cmp,https://github.com/mikedilger/float-cmp,MIT,Mike Dilger <mike@mikedilger.com>
+fluent-uri,https://github.com/yescallop/fluent-uri-rs,MIT,Scallop Ye <yescallop@gmail.com>
 fnv,https://github.com/servo/rust-fnv,Apache-2.0  OR  MIT,Alex Crichton <alex@alexcrichton.com>
 foldhash,https://github.com/orlp/foldhash,Zlib,Orson Peters <orsonpeters@gmail.com>
 form_urlencoded,https://github.com/servo/rust-url,MIT OR Apache-2.0,The rust-url developers
@@ -179,6 +181,8 @@ rand_chacha,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Proj
 rand_core,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers"
 rand_xorshift,https://github.com/rust-random/rngs,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers"
 redox_syscall,https://gitlab.redox-os.org/redox-os/syscall,MIT,Jeremy Soller <jackpot51@gmail.com>
+ref-cast,https://github.com/dtolnay/ref-cast,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+ref-cast-impl,https://github.com/dtolnay/ref-cast,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 regex,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"
 regex-automata,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"
 regex-syntax,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -1148,11 +1148,19 @@ fn start_trace_agent(
 
     let obfuscation_config = obfuscation_config::ObfuscationConfig {
         tag_replace_rules: config.apm_replace_tags.clone(),
-        http_remove_path_digits: config.apm_config_obfuscation_http_remove_paths_with_digits,
-        http_remove_query_string: config.apm_config_obfuscation_http_remove_query_string,
-        obfuscate_memcached: false,
-        obfuscation_redis_enabled: false,
-        obfuscation_redis_remove_all_args: false,
+        http: obfuscation_config::HttpConfig {
+            remove_paths_with_digits: config.apm_config_obfuscation_http_remove_paths_with_digits,
+            remove_query_string: config.apm_config_obfuscation_http_remove_query_string,
+        },
+        memcached: obfuscation_config::MemcachedConfig {
+            enabled: false,
+            ..Default::default()
+        },
+        redis: obfuscation_config::RedisConfig {
+            enabled: false,
+            remove_all_args: false,
+        },
+        ..Default::default()
     };
 
     let trace_processor = Arc::new(trace_processor::ServerlessTraceProcessor {

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -1130,7 +1130,6 @@ fn start_trace_agent(
         api_key_factory.clone(),
         stats_aggregator.clone(),
         Arc::clone(config),
-        trace_http_client.clone(),
     ));
 
     let stats_processor = Arc::new(stats_processor::ServerlessStatsProcessor {});

--- a/bottlecap/src/traces/http_client.rs
+++ b/bottlecap/src/traces/http_client.rs
@@ -6,9 +6,11 @@
 //! This module provides the HTTP client type required by `libdd_trace_utils`
 //! for sending traces and stats to Datadog intake endpoints.
 
+use http_body_util::BodyExt;
 use hyper_http_proxy;
 use hyper_rustls::HttpsConnectorBuilder;
-use libdd_common::{GenericHttpClient, http_common};
+use libdd_common::capabilities::{HttpClientTrait, HttpError};
+use libdd_common::http_common::{self, Body, GenericHttpClient};
 use rustls::RootCertStore;
 use rustls_pki_types::CertificateDer;
 use std::error::Error;
@@ -17,11 +19,51 @@ use std::io::BufReader;
 use std::sync::{Arc, LazyLock};
 use tracing::debug;
 
-/// Type alias for the HTTP client used by trace and stats flushers.
-///
-/// This is the client type expected by `libdd_trace_utils::SendData::send()`.
-pub type HttpClient =
+type InnerHttpClient =
     GenericHttpClient<hyper_http_proxy::ProxyConnector<libdd_common::connector::Connector>>;
+
+/// HTTP client wrapper that implements `HttpClientTrait` for use with
+/// `libdd_trace_utils` trace and stats sending APIs.
+#[derive(Clone, Debug)]
+pub struct HttpClient {
+    inner: InnerHttpClient,
+}
+
+impl HttpClientTrait for HttpClient {
+    fn new_client() -> Self {
+        let connector = libdd_common::connector::Connector::default();
+        let proxy_connector =
+            hyper_http_proxy::ProxyConnector::new(connector).expect("Failed to create connector");
+        Self {
+            inner: http_common::client_builder()
+                .pool_max_idle_per_host(0)
+                .build(proxy_connector),
+        }
+    }
+
+    #[allow(clippy::manual_async_fn)]
+    fn request(
+        &self,
+        req: hyper::http::Request<bytes::Bytes>,
+    ) -> impl std::future::Future<Output = Result<hyper::http::Response<bytes::Bytes>, HttpError>> + Send
+    {
+        let client = self.inner.clone();
+        async move {
+            let hyper_req = req.map(Body::from_bytes);
+            let response = client
+                .request(hyper_req)
+                .await
+                .map_err(|e| HttpError::Network(e.into()))?;
+            let (parts, body) = response.into_parts();
+            let collected = body
+                .collect()
+                .await
+                .map_err(|e| HttpError::ResponseBody(e.into()))?
+                .to_bytes();
+            Ok(hyper::http::Response::from_parts(parts, collected))
+        }
+    }
+}
 
 /// Initialize the crypto provider needed for setting custom root certificates.
 /// Uses ring for non-FIPS builds; FIPS builds install the aws-lc-rs FIPS provider
@@ -106,7 +148,7 @@ pub fn create_client(
     proxy_https: Option<&String>,
     tls_cert_file: Option<&String>,
     skip_ssl_validation: bool,
-) -> Result<HttpClient, Box<dyn Error>> {
+) -> Result<HttpClient, Box<dyn Error + Send + Sync>> {
     if skip_ssl_validation && tls_cert_file.is_some() {
         debug!(
             "HTTP_CLIENT | skip_ssl_validation=true overrides tls_cert_file={:?}, custom certificate will be ignored",
@@ -178,20 +220,22 @@ pub fn create_client(
         // invocations. Pooled connections become stale during this time, causing failures
         // when reused. Setting pool_max_idle_per_host(0) ensures each request gets a fresh
         // connection, matching the pattern used in libdatadog's new_client_periodic().
-        let client = http_common::client_builder()
+        let inner = http_common::client_builder()
             .pool_max_idle_per_host(0)
             .build(proxy_connector);
         debug!(
             "HTTP_CLIENT | Proxy connector created with proxy: {:?}",
             proxy_https
         );
-        Ok(client)
+        Ok(HttpClient { inner })
     } else {
         let proxy_connector = hyper_http_proxy::ProxyConnector::new(connector)?;
         // Disable connection pooling to avoid stale connections after Lambda freeze/resume.
         // See comment above for detailed explanation.
-        Ok(http_common::client_builder()
-            .pool_max_idle_per_host(0)
-            .build(proxy_connector))
+        Ok(HttpClient {
+            inner: http_common::client_builder()
+                .pool_max_idle_per_host(0)
+                .build(proxy_connector),
+        })
     }
 }

--- a/bottlecap/src/traces/http_client.rs
+++ b/bottlecap/src/traces/http_client.rs
@@ -24,11 +24,11 @@ pub type HttpClient =
     GenericHttpClient<hyper_http_proxy::ProxyConnector<libdd_common::connector::Connector>>;
 
 /// Initialize the crypto provider needed for setting custom root certificates.
+/// Uses ring for non-FIPS builds; FIPS builds install the aws-lc-rs FIPS provider
+/// in `fips::prepare_client_provider()` before this is called.
 fn ensure_crypto_provider_initialized() {
     static INIT_CRYPTO_PROVIDER: LazyLock<()> = LazyLock::new(|| {
-        #[cfg(unix)]
-        if let Err(_already_installed) =
-            rustls::crypto::aws_lc_rs::default_provider().install_default()
+        if let Err(_already_installed) = rustls::crypto::ring::default_provider().install_default()
         {
             debug!(
                 "HTTP_CLIENT | Default CryptoProvider already installed, using existing provider"

--- a/bottlecap/src/traces/stats_flusher.rs
+++ b/bottlecap/src/traces/stats_flusher.rs
@@ -9,7 +9,6 @@ use tokio::sync::OnceCell;
 use crate::FLUSH_RETRY_COUNT;
 use crate::config;
 use crate::lifecycle::invocation::processor::S_TO_MS;
-use crate::traces::http_client::HttpClient;
 use crate::traces::stats_aggregator::StatsAggregator;
 use dogstatsd::api_key::ApiKeyFactory;
 use libdd_common::Endpoint;
@@ -22,7 +21,6 @@ pub struct StatsFlusher {
     config: Arc<config::Config>,
     api_key_factory: Arc<ApiKeyFactory>,
     endpoint: OnceCell<Endpoint>,
-    http_client: HttpClient,
 }
 
 impl StatsFlusher {
@@ -31,14 +29,12 @@ impl StatsFlusher {
         api_key_factory: Arc<ApiKeyFactory>,
         aggregator: Arc<Mutex<StatsAggregator>>,
         config: Arc<config::Config>,
-        http_client: HttpClient,
     ) -> Self {
         StatsFlusher {
             aggregator,
             config,
             api_key_factory,
             endpoint: OnceCell::new(),
-            http_client,
         }
     }
 
@@ -96,11 +92,10 @@ impl StatsFlusher {
 
         for attempt in 1..=FLUSH_RETRY_COUNT {
             let start = std::time::Instant::now();
-            let resp = stats_utils::send_stats_payload_with_client(
+            let resp = stats_utils::send_stats_payload::<crate::traces::http_client::HttpClient>(
                 serialized_stats_payload.clone(),
                 endpoint,
                 api_key.as_str(),
-                Some(&self.http_client),
             )
             .await;
             let elapsed = start.elapsed();

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -637,7 +637,7 @@ mod tests {
     #[allow(clippy::unwrap_used)]
     #[cfg_attr(miri, ignore)]
     async fn test_process_trace() {
-        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        let _ = rustls::crypto::ring::default_provider().install_default();
         let start = get_current_timestamp_nanos();
 
         let tags_provider = create_tags_provider(create_test_config());


### PR DESCRIPTION
## Overview

Switch the default crypto backend from aws-lc-rs to ring for non-FIPS builds, reducing the release binary size by ~15% (8.7MB -> 7.4MB on macOS arm64). FIPS builds continue to use aws-lc-rs via rustls/fips.

- Bump libdatadog to 18a02650 (ring for non-FIPS)
- Switch rustls features from aws-lc-rs to ring
- Update crypto provider init to use ring::default_provider()

## Other
- Adapt ObfuscationConfig to new nested struct API

## Testing 

Layer size check
https://github.com/DataDog/libdatadog/pull/1816