### PR TITLE
build(bottlecap): allow cargo build on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 /LICENSE-3rdparty.csv linguist-generated=true
+
+# Set line endings to LF, even on Windows. Otherwise, execution within Docker fails.
+# See https://help.github.com/articles/dealing-with-line-endings/
+*.sh text eol=lf
+*.bash text eol=lf

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -79,10 +79,10 @@ libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "c812
 datadog-opentelemetry = { git = "https://github.com/DataDog/dd-trace-rs", rev = "f51cefc4ad24bec81b38fb2f36b1ed93f21ae913", default-features = false }
 dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "28f796bf767fff56caf08153ade5cd80c8e8f705", default-features = false }
 datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "28f796bf767fff56caf08153ade5cd80c8e8f705", default-features = false }
-libddwaf = { version = "1.28.1", git = "https://github.com/DataDog/libddwaf-rust", rev = "d1534a158d976bd4f747bf9fcc58e0712d2d17fc", default-features = false, features = ["serde"] }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 nix = { version = "0.26", default-features = false, features = ["feature", "fs"] }
+libddwaf = { version = "1.28.1", git = "https://github.com/DataDog/libddwaf-rust", rev = "d1534a158d976bd4f747bf9fcc58e0712d2d17fc", default-features = false, features = ["serde"] }
 
 [dev-dependencies]
 figment = { version = "0.10", default-features = false, features = ["yaml", "env", "test"] }

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -21,7 +21,6 @@ lazy_static = { version = "1.5", default-features = false }
 log = { version = "0.4", default-features = false }
 mime = { version = "0.3", default-features = false }
 multipart = { version = "0.18", default-features = false, features = ["server"] }
-nix = { version = "0.26", default-features = false, features = ["feature", "fs"] }
 ordered_hash_map = { version = "0.4", default-features = false }
 regex = { version = "1.10", default-features = false }
 reqwest = { version = "0.12.11", features = ["json", "http2"], default-features = false }
@@ -81,6 +80,9 @@ datadog-opentelemetry = { git = "https://github.com/DataDog/dd-trace-rs", rev = 
 dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "28f796bf767fff56caf08153ade5cd80c8e8f705", default-features = false }
 datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "28f796bf767fff56caf08153ade5cd80c8e8f705", default-features = false }
 libddwaf = { version = "1.28.1", git = "https://github.com/DataDog/libddwaf-rust", rev = "d1534a158d976bd4f747bf9fcc58e0712d2d17fc", default-features = false, features = ["serde"] }
+
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+nix = { version = "0.26", default-features = false, features = ["feature", "fs"] }
 
 [dev-dependencies]
 figment = { version = "0.10", default-features = false, features = ["yaml", "env", "test"] }

