### PR TITLE
refactor(stats): take `stats_url` as a `StatsFlusher::new` parameter

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -1131,6 +1131,7 @@ fn start_trace_agent(
         stats_aggregator.clone(),
         Arc::clone(config),
         trace_http_client.clone(),
+        libdd_trace_utils::config_utils::trace_stats_url(&config.site),
     ));
 
     let stats_processor = Arc::new(stats_processor::ServerlessStatsProcessor {});

--- a/bottlecap/src/traces/stats_flusher.rs
+++ b/bottlecap/src/traces/stats_flusher.rs
@@ -14,13 +14,14 @@ use crate::traces::stats_aggregator::StatsAggregator;
 use dogstatsd::api_key::ApiKeyFactory;
 use libdd_common::Endpoint;
 use libdd_trace_protobuf::pb;
-use libdd_trace_utils::{config_utils::trace_stats_url, stats_utils};
+use libdd_trace_utils::stats_utils;
 use tracing::{debug, error};
 
 pub struct StatsFlusher {
     aggregator: Arc<Mutex<StatsAggregator>>,
     config: Arc<config::Config>,
     api_key_factory: Arc<ApiKeyFactory>,
+    stats_url: String,
     endpoint: OnceCell<Endpoint>,
     http_client: HttpClient,
 }
@@ -32,11 +33,13 @@ impl StatsFlusher {
         aggregator: Arc<Mutex<StatsAggregator>>,
         config: Arc<config::Config>,
         http_client: HttpClient,
+        stats_url: String,
     ) -> Self {
         StatsFlusher {
             aggregator,
             config,
             api_key_factory,
+            stats_url,
             endpoint: OnceCell::new(),
             http_client,
         }
@@ -64,9 +67,8 @@ impl StatsFlusher {
             .endpoint
             .get_or_init({
                 move || async move {
-                    let stats_url = trace_stats_url(&self.config.site);
                     Endpoint {
-                        url: hyper::Uri::from_str(&stats_url)
+                        url: hyper::Uri::from_str(&self.stats_url)
                             .expect("can't make URI from stats url, exiting"),
                         api_key: Some(api_key_clone.into()),
                         timeout_ms: self.config.flush_timeout * S_TO_MS,
@@ -92,8 +94,6 @@ impl StatsFlusher {
             }
         };
 
-        let stats_url = trace_stats_url(&self.config.site);
-
         for attempt in 1..=FLUSH_RETRY_COUNT {
             let start = std::time::Instant::now();
             let resp = stats_utils::send_stats_payload_with_client(
@@ -108,14 +108,16 @@ impl StatsFlusher {
             match resp {
                 Ok(()) => {
                     debug!(
-                        "STATS | Successfully flushed stats to {stats_url} in {} ms (attempt {attempt}/{FLUSH_RETRY_COUNT})",
+                        "STATS | Successfully flushed stats to {} in {} ms (attempt {attempt}/{FLUSH_RETRY_COUNT})",
+                        endpoint.url,
                         elapsed.as_millis()
                     );
                     return None;
                 }
                 Err(e) => {
                     debug!(
-                        "STATS | Failed to send stats to {stats_url} in {} ms (attempt {attempt}/{FLUSH_RETRY_COUNT}): {e:?}",
+                        "STATS | Failed to send stats to {} in {} ms (attempt {attempt}/{FLUSH_RETRY_COUNT}): {e:?}",
+                        endpoint.url,
                         elapsed.as_millis()
                     );
                 }


### PR DESCRIPTION
## Summary of changes

Refactor `StatsFlusher::new` to accept a `stats_url: String` parameter instead of deriving the URL internally from `config.site`.

## Reason for change

1. **Removes internal duplication** — `trace_stats_url(&self.config.site)` was being called in two separate places inside `StatsFlusher` (in `get_or_init` and again in the retry loop). It's now computed once at the call site.
2. **Enables future flexibility** — callers can supply any URL (e.g. a custom endpoint or test harness) without `StatsFlusher` needing to know about it.
3. **Better separation of concerns** — `StatsFlusher` no longer owns URL resolution; it simply uses the URL it's given. This mirrors how `TraceFlusher` already works, where the URL comes from outside via `SendData`'s embedded `Endpoint`.

## Implementation details

- Added a `stats_url: String` field to `StatsFlusher` and a corresponding parameter to `StatsFlusher::new`.
- Removed the `trace_stats_url` import from `stats_flusher.rs`; the call now lives in `main.rs::start_trace_agent`.
- Replaced the two internal `trace_stats_url(&self.config.site)` calls with `self.stats_url`.
- Retry-loop debug logs now report `endpoint.url` so they reflect the URL actually contacted instead of a re-derived site URL.

## Test coverage

No new tests — this is a pure refactor of an internal constructor signature with no behavior change. Verified existing checks pass:

- [x] `cargo build` on the bottlecap crate
- [x] `cargo check --workspace` — clean
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --features default` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo nextest run --workspace` — 526/526 passed