### PR TITLE
[FOR TEST ONLY]debug: add trace context extraction debug log

### DIFF
--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -1146,6 +1146,7 @@ impl Processor {
             .and_then(|req| req.get("headers"))
             .and_then(|headers| propagator.extract(&JsonCarrier(headers)))
         {
+            debug!("Another test");
             debug!("Extracted trace context from event.request.headers");
             return Some(sc);
         }


### PR DESCRIPTION
## Summary
- Adds a `debug!("Another test")` log line in `processor.rs` before the existing trace context extraction log
- Helps verify the trace context extraction path is hit during debugging

## Test Plan
- [ ] Verify debug log appears when trace context is extracted from `event.request.headers`
- [ ] No functional behavior change (debug-only log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)