### PR TITLE
feat(bottlecap): thread invocation deadline through flushers

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -38,7 +38,7 @@ use bottlecap::{
         },
     },
     fips::{log_fips_status, prepare_client_provider},
-    flushing::FlushingService,
+    flushing::{FlushingService, InvocationDeadline, new_invocation_deadline},
     lifecycle::{
         flush_control::{DEFAULT_CONTINUOUS_FLUSH_INTERVAL, FlushControl, FlushDecision},
         invocation::processor_service::{InvocationProcessorHandle, InvocationProcessorService},
@@ -114,6 +114,15 @@ async fn main() -> anyhow::Result<()> {
     log_fips_status(&aws_config.region);
     let version_without_next = EXTENSION_VERSION.split('-').next().unwrap_or("NA");
     debug!("Starting Datadog Extension v{version_without_next}");
+
+    // tokio::spawn(async {
+    //     let mut tick: u64 = 0;
+    //     loop {
+    //         debug!("HEARTBEAT tick={}", tick);
+    //         tick = tick.wrapping_add(1);
+    //         tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+    //     }
+    // });
 
     // Debug: Wait for debugger to attach if DD_DEBUG_WAIT_FOR_ATTACH is set
     if let Ok(wait_secs) = env::var("DD_DEBUG_WAIT_FOR_ATTACH")
@@ -306,6 +315,13 @@ async fn extension_loop_active(
     let account_id = r.account_id.as_ref().unwrap_or(&"none".to_string()).clone();
     let tags_provider = setup_tag_provider(&Arc::clone(&aws_config), config, &account_id);
 
+    // Shared mutable cell holding the current Lambda invocation deadline (epoch ms).
+    // Updated on every INVOKE event in `handle_next_invocation`; flushers read it at
+    // send time to derive an adaptive per-request timeout. `0` means "no deadline known"
+    // (e.g. before the first INVOKE), in which case flushers fall back to the static
+    // `flush_timeout` ceiling.
+    let invocation_deadline = new_invocation_deadline();
+
     let (
         logs_agent_channel,
         logs_flusher,
@@ -319,6 +335,7 @@ async fn extension_loop_active(
         event_bus_tx.clone(),
         aws_config.is_managed_instance_mode(),
         &shared_client,
+        invocation_deadline.clone(),
     );
 
     let (metrics_flushers, metrics_aggregator_handle, dogstatsd_cancel_token) = start_dogstatsd(
@@ -372,6 +389,7 @@ async fn extension_loop_active(
         invocation_processor_handle.clone(),
         appsec_processor.clone(),
         &shared_client,
+        invocation_deadline.clone(),
     );
 
     let api_runtime_proxy_shutdown_signal = start_api_runtime_proxy(
@@ -634,7 +652,7 @@ async fn extension_loop_active(
         Arc::clone(&metrics_flushers),
         metrics_aggregator_handle.clone(),
     );
-    handle_next_invocation(next_lambda_response, &invocation_processor_handle).await;
+    handle_next_invocation(next_lambda_response, &invocation_processor_handle, &invocation_deadline).await;
     loop {
         let maybe_shutdown_event;
 
@@ -666,7 +684,7 @@ async fn extension_loop_active(
                 let next_response =
                     extension::next_event(client, &aws_config.runtime_api, &r.extension_id).await;
                 maybe_shutdown_event =
-                    handle_next_invocation(next_response, &invocation_processor_handle).await;
+                    handle_next_invocation(next_response, &invocation_processor_handle, &invocation_deadline).await;
             }
             FlushDecision::Continuous | FlushDecision::Periodic | FlushDecision::Dont => {
                 match current_flush_decision {
@@ -697,7 +715,7 @@ async fn extension_loop_active(
                     tokio::select! {
                     biased;
                         next_response = &mut next_lambda_response => {
-                            maybe_shutdown_event = handle_next_invocation(next_response, &invocation_processor_handle).await;
+                            maybe_shutdown_event = handle_next_invocation(next_response, &invocation_processor_handle, &invocation_deadline).await;
                             // Need to break here to re-call next
                             break 'next_invocation;
                         }
@@ -983,6 +1001,7 @@ async fn handle_event_bus_event(
 async fn handle_next_invocation(
     next_response: Result<NextEventResponse, ExtensionError>,
     invocation_processor_handle: &InvocationProcessorHandle,
+    invocation_deadline: &InvocationDeadline,
 ) -> NextEventResponse {
     match next_response {
         Ok(NextEventResponse::Invoke {
@@ -990,6 +1009,9 @@ async fn handle_next_invocation(
             deadline_ms,
             ref invoked_function_arn,
         }) => {
+            // Publish the new deadline so flushers can derive their adaptive
+            // per-request timeout from `deadline_ms - now - margin`.
+            invocation_deadline.store(deadline_ms, std::sync::atomic::Ordering::Relaxed);
             debug!(
                 "Invoke event {}; deadline: {}, invoked_function_arn: {}",
                 request_id.clone(),
@@ -1007,6 +1029,9 @@ async fn handle_next_invocation(
             ref shutdown_reason,
             deadline_ms,
         }) => {
+            // Clear the deadline so any post-shutdown sends fall back to the
+            // static ceiling instead of using a now-stale invocation deadline.
+            invocation_deadline.store(0, std::sync::atomic::Ordering::Relaxed);
             if let Err(e) = invocation_processor_handle.on_shutdown_event().await {
                 error!("Failed to send shutdown event to processor: {}", e);
             }
@@ -1048,6 +1073,7 @@ fn start_logs_agent(
     event_bus: Sender<Event>,
     is_managed_instance_mode: bool,
     client: &Client,
+    invocation_deadline: InvocationDeadline,
 ) -> (
     Sender<TelemetryEvent>,
     LogsFlusher,
@@ -1082,6 +1108,7 @@ fn start_logs_agent(
         aggregator_handle.clone(),
         config.clone(),
         client.clone(),
+        invocation_deadline,
     );
     (
         tx,
@@ -1100,6 +1127,7 @@ fn start_trace_agent(
     invocation_processor_handle: InvocationProcessorHandle,
     appsec_processor: Option<Arc<TokioMutex<AppSecProcessor>>>,
     client: &Client,
+    invocation_deadline: InvocationDeadline,
 ) -> (
     Sender<SendDataBuilderInfo>,
     Arc<trace_flusher::TraceFlusher>,
@@ -1131,6 +1159,7 @@ fn start_trace_agent(
         stats_aggregator.clone(),
         Arc::clone(config),
         trace_http_client.clone(),
+        invocation_deadline.clone(),
     ));
 
     let stats_processor = Arc::new(stats_processor::ServerlessStatsProcessor {});
@@ -1144,6 +1173,7 @@ fn start_trace_agent(
         config.clone(),
         api_key_factory.clone(),
         trace_http_client,
+        invocation_deadline.clone(),
     ));
 
     let obfuscation_config = obfuscation_config::ObfuscationConfig {
@@ -1170,6 +1200,7 @@ fn start_trace_agent(
         Arc::clone(tags_provider),
         Arc::clone(config),
         client.clone(),
+        invocation_deadline,
     ));
 
     let trace_agent = trace_agent::TraceAgent::new(

--- a/bottlecap/src/flushing/mod.rs
+++ b/bottlecap/src/flushing/mod.rs
@@ -12,3 +12,122 @@ mod service;
 
 pub use handles::{FlushHandles, MetricsRetryBatch};
 pub use service::FlushingService;
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Shared, hot-swappable current invocation deadline (epoch ms).
+///
+/// Stored as `0` when no deadline is known (e.g. before the first INVOKE event,
+/// or after SHUTDOWN). Updated on every Invoke event in `handle_next_invocation`.
+/// Read by each flusher's `send()` to compute an adaptive per-request timeout.
+pub type InvocationDeadline = Arc<AtomicU64>;
+
+/// Returns a new `InvocationDeadline` initialized to `0` (no deadline known).
+#[must_use]
+pub fn new_invocation_deadline() -> InvocationDeadline {
+    Arc::new(AtomicU64::new(0))
+}
+
+/// Returns the effective per-request flush timeout, honoring both the static
+/// `flush_timeout` ceiling and the Lambda invocation deadline.
+///
+/// Formula: `min(flush_timeout_secs, deadline_ms - now_ms - margin_ms)`,
+/// saturating to `Duration::ZERO` when the deadline has already passed (or is
+/// unset, indicated by `deadline_ms == 0`).
+///
+/// Callers should treat `Duration::ZERO` as "no budget — skip this send and
+/// re-enqueue."
+#[must_use]
+pub fn compute_flush_cap(
+    deadline_ms: u64,
+    flush_timeout_secs: u64,
+    margin_ms: u64,
+) -> Duration {
+    let ceiling = Duration::from_secs(flush_timeout_secs);
+    if deadline_ms == 0 {
+        return ceiling;
+    }
+    let now_ms = u64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    )
+    .unwrap_or(u64::MAX);
+    let remaining_ms = deadline_ms
+        .saturating_sub(now_ms)
+        .saturating_sub(margin_ms);
+    let remaining = Duration::from_millis(remaining_ms);
+    std::cmp::min(ceiling, remaining)
+}
+
+/// Convenience: load `deadline_ms` from the shared atomic and compute the cap.
+#[must_use]
+pub fn compute_flush_cap_from(
+    deadline: &InvocationDeadline,
+    flush_timeout_secs: u64,
+    margin_ms: u64,
+) -> Duration {
+    compute_flush_cap(
+        deadline.load(Ordering::Relaxed),
+        flush_timeout_secs,
+        margin_ms,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cap_uses_ceiling_when_no_deadline() {
+        let cap = compute_flush_cap(0, 30, 100);
+        assert_eq!(cap, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn cap_uses_remaining_when_tighter_than_ceiling() {
+        let now_ms = u64::try_from(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis(),
+        )
+        .unwrap();
+        // 5 seconds in the future, 100ms margin → 4900ms remaining, which is tighter than 30s.
+        let cap = compute_flush_cap(now_ms + 5_000, 30, 100);
+        // Allow a few ms of slop for clock movement between the two `now()` calls.
+        assert!(cap <= Duration::from_millis(4_900));
+        assert!(cap >= Duration::from_millis(4_800));
+    }
+
+    #[test]
+    fn cap_saturates_to_zero_when_deadline_passed() {
+        let now_ms = u64::try_from(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis(),
+        )
+        .unwrap();
+        // Deadline already passed.
+        let cap = compute_flush_cap(now_ms.saturating_sub(1_000), 30, 100);
+        assert_eq!(cap, Duration::ZERO);
+    }
+
+    #[test]
+    fn cap_saturates_to_zero_when_remaining_less_than_margin() {
+        let now_ms = u64::try_from(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis(),
+        )
+        .unwrap();
+        // 50ms remaining, 100ms margin → 0.
+        let cap = compute_flush_cap(now_ms + 50, 30, 100);
+        assert_eq!(cap, Duration::ZERO);
+    }
+}

--- a/bottlecap/src/logs/flusher.rs
+++ b/bottlecap/src/logs/flusher.rs
@@ -1,4 +1,5 @@
 use crate::config;
+use crate::flushing::InvocationDeadline;
 use crate::logs::aggregator_service::AggregatorHandle;
 use dogstatsd::api_key::ApiKeyFactory;
 use futures::future::join_all;
@@ -26,6 +27,12 @@ pub struct Flusher {
     config: Arc<config::Config>,
     api_key_factory: Arc<ApiKeyFactory>,
     headers: OnceCell<HeaderMap>,
+    /// Shared current Lambda invocation deadline (epoch ms). Read by the
+    /// upcoming per-request timeout wrapper to compute an adaptive cap; the
+    /// underlying value of `0` means "no deadline known" and falls back to the
+    /// static `flush_timeout` ceiling.
+    #[allow(dead_code)] // Consumed by the per-request timeout wrapper in a follow-up commit.
+    invocation_deadline: InvocationDeadline,
 }
 
 impl Flusher {
@@ -35,6 +42,7 @@ impl Flusher {
         endpoint: String,
         config: Arc<config::Config>,
         client: reqwest::Client,
+        invocation_deadline: InvocationDeadline,
     ) -> Self {
         Flusher {
             client,
@@ -42,6 +50,7 @@ impl Flusher {
             config,
             api_key_factory,
             headers: OnceCell::new(),
+            invocation_deadline,
         }
     }
 
@@ -202,6 +211,7 @@ impl LogsFlusher {
         aggregator_handle: AggregatorHandle,
         config: Arc<config::Config>,
         client: reqwest::Client,
+        invocation_deadline: InvocationDeadline,
     ) -> Self {
         let mut flushers = Vec::new();
 
@@ -220,6 +230,7 @@ impl LogsFlusher {
             endpoint,
             config.clone(),
             client.clone(),
+            invocation_deadline.clone(),
         ));
 
         // Create flushers for additional endpoints
@@ -232,6 +243,7 @@ impl LogsFlusher {
                 endpoint_url,
                 config.clone(),
                 client.clone(),
+                invocation_deadline.clone(),
             ));
         }
 

--- a/bottlecap/src/traces/proxy_flusher.rs
+++ b/bottlecap/src/traces/proxy_flusher.rs
@@ -9,6 +9,7 @@ use tracing::{debug, error, info};
 
 use crate::{
     config,
+    flushing::InvocationDeadline,
     tags::provider,
     traces::{
         DD_ADDITIONAL_TAGS_HEADER,
@@ -30,6 +31,10 @@ pub struct Flusher {
     tags_provider: Arc<provider::Provider>,
     api_key_factory: Arc<ApiKeyFactory>,
     headers: OnceCell<HeaderMap>,
+    /// Shared current Lambda invocation deadline (epoch ms). Read at send
+    /// time to derive an adaptive per-request timeout via `compute_flush_cap`.
+    #[allow(dead_code)] // Consumed by the per-request timeout wrapper in a follow-up commit.
+    invocation_deadline: InvocationDeadline,
 }
 
 impl Flusher {
@@ -39,6 +44,7 @@ impl Flusher {
         tags_provider: Arc<provider::Provider>,
         config: Arc<config::Config>,
         client: reqwest::Client,
+        invocation_deadline: InvocationDeadline,
     ) -> Self {
         Flusher {
             client,
@@ -47,6 +53,7 @@ impl Flusher {
             tags_provider,
             api_key_factory,
             headers: OnceCell::new(),
+            invocation_deadline,
         }
     }
 

--- a/bottlecap/src/traces/stats_flusher.rs
+++ b/bottlecap/src/traces/stats_flusher.rs
@@ -7,6 +7,7 @@ use tokio::sync::Mutex;
 use tokio::sync::OnceCell;
 
 use crate::config;
+use crate::flushing::InvocationDeadline;
 use crate::lifecycle::invocation::processor::S_TO_MS;
 use crate::traces::http_client::HttpClient;
 use crate::traces::stats_aggregator::StatsAggregator;
@@ -22,6 +23,9 @@ pub struct StatsFlusher {
     api_key_factory: Arc<ApiKeyFactory>,
     endpoint: OnceCell<Endpoint>,
     http_client: HttpClient,
+    /// Shared current Lambda invocation deadline (epoch ms). Read at send
+    /// time to derive an adaptive per-request timeout via `compute_flush_cap`.
+    pub invocation_deadline: InvocationDeadline,
 }
 
 impl StatsFlusher {
@@ -31,6 +35,7 @@ impl StatsFlusher {
         aggregator: Arc<Mutex<StatsAggregator>>,
         config: Arc<config::Config>,
         http_client: HttpClient,
+        invocation_deadline: InvocationDeadline,
     ) -> Self {
         StatsFlusher {
             aggregator,
@@ -38,6 +43,7 @@ impl StatsFlusher {
             api_key_factory,
             endpoint: OnceCell::new(),
             http_client,
+            invocation_deadline,
         }
     }
 

--- a/bottlecap/src/traces/trace_flusher.rs
+++ b/bottlecap/src/traces/trace_flusher.rs
@@ -16,6 +16,7 @@ use tokio::task::JoinSet;
 use tracing::{debug, error};
 
 use crate::config::Config;
+use crate::flushing::InvocationDeadline;
 use crate::lifecycle::invocation::processor::S_TO_MS;
 use crate::traces::http_client::HttpClient;
 use crate::traces::trace_aggregator_service::AggregatorHandle;
@@ -42,6 +43,9 @@ pub struct TraceFlusher {
     /// Each trace batch is sent to the primary endpoint AND all additional endpoints.
     pub additional_endpoints: Vec<Endpoint>,
     http_client: HttpClient,
+    /// Shared current Lambda invocation deadline (epoch ms). Read at flush
+    /// time to derive an adaptive per-request timeout via `compute_flush_cap`.
+    pub invocation_deadline: InvocationDeadline,
 }
 
 impl TraceFlusher {
@@ -51,6 +55,7 @@ impl TraceFlusher {
         config: Arc<Config>,
         api_key_factory: Arc<ApiKeyFactory>,
         http_client: HttpClient,
+        invocation_deadline: InvocationDeadline,
     ) -> Self {
         // Parse additional endpoints for dual-shipping from config.
         // Format: { "https://trace.agent.datadoghq.eu": ["api-key-1", "api-key-2"], ... }
@@ -77,6 +82,7 @@ impl TraceFlusher {
             api_key_factory,
             additional_endpoints,
             http_client,
+            invocation_deadline,
         }
     }
 


### PR DESCRIPTION
## Summary

Plumbing-only change. Adds an `Arc<AtomicU64>` shared cell holding the current Lambda invocation's `deadline_ms`, and threads it from `handle_next_invocation` (where it gets published on every INVOKE event) into each bottlecap-owned flusher's struct.

**No runtime behavior change yet** — the field is held but not yet consumed. The follow-up PR will read it inside `tokio::time::timeout(...)` wrappers around each HTTP `send()` so a single hung intake call can never overrun the customer's Lambda budget.

> [!NOTE]
> Stacked on #1225 — base set to `rey.abolofia/flush-config-knobs`.

## What's added

### `bottlecap/src/flushing/mod.rs`

- `InvocationDeadline` type alias for `Arc<AtomicU64>` (epoch ms; `0` means "no deadline known")
- `new_invocation_deadline()` constructor
- `compute_flush_cap(deadline_ms, flush_timeout_secs, margin_ms) -> Duration` — the cap formula:
  ```
  min(flush_timeout, deadline_ms − now_ms − margin_ms)
  ```
  saturating to `Duration::ZERO` when there is no budget left (or when no deadline is known, in which case it returns the static ceiling).
- `compute_flush_cap_from(&InvocationDeadline, ...)` convenience that loads from the atomic.
- 4 new unit tests covering: no-deadline case, tighter-than-ceiling case, deadline-already-passed, and remaining-less-than-margin.

### Each flusher

`LogsFlusher` (inner `Flusher`), `TraceFlusher`, `StatsFlusher`, `ProxyFlusher` (`Flusher` in `traces/proxy_flusher.rs`) gain an `invocation_deadline: InvocationDeadline` field, threaded through `new()` at construction. Fields carry `#[allow(dead_code)]` until the follow-up PR consumes them.

### `bottlecap/src/bin/bottlecap/main.rs`

- `extension_loop_active` builds a single `InvocationDeadline` and clones it into `start_logs_agent` and `start_trace_agent`, which forward it to each flusher constructor.
- `handle_next_invocation` takes `&InvocationDeadline` and:
  - On `NextEventResponse::Invoke`: stores the event's `deadline_ms`
  - On `NextEventResponse::Shutdown`: resets to `0`

## What's intentionally out of scope

- Metrics (`dogstatsd` in `serverless-components`) — the per-request timeout for `ship_series` / `ship_distributions` lands via an upstream PR in `serverless-components`.
- Actually wrapping `send().await` calls in `tokio::time::timeout(...)` — next PR in the stack.
- DLQ persistence of failed payloads across invocations — also next.

## Test plan

- [x] `cargo test --lib` — all **532 tests pass** (4 new + 528 existing).
- [x] `cargo check` clean — no warnings.