### PR TITLE
chore(codeowners): add `apm-serverless` as co-owner of `bottlecap/src/traces/`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,5 @@
 
 .github/chainguard/serverless-init-ci-publish.sts.yaml @DataDog/serverless
 .github/workflows/publish-serverless-init-to-ghcr.yml @DataDog/serverless
+
+bottlecap/src/traces/ @DataDog/serverless-aws @DataDog/apm-serverless

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @DataDog/serverless


### PR DESCRIPTION
## Overview

- Add `@DataDog/apm-serverless` as co-owner of `bottlecap/src/traces/` alongside `@DataDog/serverless-aws` in `.github/CODEOWNERS`.
- Delete the root `CODEOWNERS` file; the one in `.github/` takes precedence, so the root file was dead weight.

## Testing

- Verified via GitHub UI that the `.github/CODEOWNERS` rules resolve correctly for files under `bottlecap/src/traces/`.

> *"Two teams, one codepath — may your review notifications be ever balanced."* — Claude 🤖