### PR TITLE
[For Test Only]: add debug log in idle extension loop

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -282,6 +282,7 @@ async fn extension_loop_idle(
         match extension::next_event(client, &r.extension_id, &aws_config.runtime_api).await {
             Ok(_) => {
                 debug!("Extension is idle, skipping next event");
+                debug!("This is a test");
             }
             Err(e) => {
                 error!("Error getting next event: {e:?}");


### PR DESCRIPTION
## Summary
- Adds a `debug!("This is a test")` log line in the idle extension loop handler

## Test plan
- [ ] Verify debug log appears when extension is idle and `RUST_LOG=debug` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)