### PR TITLE
[SVLS-8997] chore: add shared AGENTS.md and pre-commit clippy/fmt hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd bottlecap && cargo clippy --workspace --all-targets --features default && cargo fmt --all -- --check || exit 2",
+            "if": "Bash(git commit*)",
+            "timeout": 60,
+            "statusMessage": "Running cargo clippy + fmt"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,4 @@ bottlecap/proptest-regressions
 integration-tests/cdk.context.json
 
 .gitlab/pipeline*
-/CLAUDE.md
-/AGENTS.md
+/CLAUDE_PERSONAL.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,68 @@
+# AGENTS.md
+
+This file provides guidance to coding agents when working with code in this repository.
+
+## What This Project Is
+
+The Datadog Lambda Extension ("Bottlecap") is an AWS Lambda Extension written in Rust that asynchronously collects metrics, traces, and logs from Lambda functions and forwards them to Datadog. It supports two operational modes: **On-Demand** (standard Lambda invocations) and **Managed Instance** (Lambda Managed Instances with concurrent invocations).
+
+## Common Commands
+
+All Rust code lives under `bottlecap/`. Run these from that directory unless noted.
+
+## Pull Requests
+
+- When creating a PR, follow the PR template at `.github/pull_request_template.md`.
+- When making a change on a PR, update the PR title and summary if necessary.
+- When reviewing a PR, make sure the PR summary accurately describes the code changes.
+
+## Architecture
+
+### Two Execution Modes
+
+**On-Demand Mode** (standard Lambda): one concurrent execution per environment. Configurable flush strategies:
+- `end` — flush only at end of invocation
+- `end,<ms>` — flush at end + periodic interval
+- `periodically,<ms>` — periodic blocking flushes
+- `continuously,<ms>` — non-blocking background flushes
+- `default` — adaptive (starts with `end`, switches to periodic after ~20 invocations)
+
+**Managed Instance Mode** (detected via `AWS_LAMBDA_INITIALIZATION_TYPE`): multiple concurrent invocations; background continuous flushing always active.
+
+### Core Data Flow
+
+```
+Event sources
+  ├─ Lambda Extension API (INVOKE / SHUTDOWN polled via `extension::next_event`)
+  ├─ Telemetry Listener   (logs from the Lambda telemetry API)
+  ├─ Lifecycle Listener   (HTTP endpoints called by tracer libs: start/end invocation)
+  ├─ DogStatsD Listener   (custom metrics)
+  └─ Trace / OTLP agents  (traces from tracer libs)
+        ↓
+  Event Bus (central async distribution)
+        ↓
+  Aggregator Services (batch collection)
+      LogsAggregatorService / TraceAggregatorService / MetricsAggregatorService
+        ↓
+  Flush Control (decides when to flush, per mode + strategy)
+        ↓
+  Flusher Services (send to Datadog intake)
+      LogsFlusher / TraceFlusher / MetricsFlusher
+```
+
+### Key Source Locations (`bottlecap/src/`)
+
+| Path | Purpose |
+|------|---------|
+| `bin/bottlecap/main.rs` | Entry point; initializes all subsystems for both modes |
+| `config/` | Configuration parsing (flush strategy, AWS env, log level) |
+| `event_bus/` | Central async event distribution |
+| `lifecycle/` | Lambda invocation lifecycle events and flush control logic |
+| `logs/` | Log aggregation and flushing |
+| `traces/` | Trace processing, stats generation, flushing (most complex subsystem) |
+| `metrics/` | Enhanced Lambda runtime metrics (lambda lifecycle, filesystem, usage). DogStatsD UDP server itself lives in the external `dogstatsd` crate |
+| `otlp/` | OpenTelemetry Protocol (HTTP + gRPC) support |
+| `proxy/` | HTTP proxy intercepting Lambda Runtime API requests (LWA, AppSec, trace propagation) |
+| `appsec/` | Application Security Monitoring |
+| `tags/` | Tag extraction and propagation |
+| `fips/` | FIPS mode cryptography support |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md @CLAUDE_PERSONAL.md


### PR DESCRIPTION
## Overview

Introduce a team-shared coding-agent configuration so any agent (Claude Code, Codex, etc.) gets the same project-level guidance, while still allowing personal overrides.

- `AGENTS.md` — agent-agnostic project guide (architecture, data flow, source-tree map, PR conventions). Reviewed against the codebase: corrected the `proxy/` and `metrics/` descriptions and replaced the simplistic data-flow diagram with one that lists the real event sources (Lambda Extension API polling, telemetry listener, lifecycle listener, DogStatsD, trace/OTLP agents).
- `CLAUDE.md` — single-line entrypoint that loads both `@AGENTS.md` (shared) and `@CLAUDE_PERSONAL.md` (personal, untracked).
- `.gitignore` — now ignores `/CLAUDE_PERSONAL.md` instead of the shared files.
- `.claude/settings.json` — `PreToolUse` hook that runs `cd bottlecap && cargo clippy --workspace --all-targets --features default && cargo fmt --all -- --check` before any `git commit` Bash call. Failures exit 2 and block the commit. Timeout 60s; matches via `if: "Bash(git commit*)"` so chained commands won't bypass it.

The settings split mirrors the CLAUDE.md/CLAUDE_PERSONAL.md pattern via Claude Code's built-in convention: `.claude/settings.json` is committed (team-wide), `.claude/settings.local.json` is gitignored (personal overrides).

## Testing
The team will test this in daily work and iterate as needed.