### PR TITLE
[SVLS-8969] feat(scripts): add fed-us2 environment support to publish_govcloud_layers.sh

### DIFF
--- a/scripts/publish_govcloud_layers.sh
+++ b/scripts/publish_govcloud_layers.sh
@@ -58,7 +58,7 @@ elif [ $ENVIRONMENT = "us1-fed" ]; then
     fi
 
 elif [ $ENVIRONMENT = "fed-us2" ]; then
-    AWS_VAULT_ROLE=sso-govcloud-fed-us2-engineering
+    AWS_VAULT_ROLE=sso-govcloud-fed-us2-lambda-layer-operator
 
     export ADD_LAYER_VERSION_PERMISSIONS=1
     export AUTOMATICALLY_BUMP_VERSION=0

--- a/scripts/publish_govcloud_layers.sh
+++ b/scripts/publish_govcloud_layers.sh
@@ -9,7 +9,7 @@
 # Download button on the `layer bundle` job. This will be a zip file containing
 # all of the required layers. Run this script as follows:
 #
-# ENVIRONMENT=[us1-staging-fed or us1-fed] [PIPELINE_LAYER_SUFFIX=optional-layer-suffix] [REGIONS=us-gov-west-1] ./scripts/publish_govcloud_layers.sh <layer-bundle.zip>
+# ENVIRONMENT=[us1-staging-fed or us1-fed or fed-us2] [PIPELINE_LAYER_SUFFIX=optional-layer-suffix] [REGIONS=us-gov-west-1] ./scripts/publish_govcloud_layers.sh <layer-bundle.zip>
 #
 # protip: you can drag the zip file from finder into your terminal to insert
 # its path.
@@ -57,8 +57,24 @@ elif [ $ENVIRONMENT = "us1-fed" ]; then
         exit 1
     fi
 
+elif [ $ENVIRONMENT = "fed-us2" ]; then
+    AWS_VAULT_ROLE=sso-govcloud-fed-us2-engineering
+
+    export ADD_LAYER_VERSION_PERMISSIONS=1
+    export AUTOMATICALLY_BUMP_VERSION=0
+
+    if [[ -z "$VERSION" ]]; then
+        printf "[ERROR]: VERSION not specified\n"
+        exit 1
+    fi
+
+    if [[ ! "$PACKAGE_NAME" =~ ^datadog_extension-signed-bundle-[0-9]+$ ]]; then
+        echo "[ERROR]: Unexpected package name: $PACKAGE_NAME"
+        exit 1
+    fi
+
 else
-    printf "[ERROR]: ENVIRONMENT not supported, must be us1-staging-fed or us1-fed.\n"
+    printf "[ERROR]: ENVIRONMENT not supported, must be us1-staging-fed, us1-fed, or fed-us2.\n"
     exit 1
 fi
 

--- a/scripts/publish_govcloud_layers.sh
+++ b/scripts/publish_govcloud_layers.sh
@@ -9,7 +9,7 @@
 # Download button on the `layer bundle` job. This will be a zip file containing
 # all of the required layers. Run this script as follows:
 #
-# ENVIRONMENT=[us1-staging-fed or us1-fed or fed-us2, comma-separated] [PIPELINE_LAYER_SUFFIX=optional-layer-suffix] [REGIONS=us-gov-west-1] ./scripts/publish_govcloud_layers.sh <layer-bundle.zip>
+# ENVIRONMENT=[us1-staging-fed or us1-fed or fed-us2] [PIPELINE_LAYER_SUFFIX=optional-layer-suffix] [REGIONS=us-gov-west-1] ./scripts/publish_govcloud_layers.sh <layer-bundle.zip>
 #
 # protip: you can drag the zip file from finder into your terminal to insert
 # its path.
@@ -30,10 +30,80 @@ if [ -z "$ENVIRONMENT" ]; then
     exit 1
 fi
 
