### PR TITLE
chore(deps): bump libdatadog to db05e1f and adapt to HttpClientTrait API

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -779,7 +779,7 @@ dependencies = [
 [[package]]
 name = "datadog-fips"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=8817486d6ec7eb7101c4f349b3d2b75cae701740#8817486d6ec7eb7101c4f349b3d2b75cae701740"
+source = "git+https://github.com/DataDog/serverless-components?rev=5b68f50f49c9defbfed4d25bd621e2a86405a972#5b68f50f49c9defbfed4d25bd621e2a86405a972"
 dependencies = [
  "reqwest",
  "rustls",
@@ -921,7 +921,7 @@ dependencies = [
 [[package]]
 name = "dogstatsd"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=8817486d6ec7eb7101c4f349b3d2b75cae701740#8817486d6ec7eb7101c4f349b3d2b75cae701740"
+source = "git+https://github.com/DataDog/serverless-components?rev=5b68f50f49c9defbfed4d25bd621e2a86405a972#5b68f50f49c9defbfed4d25bd621e2a86405a972"
 dependencies = [
  "datadog-protos",
  "ddsketch-agent",

--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -1867,7 +1867,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 [[package]]
 name = "libdd-capabilities"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
+source = "git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57#db05e1f8408a76075efb37ecec544d2e74217e57"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1878,7 +1878,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities-impl"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
+source = "git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57#db05e1f8408a76075efb37ecec544d2e74217e57"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -1921,7 +1921,7 @@ dependencies = [
 [[package]]
 name = "libdd-common"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
+source = "git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57#db05e1f8408a76075efb37ecec544d2e74217e57"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1994,7 +1994,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
+source = "git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57#db05e1f8408a76075efb37ecec544d2e74217e57"
 dependencies = [
  "prost 0.14.3",
 ]
@@ -2016,7 +2016,7 @@ dependencies = [
 [[package]]
 name = "libdd-shared-runtime"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
+source = "git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57#db05e1f8408a76075efb37ecec544d2e74217e57"
 dependencies = [
  "async-trait",
  "futures",
@@ -2064,7 +2064,7 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
+source = "git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57#db05e1f8408a76075efb37ecec544d2e74217e57"
 dependencies = [
  "serde",
 ]
@@ -2082,7 +2082,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
+source = "git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57#db05e1f8408a76075efb37ecec544d2e74217e57"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf 3.0.1",
@@ -2091,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-obfuscation"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
+source = "git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57#db05e1f8408a76075efb37ecec544d2e74217e57"
 dependencies = [
  "anyhow",
  "fluent-uri",
@@ -2119,7 +2119,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-protobuf"
 version = "3.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
+source = "git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57#db05e1f8408a76075efb37ecec544d2e74217e57"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -2141,7 +2141,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-stats"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
+source = "git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57#db05e1f8408a76075efb37ecec544d2e74217e57"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2150,7 +2150,7 @@ dependencies = [
  "libdd-capabilities",
  "libdd-capabilities-impl",
  "libdd-common 4.0.0",
- "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0)",
+ "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57)",
  "libdd-shared-runtime",
  "libdd-trace-protobuf 3.0.1",
  "libdd-trace-utils 3.0.1",
@@ -2192,7 +2192,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-utils"
 version = "3.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
+source = "git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57#db05e1f8408a76075efb37ecec544d2e74217e57"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2207,7 +2207,7 @@ dependencies = [
  "libdd-capabilities",
  "libdd-capabilities-impl",
  "libdd-common 4.0.0",
- "libdd-tinybytes 1.1.0 (git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0)",
+ "libdd-tinybytes 1.1.0 (git+https://github.com/DataDog/libdatadog?rev=db05e1f8408a76075efb37ecec544d2e74217e57)",
  "libdd-trace-normalization 2.0.0",
  "libdd-trace-protobuf 3.0.1",
  "prost 0.14.3",

--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -779,7 +779,7 @@ dependencies = [
 [[package]]
 name = "datadog-fips"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=28f796bf767fff56caf08153ade5cd80c8e8f705#28f796bf767fff56caf08153ade5cd80c8e8f705"
+source = "git+https://github.com/DataDog/serverless-components?rev=8817486d6ec7eb7101c4f349b3d2b75cae701740#8817486d6ec7eb7101c4f349b3d2b75cae701740"
 dependencies = [
  "reqwest",
  "rustls",
@@ -921,7 +921,7 @@ dependencies = [
 [[package]]
 name = "dogstatsd"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=28f796bf767fff56caf08153ade5cd80c8e8f705#28f796bf767fff56caf08153ade5cd80c8e8f705"
+source = "git+https://github.com/DataDog/serverless-components?rev=8817486d6ec7eb7101c4f349b3d2b75cae701740#8817486d6ec7eb7101c4f349b3d2b75cae701740"
 dependencies = [
  "datadog-protos",
  "ddsketch-agent",

--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -468,6 +468,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bottlecap"
 version = "0.1.0"
 dependencies = [
@@ -488,6 +494,7 @@ dependencies = [
  "futures",
  "hex",
  "hmac",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "httpmock",
@@ -498,12 +505,13 @@ dependencies = [
  "indexmap",
  "itertools 0.14.0",
  "lazy_static",
- "libdd-common 1.1.0",
- "libdd-trace-normalization 1.0.0",
+ "libdd-capabilities",
+ "libdd-common 4.0.0",
+ "libdd-trace-normalization 2.0.0",
  "libdd-trace-obfuscation",
- "libdd-trace-protobuf 1.0.0",
- "libdd-trace-stats 1.0.0",
- "libdd-trace-utils 1.0.0",
+ "libdd-trace-protobuf 3.0.1",
+ "libdd-trace-stats 2.0.0",
+ "libdd-trace-utils 3.0.1",
  "libddwaf",
  "log",
  "mime",
@@ -1066,6 +1074,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
 ]
 
 [[package]]
@@ -1846,37 +1865,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
-name = "libdd-common"
-version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09#c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09"
+name = "libdd-capabilities"
+version = "1.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
 dependencies = [
  "anyhow",
  "bytes",
- "cc",
- "const_format",
- "futures",
- "futures-core",
- "futures-util",
- "hex",
  "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls",
- "hyper-util",
- "libc",
- "nix 0.29.0",
- "pin-project",
- "regex",
- "rustls",
- "rustls-native-certs",
- "serde",
- "static_assertions",
  "thiserror 1.0.69",
- "tokio",
- "tokio-rustls",
- "tower-service",
- "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "libdd-capabilities-impl"
+version = "1.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
+dependencies = [
+ "bytes",
+ "http 1.4.0",
+ "http-body-util",
+ "libdd-capabilities",
+ "libdd-common 4.0.0",
 ]
 
 [[package]]
@@ -1911,6 +1919,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "libdd-common"
+version = "4.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "cc",
+ "const_format",
+ "futures",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls",
+ "hyper-util",
+ "libc",
+ "nix 0.29.0",
+ "pin-project",
+ "regex",
+ "rustls",
+ "rustls-native-certs",
+ "serde",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "libdd-data-pipeline"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1923,7 +1965,7 @@ dependencies = [
  "http 1.4.0",
  "http-body-util",
  "libdd-common 2.0.1",
- "libdd-ddsketch 1.0.1",
+ "libdd-ddsketch 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-dogstatsd-client",
  "libdd-telemetry",
  "libdd-tinybytes 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1942,8 +1984,9 @@ dependencies = [
 
 [[package]]
 name = "libdd-ddsketch"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09#c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b31b2435e2e8eaba0e35a96df3e1407b68f8ef76055383ceb2ba5a09e5a1bb5"
 dependencies = [
  "prost 0.14.3",
 ]
@@ -1951,8 +1994,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b31b2435e2e8eaba0e35a96df3e1407b68f8ef76055383ceb2ba5a09e5a1bb5"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
 dependencies = [
  "prost 0.14.3",
 ]
@@ -1972,6 +2014,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "libdd-shared-runtime"
+version = "0.1.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
+dependencies = [
+ "async-trait",
+ "futures",
+ "libdd-capabilities",
+ "libdd-common 4.0.0",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "libdd-telemetry"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,7 +2041,7 @@ dependencies = [
  "http-body-util",
  "libc",
  "libdd-common 2.0.1",
- "libdd-ddsketch 1.0.1",
+ "libdd-ddsketch 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_json",
  "sys-info",
@@ -2008,18 +2064,9 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09#c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "libdd-trace-normalization"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09#c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09"
-dependencies = [
- "anyhow",
- "libdd-trace-protobuf 1.0.0",
 ]
 
 [[package]]
@@ -2033,30 +2080,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "libdd-trace-obfuscation"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09#c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09"
+name = "libdd-trace-normalization"
+version = "2.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
 dependencies = [
  "anyhow",
- "libdd-common 1.1.0",
- "libdd-trace-protobuf 1.0.0",
- "libdd-trace-utils 1.0.0",
+ "libdd-trace-protobuf 3.0.1",
+]
+
+[[package]]
+name = "libdd-trace-obfuscation"
+version = "2.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
+dependencies = [
+ "anyhow",
+ "fluent-uri",
+ "libdd-common 4.0.0",
+ "libdd-trace-protobuf 3.0.1",
+ "libdd-trace-utils 3.0.1",
  "log",
  "percent-encoding",
  "regex",
  "serde",
  "serde_json",
- "url",
-]
-
-[[package]]
-name = "libdd-trace-protobuf"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09#c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09"
-dependencies = [
- "prost 0.14.3",
- "serde",
- "serde_bytes",
 ]
 
 [[package]]
@@ -2071,14 +2117,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "libdd-trace-stats"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09#c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09"
+name = "libdd-trace-protobuf"
+version = "3.0.1"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
 dependencies = [
- "hashbrown 0.15.5",
- "libdd-ddsketch 1.0.0",
- "libdd-trace-protobuf 1.0.0",
- "libdd-trace-utils 1.0.0",
+ "prost 0.14.3",
+ "serde",
+ "serde_bytes",
 ]
 
 [[package]]
@@ -2088,38 +2133,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea447dc8a5d84c6b5eb6ea877c4fea4149fd29f6b45fcfc5cfd7edf82a18e056"
 dependencies = [
  "hashbrown 0.15.5",
- "libdd-ddsketch 1.0.1",
+ "libdd-ddsketch 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libdd-trace-protobuf 2.0.0",
  "libdd-trace-utils 2.0.2",
 ]
 
 [[package]]
-name = "libdd-trace-utils"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09#c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09"
+name = "libdd-trace-stats"
+version = "2.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
 dependencies = [
  "anyhow",
- "bytes",
- "flate2",
- "futures",
+ "async-trait",
+ "hashbrown 0.15.5",
  "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "indexmap",
- "libdd-common 1.1.0",
- "libdd-tinybytes 1.1.0 (git+https://github.com/DataDog/libdatadog?rev=c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09)",
- "libdd-trace-normalization 1.0.0",
- "libdd-trace-protobuf 1.0.0",
- "prost 0.14.3",
- "rand 0.8.6",
- "rmp",
+ "libdd-capabilities",
+ "libdd-capabilities-impl",
+ "libdd-common 4.0.0",
+ "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0)",
+ "libdd-shared-runtime",
+ "libdd-trace-protobuf 3.0.1",
+ "libdd-trace-utils 3.0.1",
  "rmp-serde",
- "rmpv",
  "serde",
- "serde_json",
  "tokio",
+ "tokio-util",
  "tracing",
- "zstd",
 ]
 
 [[package]]
@@ -2148,6 +2187,39 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "libdd-trace-utils"
+version = "3.0.1"
+source = "git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0#0a70516d66314efdd7115644b0da4b3b3e0958e0"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bytes",
+ "flate2",
+ "futures",
+ "getrandom 0.2.17",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "indexmap",
+ "libdd-capabilities",
+ "libdd-capabilities-impl",
+ "libdd-common 4.0.0",
+ "libdd-tinybytes 1.1.0 (git+https://github.com/DataDog/libdatadog?rev=0a70516d66314efdd7115644b0da4b3b3e0958e0)",
+ "libdd-trace-normalization 2.0.0",
+ "libdd-trace-protobuf 3.0.1",
+ "prost 0.14.3",
+ "rand 0.8.6",
+ "rmp",
+ "rmp-serde",
+ "rmpv",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "zstd",
 ]
 
 [[package]]
@@ -3051,6 +3123,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3449,6 +3541,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -82,8 +82,8 @@ libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog", rev
 libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "db05e1f8408a76075efb37ecec544d2e74217e57", default-features = false }
 libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "db05e1f8408a76075efb37ecec544d2e74217e57", default-features = false }
 datadog-opentelemetry = { git = "https://github.com/DataDog/dd-trace-rs", rev = "f51cefc4ad24bec81b38fb2f36b1ed93f21ae913", default-features = false }
-dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "8817486d6ec7eb7101c4f349b3d2b75cae701740", default-features = false }
-datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "8817486d6ec7eb7101c4f349b3d2b75cae701740", default-features = false }
+dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "5b68f50f49c9defbfed4d25bd621e2a86405a972", default-features = false }
+datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "5b68f50f49c9defbfed4d25bd621e2a86405a972", default-features = false }
 libddwaf = { version = "1.28.1", git = "https://github.com/DataDog/libddwaf-rust", rev = "d1534a158d976bd4f747bf9fcc58e0712d2d17fc", default-features = false, features = ["serde"] }
 
 [dev-dependencies]

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -82,8 +82,8 @@ libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog",  re
 libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0"  }
 libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0"  }
 datadog-opentelemetry = { git = "https://github.com/DataDog/dd-trace-rs", rev = "f51cefc4ad24bec81b38fb2f36b1ed93f21ae913", default-features = false }
-dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "28f796bf767fff56caf08153ade5cd80c8e8f705", default-features = false }
-datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "28f796bf767fff56caf08153ade5cd80c8e8f705", default-features = false }
+dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "8817486d6ec7eb7101c4f349b3d2b75cae701740", default-features = false }
+datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "8817486d6ec7eb7101c4f349b3d2b75cae701740", default-features = false }
 libddwaf = { version = "1.28.1", git = "https://github.com/DataDog/libddwaf-rust", rev = "d1534a158d976bd4f747bf9fcc58e0712d2d17fc", default-features = false, features = ["serde"] }
 
 [dev-dependencies]

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -12,6 +12,7 @@ chrono = { version = "0.4", features = ["serde", "std", "now"], default-features
 cookie = { version = "0.18", default-features = false }
 figment = { version = "0.10", default-features = false, features = ["yaml", "env"] }
 fnv = { version = "1.0", default-features = false }
+http = { version = "1" }
 hyper = { version = "1.6", default-features = false, features = ["server"] }
 hyper-util = { version = "0.1.16", features = ["http1", "client", "client-legacy"] }
 http-body = { version = "1", default-features = false }
@@ -73,12 +74,13 @@ indexmap = {version = "2.11.0", default-features = false}
 # be found in the clippy.toml file adjacent to this Cargo.toml.
 datadog-protos = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "f863626dbfe3c59bb390985fa6530b0621c2a0a2"}
 ddsketch-agent = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "f863626dbfe3c59bb390985fa6530b0621c2a0a2"}
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09" }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09"  }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09" , features = ["mini_agent"] }
-libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog",  rev = "c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09" }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09"  }
-libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "c8121f422d2c8d219f8d421ff3cdb1fcbe9e8b09"  }
+libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0" }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0"  }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0" , features = ["mini_agent"] }
+libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog",  rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0"  }
+libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0"  }
 datadog-opentelemetry = { git = "https://github.com/DataDog/dd-trace-rs", rev = "f51cefc4ad24bec81b38fb2f36b1ed93f21ae913", default-features = false }
 dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "28f796bf767fff56caf08153ade5cd80c8e8f705", default-features = false }
 datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "28f796bf767fff56caf08153ade5cd80c8e8f705", default-features = false }

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -74,13 +74,13 @@ indexmap = {version = "2.11.0", default-features = false}
 # be found in the clippy.toml file adjacent to this Cargo.toml.
 datadog-protos = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "f863626dbfe3c59bb390985fa6530b0621c2a0a2"}
 ddsketch-agent = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "f863626dbfe3c59bb390985fa6530b0621c2a0a2"}
-libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0" }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0", default-features = false }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0", default-features = false, features = ["mini_agent"] }
-libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0" }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0", default-features = false }
-libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0", default-features = false }
+libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "db05e1f8408a76075efb37ecec544d2e74217e57" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "db05e1f8408a76075efb37ecec544d2e74217e57", default-features = false }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "db05e1f8408a76075efb37ecec544d2e74217e57" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "db05e1f8408a76075efb37ecec544d2e74217e57", default-features = false, features = ["mini_agent"] }
+libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog", rev = "db05e1f8408a76075efb37ecec544d2e74217e57" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "db05e1f8408a76075efb37ecec544d2e74217e57", default-features = false }
+libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "db05e1f8408a76075efb37ecec544d2e74217e57", default-features = false }
 datadog-opentelemetry = { git = "https://github.com/DataDog/dd-trace-rs", rev = "f51cefc4ad24bec81b38fb2f36b1ed93f21ae913", default-features = false }
 dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "8817486d6ec7eb7101c4f349b3d2b75cae701740", default-features = false }
 datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "8817486d6ec7eb7101c4f349b3d2b75cae701740", default-features = false }
@@ -136,6 +136,7 @@ fips = [
     "libdd-common/fips",
     "libdd-trace-utils/fips",
     "libdd-trace-obfuscation/fips",
+    "libdd-trace-stats/fips",
     "datadog-fips/fips",
     "libddwaf/fips",
     "reqwest/rustls-tls-native-roots-no-provider",

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -75,12 +75,12 @@ indexmap = {version = "2.11.0", default-features = false}
 datadog-protos = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "f863626dbfe3c59bb390985fa6530b0621c2a0a2"}
 ddsketch-agent = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "f863626dbfe3c59bb390985fa6530b0621c2a0a2"}
 libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0" }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0" }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0"  }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0" , features = ["mini_agent"] }
-libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog",  rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0" }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0"  }
-libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0"  }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0", default-features = false }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0", default-features = false, features = ["mini_agent"] }
+libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0", default-features = false }
+libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "0a70516d66314efdd7115644b0da4b3b3e0958e0", default-features = false }
 datadog-opentelemetry = { git = "https://github.com/DataDog/dd-trace-rs", rev = "f51cefc4ad24bec81b38fb2f36b1ed93f21ae913", default-features = false }
 dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "8817486d6ec7eb7101c4f349b3d2b75cae701740", default-features = false }
 datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "8817486d6ec7eb7101c4f349b3d2b75cae701740", default-features = false }
@@ -124,10 +124,18 @@ opt-level = 3
 tikv-jemallocator = "0.5"
 
 [features]
-default = ["reqwest/rustls-tls-native-roots", "datadog-fips/default" ]
+default = [
+    "reqwest/rustls-tls-native-roots",
+    "datadog-fips/default",
+    "libdd-common/https",
+    "libdd-trace-utils/https",
+    "libdd-trace-obfuscation/https",
+    "libdd-trace-stats/https",
+]
 fips = [
     "libdd-common/fips",
     "libdd-trace-utils/fips",
+    "libdd-trace-obfuscation/fips",
     "datadog-fips/fips",
     "libddwaf/fips",
     "reqwest/rustls-tls-native-roots-no-provider",

--- a/bottlecap/LICENSE-3rdparty.csv
+++ b/bottlecap/LICENSE-3rdparty.csv
@@ -19,6 +19,7 @@ bit-set,https://github.com/contain-rs/bit-set,Apache-2.0 OR MIT,Alexis Beingessn
 bit-vec,https://github.com/contain-rs/bit-vec,Apache-2.0 OR MIT,Alexis Beingessner <a.beingessner@gmail.com>
 bitflags,https://github.com/bitflags/bitflags,MIT OR Apache-2.0,The Rust Project Developers
 block-buffer,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developers
+borrow-or-share,https://github.com/yescallop/borrow-or-share,MIT-0,Scallop Ye <yescallop@gmail.com>
 buf_redux,https://github.com/abonander/buf_redux,MIT OR Apache-2.0,Austin Bonander <austin.bonander@gmail.com>
 bumpalo,https://github.com/fitzgen/bumpalo,MIT OR Apache-2.0,Nick Fitzgerald <fitzgen@gmail.com>
 bytemuck,https://github.com/Lokathor/bytemuck,Zlib OR Apache-2.0 OR MIT,Lokathor <zefria@gmail.com>
@@ -57,6 +58,7 @@ figment,https://github.com/SergioBenitez/Figment,MIT OR Apache-2.0,Sergio Benite
 find-msvc-tools,https://github.com/rust-lang/cc-rs,MIT OR Apache-2.0,The find-msvc-tools Authors
 flate2,https://github.com/rust-lang/flate2-rs,MIT OR Apache-2.0,"Alex Crichton <alex@alexcrichton.com>, Josh Triplett <josh@joshtriplett.org>"
 float-cmp,https://github.com/mikedilger/float-cmp,MIT,Mike Dilger <mike@mikedilger.com>
+fluent-uri,https://github.com/yescallop/fluent-uri-rs,MIT,Scallop Ye <yescallop@gmail.com>
 fnv,https://github.com/servo/rust-fnv,Apache-2.0  OR  MIT,Alex Crichton <alex@alexcrichton.com>
 foldhash,https://github.com/orlp/foldhash,Zlib,Orson Peters <orsonpeters@gmail.com>
 form_urlencoded,https://github.com/servo/rust-url,MIT OR Apache-2.0,The rust-url developers
@@ -109,10 +111,13 @@ js-sys,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys,MI
 lazy_static,https://github.com/rust-lang-nursery/lazy-static.rs,MIT OR Apache-2.0,Marvin Löbel <loebel.marvin@gmail.com>
 leb128fmt,https://github.com/bluk/leb128fmt,MIT OR Apache-2.0,Bryant Luk <code@bryantluk.com>
 libc,https://github.com/rust-lang/libc,MIT OR Apache-2.0,The Rust Project Developers
+libdd-capabilities,https://github.com/DataDog/libdatadog/tree/main/libdd-capabilities,Apache-2.0,The libdd-capabilities Authors
+libdd-capabilities-impl,https://github.com/DataDog/libdatadog/tree/main/libdd-capabilities-impl,Apache-2.0,The libdd-capabilities-impl Authors
 libdd-common,https://github.com/DataDog/libdatadog/tree/main/datadog-common,Apache-2.0,The libdd-common Authors
 libdd-data-pipeline,https://github.com/DataDog/libdatadog/tree/main/libdd-data-pipeline,Apache-2.0,The libdd-data-pipeline Authors
 libdd-ddsketch,https://github.com/DataDog/libdatadog/tree/main/libdd-ddsketch,Apache-2.0,The libdd-ddsketch Authors
 libdd-dogstatsd-client,https://github.com/DataDog/libdatadog/tree/main/libdd-dogstatsd-client,Apache-2.0,The libdd-dogstatsd-client Authors
+libdd-shared-runtime,https://github.com/DataDog/libdatadog/tree/main/libdd-shared-runtime,Apache-2.0,The libdd-shared-runtime Authors
 libdd-telemetry,https://github.com/DataDog/libdatadog/tree/main/libdd-telemetry,Apache-2.0,The libdd-telemetry Authors
 libdd-tinybytes,https://github.com/DataDog/libdatadog/tree/main/libdd-tinybytes,Apache-2.0,The libdd-tinybytes Authors
 libdd-trace-normalization,https://github.com/DataDog/libdatadog/tree/main/libdd-trace-normalization,Apache-2.0,David Lee <david.lee@datadoghq.com>
@@ -179,6 +184,8 @@ rand_chacha,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Proj
 rand_core,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers"
 rand_xorshift,https://github.com/rust-random/rngs,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers"
 redox_syscall,https://gitlab.redox-os.org/redox-os/syscall,MIT,Jeremy Soller <jackpot51@gmail.com>
+ref-cast,https://github.com/dtolnay/ref-cast,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+ref-cast-impl,https://github.com/dtolnay/ref-cast,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 regex,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"
 regex-automata,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"
 regex-syntax,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -1148,11 +1148,11 @@ fn start_trace_agent(
 
     let obfuscation_config = obfuscation_config::ObfuscationConfig {
         tag_replace_rules: config.apm_replace_tags.clone(),
-        http_remove_path_digits: config.apm_config_obfuscation_http_remove_paths_with_digits,
-        http_remove_query_string: config.apm_config_obfuscation_http_remove_query_string,
-        obfuscate_memcached: false,
-        obfuscation_redis_enabled: false,
-        obfuscation_redis_remove_all_args: false,
+        http: obfuscation_config::HttpConfig {
+            remove_paths_with_digits: config.apm_config_obfuscation_http_remove_paths_with_digits,
+            remove_query_string: config.apm_config_obfuscation_http_remove_query_string,
+        },
+        ..Default::default()
     };
 
     let trace_processor = Arc::new(trace_processor::ServerlessTraceProcessor {

--- a/bottlecap/src/traces/http_client.rs
+++ b/bottlecap/src/traces/http_client.rs
@@ -6,22 +6,78 @@
 //! This module provides the HTTP client type required by `libdd_trace_utils`
 //! for sending traces and stats to Datadog intake endpoints.
 
+use http_body_util::BodyExt;
 use hyper_http_proxy;
 use hyper_rustls::HttpsConnectorBuilder;
-use libdd_common::{GenericHttpClient, http_common};
+use libdd_capabilities::{
+    MaybeSend,
+    http::{HttpClientTrait, HttpError},
+};
+use libdd_common::http_common::{self, Body, GenericHttpClient};
 use rustls::RootCertStore;
 use rustls_pki_types::CertificateDer;
 use std::error::Error;
 use std::fs::File;
+use std::future::Future;
 use std::io::BufReader;
 use std::sync::{Arc, LazyLock};
 use tracing::debug;
 
-/// Type alias for the HTTP client used by trace and stats flushers.
-///
-/// This is the client type expected by `libdd_trace_utils::SendData::send()`.
-pub type HttpClient =
+type InnerClient =
     GenericHttpClient<hyper_http_proxy::ProxyConnector<libdd_common::connector::Connector>>;
+
+/// HTTP client used by trace and stats flushers.
+///
+/// Wraps a hyper client preconfigured with optional proxy and TLS settings, and
+/// implements [`HttpClientTrait`] so it can be passed to `libdd_trace_utils`
+/// senders such as `SendData::send`.
+#[derive(Clone, Debug)]
+pub struct HttpClient {
+    inner: InnerClient,
+}
+
+impl HttpClient {
+    fn new(inner: InnerClient) -> Self {
+        Self { inner }
+    }
+}
+
+impl HttpClientTrait for HttpClient {
+    fn new_client() -> Self {
+        // Used by libdd APIs that construct a default client when no
+        // pre-configured one is supplied. Bottlecap's production code paths
+        // build the client via `create_client` so this fallback only matches
+        // libdatadog's `new_default_client` shape.
+        let connector = libdd_common::connector::Connector::default();
+        let proxy_connector = hyper_http_proxy::ProxyConnector::new(connector)
+            .expect("failed to build default proxy connector");
+        let inner = http_common::client_builder()
+            .pool_max_idle_per_host(0)
+            .build(proxy_connector);
+        HttpClient { inner }
+    }
+
+    fn request(
+        &self,
+        req: http::Request<bytes::Bytes>,
+    ) -> impl Future<Output = Result<http::Response<bytes::Bytes>, HttpError>> + MaybeSend {
+        let client = self.inner.clone();
+        async move {
+            let hyper_req = req.map(Body::from_bytes);
+            let response = client
+                .request(hyper_req)
+                .await
+                .map_err(|e| HttpError::Network(e.into()))?;
+            let (parts, body) = response.into_parts();
+            let collected = body
+                .collect()
+                .await
+                .map_err(|e| HttpError::ResponseBody(e.into()))?
+                .to_bytes();
+            Ok(http::Response::from_parts(parts, collected))
+        }
+    }
+}
 
 /// Initialize the crypto provider needed for setting custom root certificates.
 fn ensure_crypto_provider_initialized() {
@@ -185,13 +241,15 @@ pub fn create_client(
             "HTTP_CLIENT | Proxy connector created with proxy: {:?}",
             proxy_https
         );
-        Ok(client)
+        Ok(HttpClient::new(client))
     } else {
         let proxy_connector = hyper_http_proxy::ProxyConnector::new(connector)?;
         // Disable connection pooling to avoid stale connections after Lambda freeze/resume.
         // See comment above for detailed explanation.
-        Ok(http_common::client_builder()
-            .pool_max_idle_per_host(0)
-            .build(proxy_connector))
+        Ok(HttpClient::new(
+            http_common::client_builder()
+                .pool_max_idle_per_host(0)
+                .build(proxy_connector),
+        ))
     }
 }

--- a/bottlecap/src/traces/http_client.rs
+++ b/bottlecap/src/traces/http_client.rs
@@ -43,18 +43,15 @@ impl HttpClient {
 }
 
 impl HttpClientTrait for HttpClient {
+    #[allow(clippy::expect_used)]
     fn new_client() -> Self {
-        // Used by libdd APIs that construct a default client when no
-        // pre-configured one is supplied. Bottlecap's production code paths
-        // build the client via `create_client` so this fallback only matches
-        // libdatadog's `new_default_client` shape.
-        let connector = libdd_common::connector::Connector::default();
-        let proxy_connector = hyper_http_proxy::ProxyConnector::new(connector)
-            .expect("failed to build default proxy connector");
-        let inner = http_common::client_builder()
-            .pool_max_idle_per_host(0)
-            .build(proxy_connector);
-        HttpClient { inner }
+        // Required by `HttpClientTrait` but never invoked on bottlecap's code
+        // paths — production builds the client via
+        // `create_client(proxy, tls_cert, skip_ssl)`. Routing this fallback
+        // through the same constructor keeps the failure mode and error
+        // surface consistent with the rest of the module.
+        create_client(None, None, false)
+            .expect("building default proxy connector with default TLS should not fail")
     }
 
     fn request(

--- a/bottlecap/src/traces/stats_flusher.rs
+++ b/bottlecap/src/traces/stats_flusher.rs
@@ -170,10 +170,15 @@ impl StatsFlusher {
     }
 }
 
+/// Maximum number of body bytes to surface in error messages.
+const ERROR_BODY_PREVIEW_BYTES: usize = 512;
+
 /// Posts a serialized stats payload using the supplied client.
 ///
 /// Equivalent to libdatadog's `stats_utils::send_stats_payload`, but uses the
-/// caller-provided client so bottlecap's proxy/TLS configuration is preserved.
+/// caller-provided client so bottlecap's proxy/TLS configuration is preserved,
+/// and enforces `target.timeout_ms` on each attempt so the surrounding retry
+/// loop stays bounded by configuration.
 async fn send_stats_payload(
     client: &HttpClient,
     target: &Endpoint,
@@ -188,14 +193,25 @@ async fn send_stats_payload(
         .header("DD-API-KEY", api_key)
         .body(Bytes::from(data))?;
 
-    let response = client
-        .request(req)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to send trace stats: {e}"))?;
+    let response = tokio::time::timeout(
+        std::time::Duration::from_millis(target.timeout_ms),
+        client.request(req),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("Stats request timed out after {} ms", target.timeout_ms))?
+    .map_err(|e| anyhow::anyhow!("Failed to send trace stats: {e}"))?;
 
-    if response.status() != http::StatusCode::ACCEPTED {
-        let response_body = String::from_utf8(response.into_body().to_vec()).unwrap_or_default();
-        anyhow::bail!("Server did not accept trace stats: {response_body}");
+    let status = response.status();
+    if status != http::StatusCode::ACCEPTED {
+        let body = response.into_body();
+        let preview_len = body.len().min(ERROR_BODY_PREVIEW_BYTES);
+        let preview = String::from_utf8_lossy(&body[..preview_len]);
+        let truncated = if body.len() > preview_len {
+            " (truncated)"
+        } else {
+            ""
+        };
+        anyhow::bail!("Server did not accept trace stats (status {status}): {preview}{truncated}");
     }
     Ok(())
 }

--- a/bottlecap/src/traces/stats_flusher.rs
+++ b/bottlecap/src/traces/stats_flusher.rs
@@ -11,7 +11,9 @@ use crate::config;
 use crate::lifecycle::invocation::processor::S_TO_MS;
 use crate::traces::http_client::HttpClient;
 use crate::traces::stats_aggregator::StatsAggregator;
+use bytes::Bytes;
 use dogstatsd::api_key::ApiKeyFactory;
+use libdd_capabilities::http::HttpClientTrait;
 use libdd_common::Endpoint;
 use libdd_trace_protobuf::pb;
 use libdd_trace_utils::{config_utils::trace_stats_url, stats_utils};
@@ -96,11 +98,11 @@ impl StatsFlusher {
 
         for attempt in 1..=FLUSH_RETRY_COUNT {
             let start = std::time::Instant::now();
-            let resp = stats_utils::send_stats_payload_with_client(
-                serialized_stats_payload.clone(),
+            let resp = send_stats_payload(
+                &self.http_client,
                 endpoint,
                 api_key.as_str(),
-                Some(&self.http_client),
+                serialized_stats_payload.clone(),
             )
             .await;
             let elapsed = start.elapsed();
@@ -166,4 +168,34 @@ impl StatsFlusher {
             Some(all_failed)
         }
     }
+}
+
+/// Posts a serialized stats payload using the supplied client.
+///
+/// Equivalent to libdatadog's `stats_utils::send_stats_payload`, but uses the
+/// caller-provided client so bottlecap's proxy/TLS configuration is preserved.
+async fn send_stats_payload(
+    client: &HttpClient,
+    target: &Endpoint,
+    api_key: &str,
+    data: Vec<u8>,
+) -> anyhow::Result<()> {
+    let req = http::Request::builder()
+        .method(http::Method::POST)
+        .uri(target.url.clone())
+        .header("Content-Type", "application/msgpack")
+        .header("Content-Encoding", "gzip")
+        .header("DD-API-KEY", api_key)
+        .body(Bytes::from(data))?;
+
+    let response = client
+        .request(req)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to send trace stats: {e}"))?;
+
+    if response.status() != http::StatusCode::ACCEPTED {
+        let response_body = String::from_utf8(response.into_body().to_vec()).unwrap_or_default();
+        anyhow::bail!("Server did not accept trace stats: {response_body}");
+    }
+    Ok(())
 }


### PR DESCRIPTION
## Summary

Bumps the `libdd-*` git revs in bottlecap from `c8121f42` (~v31.x) to `db05e1f8408a76075efb37ecec544d2e74217e57` (current libdatadog `main`), bumps the `dogstatsd` / `datadog-fips` revs to `5b68f50f49c9defbfed4d25bd621e2a86405a972` (current serverless-components `main`, which already sits on the same libdatadog `db05e1f`), and adapts bottlecap to the breaking changes that ship between those revs.

## What changed and why

### Upstream libdatadog changes that motivated this PR

- **DataDog/libdatadog#1555** *(feat: capability traits architecture for HTTP)* — replaced the raw `hyper` client API with an `HttpClientTrait` abstraction. `SendData::send` and `send_with_retry` now require `H: HttpClientTrait`, and `stats_utils::send_stats_payload_with_client` was removed in favor of a generic `send_stats_payload<H: HttpClientTrait>(…)` that constructs its own client.
- **`ObfuscationConfig` restructured** — flat fields (`http_remove_path_digits`, `obfuscate_memcached`, …) replaced with nested per-engine structs (`http: HttpConfig`, `memcached: MemcachedConfig`, `redis: RedisConfig`, plus `valkey`, `credit_cards`, `sql`, `elasticsearch`, `opensearch`, `mongodb`).
- **DataDog/libdatadog#1816 + #1872 + #1943** *(crypto provider gating)* — moved `ring` behind `libdd-common/https` and `aws-lc-rs` behind `libdd-common/fips`, then progressively gated the internal crates (`libdd-trace-utils`, `libdd-trace-obfuscation`, `libdd-capabilities-impl`, `libdd-trace-stats`, `libdd-data-pipeline`, `libdd-dogstatsd-client`, `libdd-telemetry`) so downstream consumers can pick exactly one provider. **#1943 also added a workspace-wide CI guard** in libdatadog that rejects any PR which puts both `ring` and `aws-lc-rs` in the dep graph at the same time.

Other commits in the range (`c8121f42..db05e1f`) are sidecar / FFE / tracer-flare / telemetry changes that don't touch surfaces bottlecap consumes.

### Code changes in this PR

#### `bottlecap/src/traces/http_client.rs` — wrap the client to implement `HttpClientTrait`

The bottlecap HTTP client must keep proxy + custom CA + skip-SSL support (FIPS, `DD_PROXY_HTTPS`, `DD_TLS_CERT_FILE`, `DD_SKIP_SSL_VALIDATION`). The upstream `DefaultHttpClient` from `libdd-capabilities-impl` hardcodes `Connector::default()` and supports none of those — using it would be a regression.

So `HttpClient` is now a newtype around `GenericHttpClient<ProxyConnector<Connector>>` that implements `libdd_capabilities::HttpClientTrait`. The trait's `request()` maps `http::Request<Bytes>` → `Body::from_bytes(…)` → hyper request, then collects the response body back to `Bytes`. ~30 lines, reuses libdatadog's encoding/retry/header logic.

`HttpClientTrait::new_client()` is required by the trait but doesn't fit our model (we need a configured client, not a default). It now routes through `create_client(None, None, false)` so the failure surface is consistent with the rest of the module — and it's never invoked on production paths (we always go through `create_client(proxy, tls_cert, skip_ssl)`).

#### `bottlecap/src/traces/stats_flusher.rs` — inline the stats POST

The new `send_stats_payload<H: HttpClientTrait>(data, target, api_key)` calls `H::new_client()` internally — meaning callers can't supply a pre-configured client anymore. That would lose Lambda's `pool_max_idle_per_host(0)` tuning, which exists specifically to avoid stale connections after Lambda freeze/resume cycles.

Replaced the removed call with a tiny in-module `send_stats_payload` helper that builds the same POST request (msgpack + gzip + `DD-API-KEY`) and invokes our `HttpClient`'s `request()` method directly. Per Copilot review: each attempt is wrapped in `tokio::time::timeout(target.timeout_ms, …)` so the retry loop stays bounded by config, and the error-body capture is bounded to 512 bytes (lossy UTF-8) with the HTTP status surfaced in the message instead of silently emptying on non-UTF8 responses.

#### `bottlecap/src/bin/bottlecap/main.rs` — flatten → nested `ObfuscationConfig`

Maps the two HTTP fields we configure (`apm_config_obfuscation_http_remove_paths_with_digits`, `apm_config_obfuscation_http_remove_query_string`) into the new `HttpConfig`. Everything else flows through `..Default::default()`, which preserves the previous behavior (memcached/redis disabled).

#### `bottlecap/Cargo.toml` + `bottlecap/Cargo.lock`

- Bumps all `libdd-*` revs to `db05e1f` and `dogstatsd` / `datadog-fips` revs to `5b68f50` (serverless-components `main`).
- Adds `libdd-capabilities` (source of `HttpClientTrait`) and `http` (now used directly in `stats_flusher`) as direct dependencies.
- Sets `default-features = false` on all `libdd-*` deps and forwards `libdd-*/https` from bottlecap's `default` feature and `libdd-*/fips` from bottlecap's `fips` feature — the consumer-side pattern that #1872's description prescribed.

#### `bottlecap/LICENSE-3rdparty.csv`

Regenerated via `dd-rust-license-tool write` to include the new `libdd-capabilities` / `libdd-capabilities-impl` / `libdd-shared-runtime` / `http` entries.

## FIPS

Previously a known issue — the FIPS clippy job failed because `libdd-trace-stats` (and `libdd-data-pipeline`) pulled `libdd-capabilities-impl` with default features = `https = ring`, with no downstream-side workaround possible. **DataDog/libdatadog#1943 fixed this upstream**, and this PR now forwards `libdd-trace-stats/fips` from the `fips` feature.

Verified locally:

```
$ cargo clippy --workspace --all-targets --no-default-features --features fips
warning: bottlecap@0.1.0: FIPS feature is enabled, checking for forbidden dependencies...
warning: bottlecap@0.1.0: No ring dependency found. FIPS compliance check passed
warning: bottlecap@0.1.0: No openssl dependency found. FIPS compliance check passed
warning: bottlecap@0.1.0: No boringssl dependency found. FIPS compliance check passed
warning: bottlecap@0.1.0: All dependency checks passed.
```

## Companion PRs (already merged)

- **DataDog/libdatadog#1943** — gates the internal libdatadog crates and adds the workspace-wide CI guard.
- **DataDog/serverless-components#127** — bumps the `dogstatsd` / `datadog-fips` source workspace to libdatadog `db05e1f`. This PR pins to its merge SHA `5b68f50`, so the whole chain (libdatadog → serverless-components → bottlecap) sits on a consistent baseline.

## Test plan

- [x] `cargo check --all-targets` (default features)
- [x] `cargo clippy --workspace --all-targets --features default`
- [x] `cargo clippy --workspace --all-targets --no-default-features --features fips` — FIPS dependency check now passes locally (was the long-standing CI blocker)
- [x] `cargo test --no-run`
- [x] `cargo fmt --all -- --check`
- [x] Production layer build via `ARCHITECTURE=arm64 FIPS=false ./scripts/build_bottlecap_layer.sh` — built successfully, binary 11.17 MiB stripped / layer zip 5.08 MiB (slightly smaller than `origin/main`'s 11.23 MiB / 5.11 MiB)
- [ ] End-to-end smoke test in a real Lambda environment
