### PR TITLE
fix: bump rustls-webpki to 0.103.13 to fix RUSTSEC-2026-0104

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -3261,9 +3261,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

- Bumps `rustls-webpki` from `0.103.12` to `0.103.13` in `Cargo.lock`
- Fixes RUSTSEC-2026-0104: reachable panic in certificate revocation list parsing
- Advisory published 2026-04-22; the previous cargo audit fix PR (#1190) predated it

🤖 Generated with [Claude Code](https://claude.com/claude-code)