### PR TITLE
chore(tags): bump extension version to 97-next

### DIFF
--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -45,7 +45,7 @@ const FUNCTION_TAGS_KEY: &str = "_dd.tags.function";
 // TODO(astuyve) decide what to do with the version
 const EXTENSION_VERSION_KEY: &str = "dd_extension_version";
 // TODO(duncanista) figure out a better way to not hardcode this
-pub const EXTENSION_VERSION: &str = "96-next";
+pub const EXTENSION_VERSION: &str = "97-next";
 
 const REGION_KEY: &str = "region";
 const ACCOUNT_ID_KEY: &str = "account_id";


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/SVLS-9025

- Update EXTENSION_VERSION constant from 96-next to 97-next
- Increments the extension version for the next release

Rationale: Version bump for next extension release cycle

This commit made by [/dd:git:commit:quick](https://github.com/DataDog/claude-marketplace/tree/main/dd/commands/git/commit/quick.md)


## Overview

## Testing 