+if [ "$ENVIRONMENT" = "us1-staging-fed" ]; then
+    AWS_VAULT_ROLE=sso-govcloud-us1-staging-fed-power-user
+
+    export ADD_LAYER_VERSION_PERMISSIONS=0
+    export AUTOMATICALLY_BUMP_VERSION=1
+
+    if [[ ! "$PACKAGE_NAME" =~ ^datadog_extension-(signed-)?bundle-[0-9]+$ ]]; then
+        echo "[ERROR]: Unexpected package name: $PACKAGE_NAME"
+        exit 1
+    fi
+
+elif [ $ENVIRONMENT = "us1-fed" ]; then
+    AWS_VAULT_ROLE=sso-govcloud-us1-fed-engineering
+
+    export ADD_LAYER_VERSION_PERMISSIONS=1
+    export AUTOMATICALLY_BUMP_VERSION=0
+
+    if [[ -z "$VERSION" ]]; then
+        printf "[ERROR]: VERSION not specified\n"
+        exit 1
+    fi
+
+    if [[ ! "$PACKAGE_NAME" =~ ^datadog_extension-signed-bundle-[0-9]+$ ]]; then
+        echo "[ERROR]: Unexpected package name: $PACKAGE_NAME"
+        exit 1
+    fi
+
+elif [ $ENVIRONMENT = "fed-us2" ]; then
+    AWS_VAULT_ROLE=sso-govcloud-fed-us2-engineering
+
+    export ADD_LAYER_VERSION_PERMISSIONS=1
+    export AUTOMATICALLY_BUMP_VERSION=0
+
+    if [[ -z "$VERSION" ]]; then
+        printf "[ERROR]: VERSION not specified\n"
+        exit 1
+    fi
+
+    if [[ ! "$PACKAGE_NAME" =~ ^datadog_extension-signed-bundle-[0-9]+$ ]]; then
+        echo "[ERROR]: Unexpected package name: $PACKAGE_NAME"
+        exit 1
+    fi
+
+else
+    printf "[ERROR]: ENVIRONMENT not supported, must be us1-staging-fed, us1-fed, or fed-us2.\n"
+    exit 1
+fi
+
 TEMP_DIR=$(mktemp -d)
 unzip $LAYER_PACKAGE -d $TEMP_DIR
 cp -v $TEMP_DIR/$PACKAGE_NAME/*.zip .layers/
 
+
+AWS_VAULT_PREFIX="aws-vault exec $AWS_VAULT_ROLE --"
+
+echo "Checking that you have access to the GovCloud AWS account"
+$AWS_VAULT_PREFIX aws sts get-caller-identity
+
+
+AVAILABLE_REGIONS=$($AWS_VAULT_PREFIX aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')
+
+# Determine the target regions
+if [ -z "$REGIONS" ]; then
+    echo "Region not specified, running for all available regions."
+    REGIONS=$AVAILABLE_REGIONS
+else
+    echo "Region specified: $REGIONS"
+    if [[ ! "$AVAILABLE_REGIONS" == *"$REGIONS"* ]]; then
+        echo "Could not find $REGIONS in available regions: $AVAILABLE_REGIONS"
+        echo ""
+        echo "EXITING SCRIPT."
+        exit 1
+    fi
+fi
 
 declare -A flavors
 
@@ -42,103 +112,27 @@ flavors["arm64"]="arch=arm64 suffix=arm64 layer_name_base_suffix=-ARM"
 flavors["amd64-fips"]="arch=amd64 suffix=amd64-fips layer_name_base_suffix=-FIPS"
 flavors["arm64-fips"]="arch=arm64 suffix=arm64-fips layer_name_base_suffix=-ARM-FIPS"
 
-IFS=',' read -r -a ENVIRONMENTS <<< "$ENVIRONMENT"
+for region in $REGIONS
+do
+    echo "Starting publishing layers for region $region..."
 
-for ENV in "${ENVIRONMENTS[@]}"; do
-    if [ "$ENV" = "us1-staging-fed" ]; then
-        AWS_VAULT_ROLE=sso-govcloud-us1-staging-fed-power-user
+    export REGION=$region
 
-        export ADD_LAYER_VERSION_PERMISSIONS=0
-        export AUTOMATICALLY_BUMP_VERSION=1
-
-        if [[ ! "$PACKAGE_NAME" =~ ^datadog_extension-(signed-)?bundle-[0-9]+$ ]]; then
-            echo "[ERROR]: Unexpected package name: $PACKAGE_NAME"
-            exit 1
-        fi
-
-    elif [ "$ENV" = "us1-fed" ]; then
-        AWS_VAULT_ROLE=sso-govcloud-us1-fed-engineering
-
-        export ADD_LAYER_VERSION_PERMISSIONS=1
-        export AUTOMATICALLY_BUMP_VERSION=0
-
-        if [[ -z "$VERSION" ]]; then
-            printf "[ERROR]: VERSION not specified\n"
-            exit 1
-        fi
-
-        if [[ ! "$PACKAGE_NAME" =~ ^datadog_extension-signed-bundle-[0-9]+$ ]]; then
-            echo "[ERROR]: Unexpected package name: $PACKAGE_NAME"
-            exit 1
-        fi
-
-    elif [ "$ENV" = "fed-us2" ]; then
-        AWS_VAULT_ROLE=sso-govcloud-fed-us2-engineering
-
-        export ADD_LAYER_VERSION_PERMISSIONS=1
-        export AUTOMATICALLY_BUMP_VERSION=0
-
-        if [[ -z "$VERSION" ]]; then
-            printf "[ERROR]: VERSION not specified\n"
-            exit 1
-        fi
-
-        if [[ ! "$PACKAGE_NAME" =~ ^datadog_extension-signed-bundle-[0-9]+$ ]]; then
-            echo "[ERROR]: Unexpected package name: $PACKAGE_NAME"
-            exit 1
-        fi
-
-    else
-        printf "[ERROR]: ENVIRONMENT not supported: $ENV, must be us1-staging-fed, us1-fed, or fed-us2.\n"
-        exit 1
-    fi
-
-    AWS_VAULT_PREFIX="aws-vault exec $AWS_VAULT_ROLE --"
-
-    echo "Checking that you have access to the GovCloud AWS account ($ENV)"
-    $AWS_VAULT_PREFIX aws sts get-caller-identity
-
-
-    AVAILABLE_REGIONS=$($AWS_VAULT_PREFIX aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')
-
-    # Determine the target regions
-    if [ -z "$REGIONS" ]; then
-        echo "Region not specified, running for all available regions."
-        ENV_REGIONS=$AVAILABLE_REGIONS
-    else
-        echo "Region specified: $REGIONS"
-        if [[ ! "$AVAILABLE_REGIONS" == *"$REGIONS"* ]]; then
-            echo "Could not find $REGIONS in available regions: $AVAILABLE_REGIONS"
-            echo ""
-            echo "EXITING SCRIPT."
-            exit 1
-        fi
-        ENV_REGIONS=$REGIONS
-    fi
-
-    for region in $ENV_REGIONS
-    do
-        echo "Starting publishing layers for region $region..."
-
-        export REGION=$region
-
-        for flavor in "${!flavors[@]}"; do
-            export LAYER_NAME_BASE_SUFFIX=""
-            IFS=' ' read -r -a values <<< "${flavors[$flavor]}"
-            for value in "${values[@]}"; do
-                case $value in
-                    arch=*) export ARCHITECTURE="${value#arch=}" ;;
-                    suffix=*) SUFFIX="${value#suffix=}" ;;
-                    layer_name_base_suffix=*) export LAYER_NAME_BASE_SUFFIX="${value#layer_name_base_suffix=}" ;;
-                esac
-            done
-
-            export LAYER_FILE="datadog_extension-$SUFFIX.zip"
-            echo "Publishing $LAYER_FILE"
-
-            $AWS_VAULT_PREFIX .gitlab/scripts/publish_layers.sh
+    for flavor in "${!flavors[@]}"; do
+        export LAYER_NAME_BASE_SUFFIX=""
+        IFS=' ' read -r -a values <<< "${flavors[$flavor]}"
+        for value in "${values[@]}"; do
+            case $value in
+                arch=*) export ARCHITECTURE="${value#arch=}" ;;
+                suffix=*) SUFFIX="${value#suffix=}" ;;
+                layer_name_base_suffix=*) export LAYER_NAME_BASE_SUFFIX="${value#layer_name_base_suffix=}" ;;
+            esac
         done
 
+        export LAYER_FILE="datadog_extension-$SUFFIX.zip"
+        echo "Publishing $LAYER_FILE"
+
+        $AWS_VAULT_PREFIX .gitlab/scripts/publish_layers.sh
     done
 
 done

--- a/scripts/publish_govcloud_layers.sh
+++ b/scripts/publish_govcloud_layers.sh
@@ -9,7 +9,7 @@
 # Download button on the `layer bundle` job. This will be a zip file containing
 # all of the required layers. Run this script as follows:
 #
-# ENVIRONMENT=[us1-staging-fed or us1-fed or fed-us2] [PIPELINE_LAYER_SUFFIX=optional-layer-suffix] [REGIONS=us-gov-west-1] ./scripts/publish_govcloud_layers.sh <layer-bundle.zip>
+# ENVIRONMENT=[us1-staging-fed or us1-fed or fed-us2, comma-separated] [PIPELINE_LAYER_SUFFIX=optional-layer-suffix] [REGIONS=us-gov-west-1] ./scripts/publish_govcloud_layers.sh <layer-bundle.zip>
 #
 # protip: you can drag the zip file from finder into your terminal to insert
 # its path.
@@ -30,80 +30,10 @@ if [ -z "$ENVIRONMENT" ]; then
     exit 1
 fi
 
-if [ "$ENVIRONMENT" = "us1-staging-fed" ]; then
-    AWS_VAULT_ROLE=sso-govcloud-us1-staging-fed-power-user
-
-    export ADD_LAYER_VERSION_PERMISSIONS=0
-    export AUTOMATICALLY_BUMP_VERSION=1
-
-    if [[ ! "$PACKAGE_NAME" =~ ^datadog_extension-(signed-)?bundle-[0-9]+$ ]]; then
-        echo "[ERROR]: Unexpected package name: $PACKAGE_NAME"
-        exit 1
-    fi
-
-elif [ $ENVIRONMENT = "us1-fed" ]; then
-    AWS_VAULT_ROLE=sso-govcloud-us1-fed-engineering
-
-    export ADD_LAYER_VERSION_PERMISSIONS=1
-    export AUTOMATICALLY_BUMP_VERSION=0
-
-    if [[ -z "$VERSION" ]]; then
-        printf "[ERROR]: VERSION not specified\n"
-        exit 1
-    fi
-
-    if [[ ! "$PACKAGE_NAME" =~ ^datadog_extension-signed-bundle-[0-9]+$ ]]; then
-        echo "[ERROR]: Unexpected package name: $PACKAGE_NAME"
-        exit 1
-    fi
-
-elif [ $ENVIRONMENT = "fed-us2" ]; then
-    AWS_VAULT_ROLE=sso-govcloud-fed-us2-engineering
-
-    export ADD_LAYER_VERSION_PERMISSIONS=1
-    export AUTOMATICALLY_BUMP_VERSION=0
-
-    if [[ -z "$VERSION" ]]; then
-        printf "[ERROR]: VERSION not specified\n"
-        exit 1
-    fi
-
-    if [[ ! "$PACKAGE_NAME" =~ ^datadog_extension-signed-bundle-[0-9]+$ ]]; then
-        echo "[ERROR]: Unexpected package name: $PACKAGE_NAME"
-        exit 1
-    fi
-
-else
-    printf "[ERROR]: ENVIRONMENT not supported, must be us1-staging-fed, us1-fed, or fed-us2.\n"
-    exit 1
-fi
-
 TEMP_DIR=$(mktemp -d)
 unzip $LAYER_PACKAGE -d $TEMP_DIR
 cp -v $TEMP_DIR/$PACKAGE_NAME/*.zip .layers/
 
-
-AWS_VAULT_PREFIX="aws-vault exec $AWS_VAULT_ROLE --"
-
-echo "Checking that you have access to the GovCloud AWS account"
-$AWS_VAULT_PREFIX aws sts get-caller-identity
-
-
-AVAILABLE_REGIONS=$($AWS_VAULT_PREFIX aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')
-
-# Determine the target regions
-if [ -z "$REGIONS" ]; then
-    echo "Region not specified, running for all available regions."
-    REGIONS=$AVAILABLE_REGIONS
-else
-    echo "Region specified: $REGIONS"
-    if [[ ! "$AVAILABLE_REGIONS" == *"$REGIONS"* ]]; then
-        echo "Could not find $REGIONS in available regions: $AVAILABLE_REGIONS"
-        echo ""
-        echo "EXITING SCRIPT."
-        exit 1
-    fi
-fi
 
 declare -A flavors
 
@@ -112,27 +42,103 @@ flavors["arm64"]="arch=arm64 suffix=arm64 layer_name_base_suffix=-ARM"
 flavors["amd64-fips"]="arch=amd64 suffix=amd64-fips layer_name_base_suffix=-FIPS"
 flavors["arm64-fips"]="arch=arm64 suffix=arm64-fips layer_name_base_suffix=-ARM-FIPS"
 
-for region in $REGIONS
-do
-    echo "Starting publishing layers for region $region..."
+IFS=',' read -r -a ENVIRONMENTS <<< "$ENVIRONMENT"
 
-    export REGION=$region
+for ENV in "${ENVIRONMENTS[@]}"; do
+    if [ "$ENV" = "us1-staging-fed" ]; then
+        AWS_VAULT_ROLE=sso-govcloud-us1-staging-fed-power-user
 
-    for flavor in "${!flavors[@]}"; do
-        export LAYER_NAME_BASE_SUFFIX=""
-        IFS=' ' read -r -a values <<< "${flavors[$flavor]}"
-        for value in "${values[@]}"; do
-            case $value in
-                arch=*) export ARCHITECTURE="${value#arch=}" ;;
-                suffix=*) SUFFIX="${value#suffix=}" ;;
-                layer_name_base_suffix=*) export LAYER_NAME_BASE_SUFFIX="${value#layer_name_base_suffix=}" ;;
-            esac
+        export ADD_LAYER_VERSION_PERMISSIONS=0
+        export AUTOMATICALLY_BUMP_VERSION=1
+
+        if [[ ! "$PACKAGE_NAME" =~ ^datadog_extension-(signed-)?bundle-[0-9]+$ ]]; then
+            echo "[ERROR]: Unexpected package name: $PACKAGE_NAME"
+            exit 1
+        fi
+
+    elif [ "$ENV" = "us1-fed" ]; then
+        AWS_VAULT_ROLE=sso-govcloud-us1-fed-engineering
+
+        export ADD_LAYER_VERSION_PERMISSIONS=1
+        export AUTOMATICALLY_BUMP_VERSION=0
+
+        if [[ -z "$VERSION" ]]; then
+            printf "[ERROR]: VERSION not specified\n"
+            exit 1
+        fi
+
+        if [[ ! "$PACKAGE_NAME" =~ ^datadog_extension-signed-bundle-[0-9]+$ ]]; then
+            echo "[ERROR]: Unexpected package name: $PACKAGE_NAME"
+            exit 1
+        fi
+
+    elif [ "$ENV" = "fed-us2" ]; then
+        AWS_VAULT_ROLE=sso-govcloud-fed-us2-engineering
+
+        export ADD_LAYER_VERSION_PERMISSIONS=1
+        export AUTOMATICALLY_BUMP_VERSION=0
+
+        if [[ -z "$VERSION" ]]; then
+            printf "[ERROR]: VERSION not specified\n"
+            exit 1
+        fi
+
+        if [[ ! "$PACKAGE_NAME" =~ ^datadog_extension-signed-bundle-[0-9]+$ ]]; then
+            echo "[ERROR]: Unexpected package name: $PACKAGE_NAME"
+            exit 1
+        fi
+
+    else
+        printf "[ERROR]: ENVIRONMENT not supported: $ENV, must be us1-staging-fed, us1-fed, or fed-us2.\n"
+        exit 1
+    fi
+
+    AWS_VAULT_PREFIX="aws-vault exec $AWS_VAULT_ROLE --"
+
+    echo "Checking that you have access to the GovCloud AWS account ($ENV)"
+    $AWS_VAULT_PREFIX aws sts get-caller-identity
+
+
+    AVAILABLE_REGIONS=$($AWS_VAULT_PREFIX aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')
+
+    # Determine the target regions
+    if [ -z "$REGIONS" ]; then
+        echo "Region not specified, running for all available regions."
+        ENV_REGIONS=$AVAILABLE_REGIONS
+    else
+        echo "Region specified: $REGIONS"
+        if [[ ! "$AVAILABLE_REGIONS" == *"$REGIONS"* ]]; then
+            echo "Could not find $REGIONS in available regions: $AVAILABLE_REGIONS"
+            echo ""
+            echo "EXITING SCRIPT."
+            exit 1
+        fi
+        ENV_REGIONS=$REGIONS
+    fi
+
+    for region in $ENV_REGIONS
+    do
+        echo "Starting publishing layers for region $region..."
+
+        export REGION=$region
+
+        for flavor in "${!flavors[@]}"; do
+            export LAYER_NAME_BASE_SUFFIX=""
+            IFS=' ' read -r -a values <<< "${flavors[$flavor]}"
+            for value in "${values[@]}"; do
+                case $value in
+                    arch=*) export ARCHITECTURE="${value#arch=}" ;;
+                    suffix=*) SUFFIX="${value#suffix=}" ;;
+                    layer_name_base_suffix=*) export LAYER_NAME_BASE_SUFFIX="${value#layer_name_base_suffix=}" ;;
+                esac
+            done
+
+            export LAYER_FILE="datadog_extension-$SUFFIX.zip"
+            echo "Publishing $LAYER_FILE"
+
+            $AWS_VAULT_PREFIX .gitlab/scripts/publish_layers.sh
         done
 
-        export LAYER_FILE="datadog_extension-$SUFFIX.zip"
-        echo "Publishing $LAYER_FILE"
-
-        $AWS_VAULT_PREFIX .gitlab/scripts/publish_layers.sh
     done
 
 done

--- a/scripts/publish_govcloud_layers.sh
+++ b/scripts/publish_govcloud_layers.sh
@@ -57,7 +57,7 @@ elif [ $ENVIRONMENT = "us1-fed" ]; then
         exit 1
     fi
 
-elif [ $ENVIRONMENT = "fed-us2" ]; then
+elif [ "$ENVIRONMENT" = "fed-us2" ]; then
     AWS_VAULT_ROLE=sso-govcloud-fed-us2-lambda-layer-operator
 
     export ADD_LAYER_VERSION_PERMISSIONS=1


### PR DESCRIPTION
## Summary

- Adds `fed-us2` as a supported `ENVIRONMENT` value in `publish_govcloud_layers.sh`
- Uses the `sso-govcloud-fed-us2-lambda-layer-operator` AWS Vault role
- Matches `us1-fed` behavior: requires explicit `VERSION`, enables layer version permissions, disables auto-bump

## Testing 
Ran the script and published the layers to fed-us2.