--- a/bottlecap/src/appsec_stub.rs
+++ b/bottlecap/src/appsec_stub.rs
@@ -1,0 +1,87 @@
+//! Windows stub for the `appsec` module. `libddwaf-sys` is Unix-only, so on
+//! Windows we substitute a no-op surface with the same public API.
+#![allow(
+    dead_code,
+    unused_variables,
+    clippy::unused_self,
+    clippy::unused_async,
+    clippy::needless_pass_by_value
+)]
+
+pub mod processor {
+    use bytes::Bytes;
+    use libdd_trace_protobuf::pb::Span;
+
+    use crate::config::Config;
+    use crate::lifecycle::invocation::triggers::IdentifiedTrigger;
+
+    pub mod context {
+        use std::sync::Arc;
+
+        use libdd_trace_protobuf::pb::Span;
+
+        use crate::config::Config;
+        use crate::tags::provider::Provider;
+        use crate::traces::span_pointers::SpanPointer;
+        use crate::traces::trace_processor::SendingTraceProcessor;
+
+        #[derive(Debug, Copy, Clone)]
+        pub struct Context;
+
+        impl Context {
+            pub fn hold_trace(
+                &mut self,
+                _trace: Vec<Span>,
+                _sender: SendingTraceProcessor,
+                _args: HoldArguments,
+            ) {
+            }
+        }
+
+        pub struct HoldArguments {
+            pub config: Arc<Config>,
+            pub tags_provider: Arc<Provider>,
+            pub body_size: usize,
+            pub span_pointers: Option<Vec<SpanPointer>>,
+            pub tracer_header_tags_lang: String,
+            pub tracer_header_tags_lang_version: String,
+            pub tracer_header_tags_lang_interpreter: String,
+            pub tracer_header_tags_lang_vendor: String,
+            pub tracer_header_tags_tracer_version: String,
+            pub tracer_header_tags_container_id: String,
+            pub tracer_header_tags_client_computed_top_level: bool,
+            pub tracer_header_tags_client_computed_stats: bool,
+            pub tracer_header_tags_dropped_p0_traces: usize,
+            pub tracer_header_tags_dropped_p0_spans: usize,
+        }
+    }
+
+    #[derive(Debug, Copy, Clone)]
+    pub struct Processor;
+
+    impl Processor {
+        pub fn new(_cfg: &Config) -> Result<Self, Error> {
+            Err(Error::FeatureDisabled)
+        }
+
+        pub fn service_entry_span_mut(_trace: &mut [Span]) -> Option<&mut Span> {
+            None
+        }
+
+        pub fn process_span(&mut self, _span: &mut Span) -> (bool, Option<&mut context::Context>) {
+            (true, None)
+        }
+
+        pub async fn process_invocation_next(&mut self, _rid: &str, _payload: &IdentifiedTrigger) {}
+
+        pub async fn process_invocation_result(&mut self, _rid: &str, _payload: &Bytes) {}
+    }
+
+    #[derive(thiserror::Error, Debug, Clone, Copy)]
+    pub enum Error {
+        #[error("aap: feature is not enabled")]
+        FeatureDisabled,
+        #[error("aap: feature is not available on this platform")]
+        Unavailable,
+    }
+}

