### PR TITLE
fix(scripts): detect failures in `publish_bottlecap_sandbox.sh`

### DIFF
--- a/scripts/publish_bottlecap_sandbox.sh
+++ b/scripts/publish_bottlecap_sandbox.sh
@@ -12,7 +12,7 @@
 # ARCHITECTURE - Which architecture to build for (amd64 or arm64). The default is amd64.
 # RELEASE_CANDIDATE - If true, publish as a release candidate to us-east-1. The default is false.
 
-set -e
+set -eo pipefail
 
 _init_arg(){
   if [ "$ARCHITECTURE" == "amd64" ]; then
@@ -24,7 +24,7 @@ _init_arg(){
       LAYER_PATH=".layers/datadog_extension-arm64.zip"
       LAYER_NAME="Datadog-Bottlecap-Beta-ARM"
   fi
-  if [ -z $ARCHITECTURE ]; then
+  if [ -z "$ARCHITECTURE" ]; then
       echo "No architecture specified, defaulting to amd64"
       ARCHITECTURE="amd64"
   fi
@@ -33,7 +33,7 @@ _init_arg(){
      LAYER_NAME+="-$SUFFIX"
   fi
 
-  if [ -z $REGION ]; then
+  if [ -z "$REGION" ]; then
       echo "No region specified, defaulting to us-east-1"
       REGION="us-east-1"
   fi
@@ -44,7 +44,11 @@ publish(){
   NEW_VERSION=$(aws-vault exec sso-serverless-sandbox-account-admin -- aws lambda publish-layer-version --layer-name "${LAYER_NAME}" \
       --description "Datadog Bottlecap Beta" \
       --zip-file "fileb://${LAYER_PATH}" \
-      --region $REGION | jq -r '.Version')
+      --region "$REGION" | jq -r '.Version')
+  if [ -z "$NEW_VERSION" ] || [ "$NEW_VERSION" = "null" ]; then
+    echo "ERROR: Failed to publish layer $LAYER_NAME to region $REGION"
+    exit 1
+  fi
   echo "DONE: Published version $NEW_VERSION of layer $LAYER_NAME to region $REGION"
 }
 


### PR DESCRIPTION
## Overview

`publish_bottlecap_sandbox.sh` would print

```
DONE: Published version  of layer ...
```

even when the `aws-vault`/`aws` call failed, because pipeline failures were not propagated and `NEW_VERSION` was silently empty.

Changes:
- Replace `set -e` with `set -eo pipefail` so any failure in the `aws-vault | jq` pipeline aborts the script immediately
- Add explicit validation: if `NEW_VERSION` is empty or `null` after the publish call, print `ERROR:` and exit 1 instead of a misleading success message
- Fix unquoted `$ARCHITECTURE`, `$REGION` variables (shellcheck warnings)

## Testing

Verified locally by running the script without `aws` in `$PATH` — the script now exits with `ERROR: Failed to publish layer ...` instead of `DONE: Published version  of layer ...`.