### PR TITLE
perf(deps): drop aws-lc-rs from non-FIPS builds, use ring backend

### DIFF
--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -40,7 +40,7 @@ hmac = { version = "0.12", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["std"] }
 base64 = { version = "0.22", default-features = false }
-rustls = { version = "0.23.18", default-features = false, features = ["aws-lc-rs"] }
+rustls = { version = "0.23.18", default-features = false }
 # Transitive via rustls. Pinned to >=0.103.13 so cargo audit passes (RUSTSEC-2026-0098, RUSTSEC-2026-0099, RUSTSEC-2026-0104).
 rustls-webpki = { version = "0.103.13", default-features = false }
 rustls-pemfile = { version = "2.0", default-features = false, features = ["std"] }

--- a/bottlecap/src/traces/http_client.rs
+++ b/bottlecap/src/traces/http_client.rs
@@ -79,10 +79,16 @@ impl HttpClientTrait for HttpClient {
 /// Initialize the crypto provider needed for setting custom root certificates.
 fn ensure_crypto_provider_initialized() {
     static INIT_CRYPTO_PROVIDER: LazyLock<()> = LazyLock::new(|| {
+        // FIPS builds use the FIPS-validated aws-lc-rs provider, non-FIPS
+        // builds use ring (the libdatadog default). Pick based on the bottlecap
+        // `fips` feature so we never pull both crypto backends into the binary.
+        #[cfg(all(unix, feature = "fips"))]
+        let provider = rustls::crypto::aws_lc_rs::default_provider();
+        #[cfg(all(unix, not(feature = "fips")))]
+        let provider = rustls::crypto::ring::default_provider();
+
         #[cfg(unix)]
-        if let Err(_already_installed) =
-            rustls::crypto::aws_lc_rs::default_provider().install_default()
-        {
+        if let Err(_already_installed) = provider.install_default() {
             debug!(
                 "HTTP_CLIENT | Default CryptoProvider already installed, using existing provider"
             );

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -637,7 +637,10 @@ mod tests {
     #[allow(clippy::unwrap_used)]
     #[cfg_attr(miri, ignore)]
     async fn test_process_trace() {
+        #[cfg(feature = "fips")]
         let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        #[cfg(not(feature = "fips"))]
+        let _ = rustls::crypto::ring::default_provider().install_default();
         let start = get_current_timestamp_nanos();
 
         let tags_provider = create_tags_provider(create_test_config());


### PR DESCRIPTION
## Summary

Stacks on top of #1218. Drops the duplicate `aws-lc-rs` crypto provider from non-FIPS builds, leaving a single backend per mode. Cuts ~15% off the deployed layer zip on its own.

| | before | after | Δ |
|---|---:|---:|---:|
| `bottlecap` stripped (arm64) | 11,709,896 B | **10,137,032 B** | **−1,572,864 B (−13.4%)** |
| `datadog_extension.zip` (arm64) | 5,324,844 B | **4,528,013 B** | **−796,831 B (−15.0%)** |

## Why this exists

Until #1218 landed the libdatadog gating fixes, bottlecap was pulling **both** `ring` and `aws-lc-rs` into every build:

- `ring` came in transitively via `libdd-common/https → rustls/ring + hyper-rustls/ring`
- `aws-lc-rs` was hardcoded directly via `rustls = { features = ["aws-lc-rs"] }` in `bottlecap/Cargo.toml`, plus explicit `rustls::crypto::aws_lc_rs::default_provider().install_default()` calls in `http_client.rs` and `trace_processor.rs`

The libdatadog gating from DataDog/libdatadog#1943 fixed the *transitive* path, but bottlecap's *direct* `aws-lc-rs` usage remained. Result: the `db05e1f` bump in #1218 keeps both providers linked into the binary and ships ~1.5 MiB of unused machine code (`aws-lc-sys` alone is ~543 KiB stripped per `cargo bloat`, and the surrounding rustls / hyper-rustls / boringssl glue makes up the rest).

## Change

1. **`bottlecap/Cargo.toml`** — drop the `aws-lc-rs` feature from the rustls direct dep:
   ```diff
   -rustls = { version = "0.23.18", default-features = false, features = ["aws-lc-rs"] }
   +rustls = { version = "0.23.18", default-features = false }
   ```
   The provider now flows in transitively per mode:
   - `default`: `libdd-common/https` → `rustls/ring`
   - `fips`: `bottlecap/fips` → `rustls/fips` (FIPS-validated aws-lc-rs)

2. **`bottlecap/src/traces/http_client.rs`** — make `ensure_crypto_provider_initialized` cfg-conditional on the bottlecap `fips` feature so `rustls::crypto::ring::default_provider` is used in non-FIPS and `rustls::crypto::aws_lc_rs::default_provider` only in FIPS.

3. **`bottlecap/src/traces/trace_processor.rs`** — same cfg split for the test-helper `default_provider().install_default()` call.

## Verification

`cargo tree`:

```
$ cargo tree -i ring        --no-default-features --features default
ring v0.17.14
└── ... (via libdd-common/https path)            ✓ pulled

$ cargo tree -i aws-lc-rs   --no-default-features --features default
warning: nothing to print.                        ✓ absent

$ cargo tree -i ring        --no-default-features --features fips
warning: nothing to print.                        ✓ absent

$ cargo tree -i aws-lc-rs   --no-default-features --features fips
aws-lc-rs v1.16.2
└── ...                                           ✓ pulled
```

Build script's FIPS dep check still passes:

```
$ cargo clippy --workspace --all-targets --no-default-features --features fips
warning: bottlecap@0.1.0: No ring dependency found. FIPS compliance check passed
warning: bottlecap@0.1.0: No openssl dependency found. FIPS compliance check passed
warning: bottlecap@0.1.0: No boringssl dependency found. FIPS compliance check passed
warning: bottlecap@0.1.0: All dependency checks passed.
```

## Risk

This is a real behavior change for non-FIPS deployments — TLS goes from `aws-lc-rs` to `ring` as the default provider. Both are FIPS-incapable in non-FIPS builds anyway (the FIPS variant lives behind `rustls/fips`), so the user-visible difference is limited to TLS internals (cipher suite priority list, perf characteristics, supported algorithms). `ring` is the libdatadog-wide default and is what every other libdd-* consumer in the workspace ends up on after #1943, so this aligns bottlecap with the rest of the ecosystem.

Should be smoke-tested in a real Lambda environment before merging — the dev-server path and a representative trace/metric flush should both work end-to-end.

## Test plan

- [x] `cargo check --all-targets` (default features)
- [x] `cargo clippy --workspace --all-targets --features default`
- [x] `cargo clippy --workspace --all-targets --no-default-features --features fips` — FIPS dep check still passes
- [x] `cargo tree` — verified single provider per mode
- [x] Production layer build via `ARCHITECTURE=arm64 FIPS=false ./scripts/build_bottlecap_layer.sh` — built successfully, sizes above
- [ ] End-to-end smoke test in a real Lambda environment (TLS handshake, trace/metric/log flushes)
- [ ] FIPS production build smoke test

## Base

Stacked on #1218 (libdatadog `db05e1f` bump + HttpClientTrait adoption). Will rebase to `main` once that lands.
