### PR TITLE
fix(bottlecap): thread flush_timeout into HTTP fallback client

### DIFF
--- a/bottlecap/src/http.rs
+++ b/bottlecap/src/http.rs
@@ -18,8 +18,14 @@ pub fn get_client(config: &Arc<config::Config>) -> reqwest::Client {
             "Unable to parse proxy configuration: {}, no proxy will be used",
             e
         );
-        //TODO this fallback doesn't respect the flush timeout
-        reqwest::Client::new()
+        create_reqwest_client_builder()
+            .ok()
+            .and_then(|b| {
+                b.timeout(Duration::from_secs(config.flush_timeout))
+                    .build()
+                    .ok()
+            })
+            .unwrap_or_else(reqwest::Client::new)
     })
 }
 
@@ -144,4 +150,20 @@ pub fn headers_to_map(headers: &HeaderMap) -> HashMap<String, String> {
             )
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_client_fallback_with_bad_proxy_does_not_panic() {
+        let config = Arc::new(config::Config {
+            proxy_https: Some("://unparseable-proxy".to_string()),
+            flush_timeout: 5,
+            ..config::Config::default()
+        });
+        // Should not panic; fallback path must return a usable client.
+        let _client = get_client(&config);
+    }
 }


### PR DESCRIPTION
## Summary

- The fallback path in `get_client` (`bottlecap/src/http.rs`) called `reqwest::Client::new()` when the configured proxy URI was unparseable, producing a client with no timeout — requests could block indefinitely regardless of `flush_timeout`.
- Replaced the bare `Client::new()` with `create_reqwest_client_builder().ok().and_then(|b| b.timeout(Duration::from_secs(config.flush_timeout)).build().ok()).unwrap_or_else(reqwest::Client::new)` so the fallback client honours the configured timeout.
- Removed the `//TODO` comment and added a unit test that forces the fallback via an unparseable `proxy_https` value.

## Reviewer notes

- The inner `unwrap_or_else(reqwest::Client::new)` is a last-resort safety net for the case where `create_reqwest_client_builder()` itself fails on a FIPS build; the pre-existing infinite-timeout behaviour is preserved only for that edge case.
- Proxy / keepalive / HTTP2 / cert settings are intentionally omitted from the fallback builder — those settings are irrelevant when proxy parsing already failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)