--- a/bottlecap/src/appsec_stub.rs
+++ b/bottlecap/src/appsec_stub.rs
@@ -25,11 +25,11 @@ pub mod processor {
         use crate::traces::span_pointers::SpanPointer;
         use crate::traces::trace_processor::SendingTraceProcessor;
 
-        #[derive(Debug, Copy, Clone)]
+        #[derive(Debug)]
         pub struct Context;
 
         impl Context {
-            pub fn hold_trace(
+            pub(crate) fn hold_trace(
                 &mut self,
                 _trace: Vec<Span>,
                 _sender: SendingTraceProcessor,
@@ -56,7 +56,7 @@ pub mod processor {
         }
     }
 
-    #[derive(Debug, Copy, Clone)]
+    #[derive(Debug)]
     pub struct Processor;
 
     impl Processor {
@@ -77,7 +77,7 @@ pub mod processor {
         pub async fn process_invocation_result(&mut self, _rid: &str, _payload: &Bytes) {}
     }
 
-    #[derive(thiserror::Error, Debug, Clone, Copy)]
+    #[derive(thiserror::Error, Debug)]
     pub enum Error {
         #[error("aap: feature is not enabled")]
         FeatureDisabled,

--- a/bottlecap/src/appsec_stub.rs
+++ b/bottlecap/src/appsec_stub.rs
@@ -61,7 +61,7 @@ pub mod processor {
 
     impl Processor {
         pub fn new(_cfg: &Config) -> Result<Self, Error> {
-            Err(Error::FeatureDisabled)
+            Err(Error::Unavailable)
         }
 
         pub fn service_entry_span_mut(_trace: &mut [Span]) -> Option<&mut Span> {

--- a/bottlecap/src/appsec_stub.rs
+++ b/bottlecap/src/appsec_stub.rs
@@ -5,7 +5,6 @@
     unused_variables,
     clippy::unused_self,
     clippy::unused_async,
-    clippy::needless_pass_by_value
 )]
 
 pub mod processor {
@@ -29,6 +28,7 @@ pub mod processor {
         pub struct Context;
 
         impl Context {
+            #[allow(clippy::needless_pass_by_value)]
             pub(crate) fn hold_trace(
                 &mut self,
                 _trace: Vec<Span>,

--- a/bottlecap/src/lib.rs
+++ b/bottlecap/src/lib.rs
@@ -19,6 +19,11 @@
 // Allow use of the `coverage_nightly` attribute
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
+#[cfg(not(target_os = "windows"))]
+pub mod appsec;
+
+#[cfg(target_os = "windows")]
+#[path = "appsec_stub.rs"]
 pub mod appsec;
 pub mod config;
 pub mod event_bus;

--- a/bottlecap/src/lifecycle/invocation/triggers/body.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/body.rs
@@ -16,6 +16,7 @@ pub struct Body {
 impl Body {
     /// Obtains a reader to the data contained in this [`Body`], decoded from
     /// Base64 if [`Body::is_base64_encoded`] is `true`.
+    #[cfg_attr(target_os = "windows", allow(dead_code))]
     pub(crate) fn reader<'a>(&'a self) -> Result<Option<Box<dyn Read + 'a>>, base64::DecodeError> {
         let Some(body) = &self.body else {
             return Ok(None);

--- a/bottlecap/src/metrics/enhanced/statfs.rs
+++ b/bottlecap/src/metrics/enhanced/statfs.rs
@@ -21,11 +21,8 @@ pub fn statfs_info(path: &str) -> Result<(f64, f64, f64), io::Error> {
 }
 
 #[cfg(target_os = "windows")]
-fn statfs_info(path: &str) -> Result<(f64, f64, f64), io::Error> {
-    Err(io::Error::new(
-        io::ErrorKind::Other,
-        "Cannot get tmp data on Windows",
-    ))
+fn statfs_info(_path: &str) -> Result<(f64, f64, f64), io::Error> {
+    Err(io::Error::other("Cannot get tmp data on Windows"))
 }
 
 pub fn get_tmp_max() -> Result<f64, io::Error> {

--- a/bottlecap/src/metrics/enhanced/statfs.rs
+++ b/bottlecap/src/metrics/enhanced/statfs.rs
@@ -1,8 +1,10 @@
 #![allow(clippy::module_name_repetitions)]
 
 use crate::metrics::enhanced::constants;
+#[cfg(not(target_os = "windows"))]
 use nix::sys::statfs::statfs;
 use std::io;
+#[cfg(not(target_os = "windows"))]
 use std::path::Path;
 
 #[cfg(not(target_os = "windows"))]

--- a/bottlecap/src/metrics/enhanced/statfs.rs
+++ b/bottlecap/src/metrics/enhanced/statfs.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 #[allow(clippy::cast_lossless)]
 /// Returns the block size, total number of blocks, and number of blocks available for the specified directory path.
 ///
-pub fn statfs_info(path: &str) -> Result<(f64, f64, f64), io::Error> {
+fn statfs_info(path: &str) -> Result<(f64, f64, f64), io::Error> {
     let stat = statfs(Path::new(path)).map_err(io::Error::other)?;
     Ok((
         stat.block_size() as f64,

--- a/bottlecap/src/proc/clock.rs
+++ b/bottlecap/src/proc/clock.rs
@@ -1,3 +1,4 @@
+#[cfg(not(target_os = "windows"))]
 use nix::unistd::{SysconfVar, sysconf};
 use std::io;
 

--- a/bottlecap/src/proc/mod.rs
+++ b/bottlecap/src/proc/mod.rs
@@ -395,6 +395,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_os = "windows"))]
     fn test_get_cpu_data() {
         let path = "./tests/proc/stat/valid_stat";
         let cpu_data_result = get_cpu_data_from_path(path_from_root(path).as_str());

--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -388,7 +388,7 @@ mod tests {
         let mut file = File::create(&path).unwrap();
         file.write_all(content.as_bytes()).unwrap();
 
-        let runtime = resolve_runtime_from_proc("", path.to_str().unwrap());
+        let runtime = resolve_runtime_from_proc("", &path.to_string_lossy());
         fs::remove_file(&path).unwrap();
         assert_eq!(runtime, "provided.al2");
     }
@@ -401,7 +401,7 @@ mod tests {
         let mut file = File::create(&path).unwrap();
         file.write_all(content.as_bytes()).unwrap();
 
-        let runtime = resolve_runtime_from_proc("", path.to_str().unwrap());
+        let runtime = resolve_runtime_from_proc("", &path.to_string_lossy());
         fs::remove_file(&path).unwrap();
         assert_eq!(runtime, "provided.al2023");
     }

--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -377,7 +377,8 @@ mod tests {
 
         let runtime =
             resolve_runtime_from_proc(proc_id_folder.parent().unwrap().to_str().unwrap(), "");
-        fs::remove_file(path).unwrap();
+        fs::remove_file(&path).unwrap();
+        fs::remove_dir_all(std::env::temp_dir().join("test-bottlecap")).unwrap();
         assert_eq!(runtime, "java123");
     }
 

--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -294,7 +294,6 @@ mod tests {
     use std::collections::HashMap;
     use std::fs::File;
     use std::io::Write;
-    use std::path::Path;
 
     #[test]
     fn test_new_from_config() {
@@ -368,8 +367,8 @@ mod tests {
 
     #[test]
     fn test_resolve_runtime() {
-        let proc_id_folder = Path::new("/tmp/test-bottlecap/proc_root/123");
-        fs::create_dir_all(proc_id_folder).unwrap();
+        let proc_id_folder = std::env::temp_dir().join("test-bottlecap/proc_root/123");
+        fs::create_dir_all(&proc_id_folder).unwrap();
         let path = proc_id_folder.join("environ");
         let content = "\0NAME =\"AmazonLinux\"\0V=\"2\0AWS_EXECUTION_ENV=\"AWS_Lambda_java123\"\0somethingelse=\"abd\0\"";
 
@@ -384,26 +383,26 @@ mod tests {
 
     #[test]
     fn test_resolve_provided_al2() {
-        let path = "/tmp/test-os-release1";
+        let path = std::env::temp_dir().join("test-os-release1");
         let content = "NAME =\"Amazon Linux\"\nVERSION=\"2\nPRETTY_NAME=\"Amazon Linux 2\"";
-        let mut file = File::create(path).unwrap();
+        let mut file = File::create(&path).unwrap();
         file.write_all(content.as_bytes()).unwrap();
 
-        let runtime = resolve_runtime_from_proc("", path);
-        fs::remove_file(path).unwrap();
+        let runtime = resolve_runtime_from_proc("", path.to_str().unwrap());
+        fs::remove_file(&path).unwrap();
         assert_eq!(runtime, "provided.al2");
     }
 
     #[test]
     fn test_resolve_provided_al2023() {
-        let path = "/tmp/test-os-release2";
+        let path = std::env::temp_dir().join("test-os-release2");
         let content =
             "NAME=\"Amazon Linux\"\nVERSION=\"2\nPRETTY_NAME=\"Amazon Linux 2023.4.20240429\"";
-        let mut file = File::create(path).unwrap();
+        let mut file = File::create(&path).unwrap();
         file.write_all(content.as_bytes()).unwrap();
 
-        let runtime = resolve_runtime_from_proc("", path);
-        fs::remove_file(path).unwrap();
+        let runtime = resolve_runtime_from_proc("", path.to_str().unwrap());
+        fs::remove_file(&path).unwrap();
         assert_eq!(runtime, "provided.al2023");
     }
 

--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -377,9 +377,9 @@ mod tests {
 
         let runtime =
             resolve_runtime_from_proc(proc_id_folder.parent().unwrap().to_str().unwrap(), "");
+        assert_eq!(runtime, "java123");
         fs::remove_file(&path).unwrap();
         fs::remove_dir_all(std::env::temp_dir().join("test-bottlecap")).unwrap();
-        assert_eq!(runtime, "java123");
     }
 
     #[test]

--- a/bottlecap/tests/appsec_processor_test.rs
+++ b/bottlecap/tests/appsec_processor_test.rs
@@ -1,3 +1,6 @@
+// appsec is stubbed out on Windows; this test exercises the real libddwaf-backed API.
+#![cfg(not(target_os = "windows"))]
+
 use std::collections::HashMap;
 use std::num::NonZero;
 use std::path::PathBuf;


### PR DESCRIPTION
## Summary

Enables `cargo build`, `cargo clippy`, and `cargo test` to succeed on `x86_64-pc-windows-msvc` for local development, with zero change to Linux build artifacts or runtime behavior. Useful for editing bottlecap from Windows without spinning up WSL or a VM.

### What changed

**Build system:**
- `nix` and `libddwaf` dependencies are now target-conditional (Unix-only). Both have Unix-only build scripts that panic on Windows.
- On Windows, `appsec` resolves to a no-op stub (`bottlecap/src/appsec_stub.rs`) that mirrors the public API used outside the module, so callers in `main.rs`, `traces/trace_processor.rs`, `traces/trace_agent.rs`, and `proxy/interceptor.rs` compile unchanged. The stub closely mirrors the real module: matching derives on `Processor`/`Context`/`Error`, `pub(crate)` visibility on `hold_trace`, and `Processor::new` returns `Error::Unavailable` rather than a phantom processor.
- `*.sh` / `*.bash` pinned to LF line endings so scripts checked out on Windows still execute inside Linux Docker containers.

**Code cleanups surfaced by Windows builds:**
- `nix` imports in `proc/clock.rs` and `metrics/enhanced/statfs.rs` are `#[cfg]`-gated to match already-gated function bodies.
- `Body::reader` marked `#[cfg_attr(target_os = "windows", allow(dead_code))]` since its only callers are inside the stubbed-out appsec module.
- `statfs_info` Windows stub: prefix unused parameter with `_` and switch to `io::Error::other` per `clippy::io_other_error`.

**Test fixes:**
- `tests/appsec_processor_test.rs` gated off Windows since it drives the real libddwaf-backed API which is not present in the stub.
- The three `tags::lambda::tags::tests::test_resolve_*` tests switched from hard-coded Linux temp paths to `std::env::temp_dir()` to avoid a bootstrap race on Windows. Safer on Linux too (temp path no longer shared via filesystem side effects between tests). Paths are rendered with `to_string_lossy` to tolerate non-UTF-8 temp directories, and `test_resolve_runtime` now cleans up the file it creates.
- `proc::tests::test_get_cpu_data` gated off Windows since it assumes `SC_CLK_TCK = 100`, which is Linux-specific.

### What did not change

- No runtime behavior on Linux/Lambda (the only supported deployment target).
- No CI jobs added. Windows remains unsupported for CI.
- Go extension, build scripts, publishing pipelines: untouched.

## Testing

Manually validated on `x86_64-pc-windows-msvc` from a clean state:

- `cargo build` — success
- `cargo clippy --workspace` — success, no warnings
- `cargo fmt --all -- --check` — success
- `cargo test --lib` — **511 passed, 0 failed**
- `cargo test --no-run` — all integration test binaries compile

- [x] validate `cargo build` / `cargo clippy` / `cargo test` on Linux before merging. No regressions expected because every gate is `#[cfg(not(target_os = "windows"))]` or `#[cfg_attr(target_os = "windows", ...)]`, so Linux code paths and the dependency graph should be byte-identical to before, but this has not been verified by me directly.

## Out of scope

- Runtime behavior on Windows is undefined. `appsec` and filesystem metrics are no-ops. This is explicitly acceptable, the goal is "build for local development."
- No Windows CI job added.

> *"Turns out making a Linux-only Lambda extension build on Windows is mostly a matter of politely asking libddwaf to sit this one out."* — Claude 🤖

