### PR TITLE
chore: bump EXTENSION_VERSION to 96-next

### DIFF
--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -45,7 +45,7 @@ const FUNCTION_TAGS_KEY: &str = "_dd.tags.function";
 // TODO(astuyve) decide what to do with the version
 const EXTENSION_VERSION_KEY: &str = "dd_extension_version";
 // TODO(duncanista) figure out a better way to not hardcode this
-pub const EXTENSION_VERSION: &str = "95-next";
+pub const EXTENSION_VERSION: &str = "96-next";
 
 const REGION_KEY: &str = "region";
 const ACCOUNT_ID_KEY: &str = "account_id";


### PR DESCRIPTION
## Summary
- Bumps `EXTENSION_VERSION` constant from `95-next` to `96-next`

## Test plan
- [ ] Verify extension reports correct version tag in Lambda traces