### PR TITLE
feat(bottlecap): make flush retry/DLQ/deadline-margin configurable

### DIFF
--- a/bottlecap/src/config/env.rs
+++ b/bottlecap/src/config/env.rs
@@ -59,6 +59,29 @@ pub struct EnvConfig {
     #[serde(deserialize_with = "deserialize_option_lossless")]
     pub flush_timeout: Option<u64>,
 
+    /// @env `DD_FLUSH_DEADLINE_MARGIN_MS`
+    ///
+    /// Safety margin (ms) reserved at the tail of the Lambda budget so the
+    /// extension can finish `/extension/event/next` after flushing. Per-request
+    /// timeout = `min(flush_timeout, deadline_ms - now_ms - flush_deadline_margin_ms)`.
+    #[serde(deserialize_with = "deserialize_option_lossless")]
+    pub flush_deadline_margin_ms: Option<u64>,
+
+    /// @env `DD_FLUSH_DLQ_MAX_BYTES`
+    ///
+    /// Maximum combined size (bytes) of the in-memory dead letter queue across
+    /// all telemetry types. When pushing a still-failed payload would exceed
+    /// this cap, the incoming payload is dropped.
+    #[serde(deserialize_with = "deserialize_option_lossless")]
+    pub flush_dlq_max_bytes: Option<u64>,
+
+    /// @env `DD_FLUSH_RETRY_ATTEMPTS`
+    ///
+    /// Maximum number of attempts each flusher will make per `flush()` call
+    /// before returning the payload for redrive / DLQ.
+    #[serde(deserialize_with = "deserialize_option_lossless")]
+    pub flush_retry_attempts: Option<u32>,
+
     // Proxy
     /// @env `DD_PROXY_HTTPS`
     ///
@@ -497,6 +520,9 @@ fn merge_config(config: &mut Config, env_config: &EnvConfig) {
     merge_string!(config, env_config, api_key);
     merge_option_to_value!(config, env_config, log_level);
     merge_option_to_value!(config, env_config, flush_timeout);
+    merge_option_to_value!(config, env_config, flush_deadline_margin_ms);
+    merge_option_to_value!(config, env_config, flush_dlq_max_bytes);
+    merge_option_to_value!(config, env_config, flush_retry_attempts);
 
     // Unified Service Tagging
     merge_option!(config, env_config, env);
@@ -742,6 +768,9 @@ mod tests {
             jail.set_env("DD_API_KEY", "test-api-key");
             jail.set_env("DD_LOG_LEVEL", "debug");
             jail.set_env("DD_FLUSH_TIMEOUT", "42");
+            jail.set_env("DD_FLUSH_DEADLINE_MARGIN_MS", "250");
+            jail.set_env("DD_FLUSH_DLQ_MAX_BYTES", "1048576");
+            jail.set_env("DD_FLUSH_RETRY_ATTEMPTS", "5");
 
             // Proxy
             jail.set_env("DD_PROXY_HTTPS", "https://proxy.example.com");
@@ -907,6 +936,9 @@ mod tests {
                 log_level: LogLevel::Debug,
                 compression_level: 4,
                 flush_timeout: 42,
+                flush_deadline_margin_ms: 250,
+                flush_dlq_max_bytes: 1_048_576,
+                flush_retry_attempts: 5,
                 proxy_https: Some("https://proxy.example.com".to_string()),
                 proxy_no_proxy: vec!["localhost".to_string(), "127.0.0.1".to_string()],
                 http_protocol: Some("http1".to_string()),

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -247,6 +247,21 @@ pub struct Config {
     // Timeout for the request to flush data to Datadog endpoint
     pub flush_timeout: u64,
 
+    /// Safety margin (ms) reserved at the tail of the Lambda budget so the
+    /// extension can finish its `/extension/event/next` call after flushing.
+    /// The per-request flush deadline is `min(flush_timeout, deadline_ms - now_ms - flush_deadline_margin_ms)`.
+    pub flush_deadline_margin_ms: u64,
+
+    /// Maximum combined size of the in-memory dead letter queue across all
+    /// telemetry types. When pushing a still-failed payload would exceed this
+    /// cap, the incoming payload is dropped (matching dd-trace-py's policy).
+    pub flush_dlq_max_bytes: u64,
+
+    /// Maximum number of attempts each flusher will make per `flush()` call
+    /// before returning the payload for redrive / DLQ. Previously the
+    /// `FLUSH_RETRY_COUNT` constant; now runtime-configurable.
+    pub flush_retry_attempts: u32,
+
     // Global config of compression levels.
     // It would be overridden by the setup for the individual component
     pub compression_level: i32,
@@ -380,6 +395,9 @@ impl Default for Config {
             api_key: String::default(),
             log_level: LogLevel::default(),
             flush_timeout: 30,
+            flush_deadline_margin_ms: 100,
+            flush_dlq_max_bytes: 52_428_800, // 50 MiB
+            flush_retry_attempts: 3,
 
             // Proxy
             proxy_https: None,

--- a/bottlecap/src/config/yaml.rs
+++ b/bottlecap/src/config/yaml.rs
@@ -43,6 +43,15 @@ pub struct YamlConfig {
     pub flush_timeout: Option<u64>,
 
     #[serde(deserialize_with = "deserialize_option_lossless")]
+    pub flush_deadline_margin_ms: Option<u64>,
+
+    #[serde(deserialize_with = "deserialize_option_lossless")]
+    pub flush_dlq_max_bytes: Option<u64>,
+
+    #[serde(deserialize_with = "deserialize_option_lossless")]
+    pub flush_retry_attempts: Option<u32>,
+
+    #[serde(deserialize_with = "deserialize_option_lossless")]
     pub compression_level: Option<i32>,
 
     // Proxy
@@ -419,6 +428,9 @@ fn merge_config(config: &mut Config, yaml_config: &YamlConfig) {
     merge_string!(config, yaml_config, api_key);
     merge_option_to_value!(config, yaml_config, log_level);
     merge_option_to_value!(config, yaml_config, flush_timeout);
+    merge_option_to_value!(config, yaml_config, flush_deadline_margin_ms);
+    merge_option_to_value!(config, yaml_config, flush_dlq_max_bytes);
+    merge_option_to_value!(config, yaml_config, flush_retry_attempts);
 
     // Unified Service Tagging
     merge_option!(config, yaml_config, env);
@@ -761,6 +773,9 @@ site: "test-site"
 api_key: "test-api-key"
 log_level: "debug"
 flush_timeout: 42
+flush_deadline_margin_ms: 250
+flush_dlq_max_bytes: 1048576
+flush_retry_attempts: 5
 compression_level: 4
 # Proxy
 proxy:
@@ -905,6 +920,9 @@ api_security_sample_delay: 60 # Seconds
                 api_key: "test-api-key".to_string(),
                 log_level: LogLevel::Debug,
                 flush_timeout: 42,
+                flush_deadline_margin_ms: 250,
+                flush_dlq_max_bytes: 1_048_576,
+                flush_retry_attempts: 5,
                 compression_level: 4,
                 proxy_https: Some("https://proxy.example.com".to_string()),
                 proxy_no_proxy: vec!["localhost".to_string(), "127.0.0.1".to_string()],

--- a/bottlecap/src/lib.rs
+++ b/bottlecap/src/lib.rs
@@ -40,8 +40,5 @@ pub mod traces;
 
 pub const LAMBDA_RUNTIME_SLUG: &str = "lambda";
 
-// todo: consider making this configurable
-pub const FLUSH_RETRY_COUNT: usize = 3;
-
 // todo: make sure we can override those with environment variables
 pub const DOGSTATSD_PORT: u16 = 8125;

--- a/bottlecap/src/logs/flusher.rs
+++ b/bottlecap/src/logs/flusher.rs
@@ -1,4 +1,3 @@
-use crate::FLUSH_RETRY_COUNT;
 use crate::config;
 use crate::logs::aggregator_service::AggregatorHandle;
 use dogstatsd::api_key::ApiKeyFactory;
@@ -53,6 +52,7 @@ impl Flusher {
         };
 
         let mut set = JoinSet::new();
+        let max_attempts = self.config.flush_retry_attempts;
 
         if let Some(logs_batches) = batches {
             for batch in logs_batches.iter() {
@@ -60,7 +60,7 @@ impl Flusher {
                     continue;
                 }
                 let req = self.create_request(batch.clone(), api_key.as_str()).await;
-                set.spawn(async move { Self::send(req).await });
+                set.spawn(async move { Self::send(req, max_attempts).await });
             }
         }
 
@@ -105,8 +105,11 @@ impl Flusher {
             .body(data)
     }
 
-    async fn send(req: reqwest::RequestBuilder) -> Result<(), Box<dyn Error + Send>> {
-        let mut attempts = 0;
+    async fn send(
+        req: reqwest::RequestBuilder,
+        max_attempts: u32,
+    ) -> Result<(), Box<dyn Error + Send>> {
+        let mut attempts: u32 = 0;
 
         loop {
             let time = Instant::now();
@@ -133,9 +136,9 @@ impl Flusher {
                     }
                 }
                 Err(e) => {
-                    if attempts >= FLUSH_RETRY_COUNT {
-                        // After 3 failed attempts, return the original request for later retry
-                        // Create a custom error that can be downcast to get the RequestBuilder
+                    if attempts >= max_attempts {
+                        // After max_attempts failed attempts, return the original request for later retry.
+                        // Create a custom error that can be downcast to get the RequestBuilder.
                         error!(
                             "LOGS | Failed to send request after {} ms and {} attempts: {:?}",
                             elapsed.as_millis(),
@@ -248,7 +251,7 @@ impl LogsFlusher {
         // If retry_request is provided, only process that request
         if let Some(req) = retry_request {
             if let Some(req_clone) = req.try_clone()
-                && let Err(e) = Flusher::send(req_clone).await
+                && let Err(e) = Flusher::send(req_clone, self.config.flush_retry_attempts).await
                 && let Some(failed_req_err) = e.downcast_ref::<FailedRequestError>()
             {
                 failed_requests.push(

--- a/bottlecap/src/traces/proxy_flusher.rs
+++ b/bottlecap/src/traces/proxy_flusher.rs
@@ -8,7 +8,7 @@ use tokio::{sync::Mutex, task::JoinSet};
 use tracing::{debug, error, info};
 
 use crate::{
-    FLUSH_RETRY_COUNT, config,
+    config,
     tags::provider,
     traces::{
         DD_ADDITIONAL_TAGS_HEADER,
@@ -105,8 +105,9 @@ impl Flusher {
             }
         }
 
+        let max_attempts = self.config.flush_retry_attempts;
         for request in requests {
-            join_set.spawn(async move { Self::send(request).await });
+            join_set.spawn(async move { Self::send(request, max_attempts).await });
         }
 
         let send_results = join_set.join_all().await;
@@ -134,9 +135,12 @@ impl Flusher {
             .body(request.body)
     }
 
-    async fn send(request: reqwest::RequestBuilder) -> Result<(), Box<dyn Error + Send>> {
+    async fn send(
+        request: reqwest::RequestBuilder,
+        max_attempts: u32,
+    ) -> Result<(), Box<dyn Error + Send>> {
         debug!("PROXY_FLUSHER | Attempting to send request");
-        let mut attempts = 0;
+        let mut attempts: u32 = 0;
 
         loop {
             attempts += 1;
@@ -160,7 +164,7 @@ impl Flusher {
                             elapsed.as_millis()
                         );
                         return Ok(());
-                    } else if attempts >= FLUSH_RETRY_COUNT {
+                    } else if attempts >= max_attempts {
                         // Final attempt. Log with error level and return error.
                         let body_string = body.unwrap_or_default();
                         error!(
@@ -173,11 +177,11 @@ impl Flusher {
                     }
                     // Not the final attempt. Log with info level and retry.
                     info!(
-                        "PROXY_FLUSHER | Request failed with status {status} to {url}: {body:?} (attempt {attempts}/{FLUSH_RETRY_COUNT})"
+                        "PROXY_FLUSHER | Request failed with status {status} to {url}: {body:?} (attempt {attempts}/{max_attempts})"
                     );
                 }
                 Err(e) => {
-                    if attempts >= FLUSH_RETRY_COUNT {
+                    if attempts >= max_attempts {
                         error!(
                             "PROXY_FLUSHER | Failed to send request after {} attempts: {:?}",
                             attempts, e

--- a/bottlecap/src/traces/stats_flusher.rs
+++ b/bottlecap/src/traces/stats_flusher.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::sync::OnceCell;
 
-use crate::FLUSH_RETRY_COUNT;
 use crate::config;
 use crate::lifecycle::invocation::processor::S_TO_MS;
 use crate::traces::http_client::HttpClient;
@@ -93,8 +92,9 @@ impl StatsFlusher {
         };
 
         let stats_url = trace_stats_url(&self.config.site);
+        let max_attempts = self.config.flush_retry_attempts;
 
-        for attempt in 1..=FLUSH_RETRY_COUNT {
+        for attempt in 1..=max_attempts {
             let start = std::time::Instant::now();
             let resp = stats_utils::send_stats_payload_with_client(
                 serialized_stats_payload.clone(),
@@ -108,21 +108,21 @@ impl StatsFlusher {
             match resp {
                 Ok(()) => {
                     debug!(
-                        "STATS | Successfully flushed stats to {stats_url} in {} ms (attempt {attempt}/{FLUSH_RETRY_COUNT})",
+                        "STATS | Successfully flushed stats to {stats_url} in {} ms (attempt {attempt}/{max_attempts})",
                         elapsed.as_millis()
                     );
                     return None;
                 }
                 Err(e) => {
                     debug!(
-                        "STATS | Failed to send stats to {stats_url} in {} ms (attempt {attempt}/{FLUSH_RETRY_COUNT}): {e:?}",
+                        "STATS | Failed to send stats to {stats_url} in {} ms (attempt {attempt}/{max_attempts}): {e:?}",
                         elapsed.as_millis()
                     );
                 }
             }
         }
 
-        error!("STATS | Exhausted all {FLUSH_RETRY_COUNT} attempts, returning stats for redrive");
+        error!("STATS | Exhausted all {max_attempts} attempts, returning stats for redrive");
         Some(stats)
     }
 

--- a/bottlecap/src/traces/trace_flusher.rs
+++ b/bottlecap/src/traces/trace_flusher.rs
@@ -15,19 +15,18 @@ use std::sync::Arc;
 use tokio::task::JoinSet;
 use tracing::{debug, error};
 
-use crate::FLUSH_RETRY_COUNT;
 use crate::config::Config;
 use crate::lifecycle::invocation::processor::S_TO_MS;
 use crate::traces::http_client::HttpClient;
 use crate::traces::trace_aggregator_service::AggregatorHandle;
 
-/// Retry strategy for trace flushing using the shared `FLUSH_RETRY_COUNT`
+/// Retry strategy for trace flushing using the configured retry attempts
 /// with no delay between attempts. In Lambda, every millisecond of wall-clock
 /// time matters, and the per-attempt request timeout already bounds how long
 /// each retry can take.
-fn trace_retry_strategy() -> RetryStrategy {
+fn trace_retry_strategy(config: &Config) -> RetryStrategy {
     RetryStrategy::new(
-        u32::try_from(FLUSH_RETRY_COUNT).unwrap_or(3),
+        config.flush_retry_attempts,
         0,
         RetryBackoffType::Constant,
         None,
@@ -131,7 +130,7 @@ impl TraceFlusher {
                     let trace = info
                         .builder
                         .with_api_key(api_key.as_str())
-                        .with_retry_strategy(trace_retry_strategy())
+                        .with_retry_strategy(trace_retry_strategy(&self.config))
                         .build();
                     (trace, info.header_tags)
                 })
@@ -151,7 +150,7 @@ impl TraceFlusher {
                                 tags.to_tracer_header_tags(),
                                 &endpoint,
                             );
-                            send_data.set_retry_strategy(trace_retry_strategy());
+                            send_data.set_retry_strategy(trace_retry_strategy(&self.config));
                             Some(send_data)
                         }
                         // All payloads in the extension are V07 (produced by


### PR DESCRIPTION
## Summary

Adds three new config knobs and migrates the `FLUSH_RETRY_COUNT` constant to a per-config value. **No runtime behavior change yet on its own** — this is the foundation for upcoming deadline-aware per-request timeouts and an in-memory dead letter queue that will ensure extension flushes never cause a customer's Lambda to time out.

## New config fields

All read once at startup into `Arc<Config>` via env-var (`DD_*`) and YAML bindings, alongside the existing `flush_timeout` plumbing.

| Env var | Default | Effect |
|---|---|---|
| `DD_FLUSH_DEADLINE_MARGIN_MS` | **100** | Safety margin (ms) reserved at the tail of the Lambda budget so the extension can finish its `/extension/event/next` call after flushing. Will gate the upcoming per-request deadline math. |
| `DD_FLUSH_DLQ_MAX_BYTES` | **52_428_800** (50 MiB) | Cap on combined in-memory size of the upcoming dead letter queue across all telemetry types. |
| `DD_FLUSH_RETRY_ATTEMPTS` | **3** | Max attempts each flusher will make per `flush()` call before returning the payload for redrive / DLQ. Previously the `FLUSH_RETRY_COUNT: usize = 3` constant in `lib.rs`. |

`DD_FLUSH_TIMEOUT` default is **unchanged at 30 s**.

## What changed

- `bottlecap/src/config/{mod,env,yaml}.rs`: new fields + bindings + merge logic + test fixtures.
- `bottlecap/src/lib.rs`: removed the `FLUSH_RETRY_COUNT` constant.
- `bottlecap/src/logs/flusher.rs`, `traces/proxy_flusher.rs`: `send()` associated functions now take `max_attempts: u32`; callers pass `self.config.flush_retry_attempts`.
- `bottlecap/src/traces/stats_flusher.rs`: retry loop reads `self.config.flush_retry_attempts`.
- `bottlecap/src/traces/trace_flusher.rs`: `trace_retry_strategy()` now takes `&Config` and reads the value at runtime.

## Test plan

- [x] \`cargo test --lib\` — all 528 existing unit tests pass.
- [x] \`cargo check\` clean.
- [ ] Follow-up PR will land deadline-aware per-request timeout and dead letter queue (this is the foundation).

## Why draft

This is part 1 of a multi-PR effort to fix a class of Lambda timeouts caused by stalled telemetry intake. Draft until the follow-up PRs land so review can evaluate the full picture; this piece alone is intentionally inert.