### PR TITLE
feat(bottlecap): adaptive per-request flush timeout from invocation deadline

### DIFF
--- a/bottlecap/src/logs/flusher.rs
+++ b/bottlecap/src/logs/flusher.rs
@@ -1,5 +1,5 @@
 use crate::config;
-use crate::flushing::InvocationDeadline;
+use crate::flushing::{InvocationDeadline, compute_flush_cap_from};
 use crate::logs::aggregator_service::AggregatorHandle;
 use dogstatsd::api_key::ApiKeyFactory;
 use futures::future::join_all;
@@ -28,10 +28,9 @@ pub struct Flusher {
     api_key_factory: Arc<ApiKeyFactory>,
     headers: OnceCell<HeaderMap>,
     /// Shared current Lambda invocation deadline (epoch ms). Read by the
-    /// upcoming per-request timeout wrapper to compute an adaptive cap; the
+    /// per-request timeout wrapper to compute an adaptive cap; the
     /// underlying value of `0` means "no deadline known" and falls back to the
     /// static `flush_timeout` ceiling.
-    #[allow(dead_code)] // Consumed by the per-request timeout wrapper in a follow-up commit.
     invocation_deadline: InvocationDeadline,
 }
 
@@ -69,7 +68,9 @@ impl Flusher {
                     continue;
                 }
                 let req = self.create_request(batch.clone(), api_key.as_str()).await;
-                set.spawn(async move { Self::send(req, max_attempts).await });
+                let deadline = self.invocation_deadline.clone();
+                let config = self.config.clone();
+                set.spawn(async move { Self::send(req, max_attempts, deadline, config).await });
             }
         }
 
@@ -117,20 +118,44 @@ impl Flusher {
     async fn send(
         req: reqwest::RequestBuilder,
         max_attempts: u32,
+        invocation_deadline: InvocationDeadline,
+        config: Arc<config::Config>,
     ) -> Result<(), Box<dyn Error + Send>> {
         let mut attempts: u32 = 0;
 
         loop {
-            let time = Instant::now();
             attempts += 1;
+
+            // Compute the per-attempt cap *fresh* each iteration so retries
+            // tighten as the Lambda deadline approaches. When there's no budget
+            // left we bail immediately so the payload can be queued for retry
+            // on the next invocation instead of risking a Lambda timeout.
+            let cap = compute_flush_cap_from(
+                &invocation_deadline,
+                config.flush_timeout,
+                config.flush_deadline_margin_ms,
+            );
+            if cap.is_zero() {
+                debug!(
+                    "LOGS | Insufficient remaining invocation budget for attempt {attempts}; deferring for retry"
+                );
+                return Err(Box::new(FailedRequestError {
+                    request: req,
+                    message: format!(
+                        "LOGS | Deferred after {attempts} attempts: no remaining invocation budget"
+                    ),
+                }));
+            }
+
+            let time = Instant::now();
             let Some(cloned_req) = req.try_clone() else {
                 return Err(Box::new(std::io::Error::other("can't clone")));
             };
-            let resp = cloned_req.send().await;
+            let resp = tokio::time::timeout(cap, cloned_req.send()).await;
             let elapsed = time.elapsed();
 
             match resp {
-                Ok(resp) => {
+                Ok(Ok(resp)) => {
                     let status = resp.status();
                     _ = resp.text().await;
                     if status == StatusCode::FORBIDDEN {
@@ -144,7 +169,7 @@ impl Flusher {
                         return Ok(());
                     }
                 }
-                Err(e) => {
+                Ok(Err(e)) => {
                     if attempts >= max_attempts {
                         // After max_attempts failed attempts, return the original request for later retry.
                         // Create a custom error that can be downcast to get the RequestBuilder.
@@ -157,6 +182,25 @@ impl Flusher {
                         return Err(Box::new(FailedRequestError {
                             request: req,
                             message: format!("LOGS | Failed after {attempts} attempts: {e}"),
+                        }));
+                    }
+                }
+                Err(_elapsed) => {
+                    // Per-request deadline elapsed (tokio::time::timeout fired).
+                    if attempts >= max_attempts {
+                        error!(
+                            "LOGS | Request timed out after {} ms (cap {} ms) on attempt {} of {}",
+                            elapsed.as_millis(),
+                            cap.as_millis(),
+                            attempts,
+                            max_attempts
+                        );
+                        return Err(Box::new(FailedRequestError {
+                            request: req,
+                            message: format!(
+                                "LOGS | Timed out after {attempts} attempts (cap {} ms)",
+                                cap.as_millis()
+                            ),
                         }));
                     }
                 }
@@ -203,6 +247,7 @@ pub struct LogsFlusher {
     config: Arc<config::Config>,
     pub flushers: Vec<Flusher>,
     aggregator_handle: AggregatorHandle,
+    invocation_deadline: InvocationDeadline,
 }
 
 impl LogsFlusher {
@@ -251,6 +296,7 @@ impl LogsFlusher {
             config,
             flushers,
             aggregator_handle,
+            invocation_deadline,
         }
     }
 
@@ -263,7 +309,13 @@ impl LogsFlusher {
         // If retry_request is provided, only process that request
         if let Some(req) = retry_request {
             if let Some(req_clone) = req.try_clone()
-                && let Err(e) = Flusher::send(req_clone, self.config.flush_retry_attempts).await
+                && let Err(e) = Flusher::send(
+                    req_clone,
+                    self.config.flush_retry_attempts,
+                    self.invocation_deadline.clone(),
+                    self.config.clone(),
+                )
+                .await
                 && let Some(failed_req_err) = e.downcast_ref::<FailedRequestError>()
             {
                 failed_requests.push(

--- a/bottlecap/src/traces/proxy_flusher.rs
+++ b/bottlecap/src/traces/proxy_flusher.rs
@@ -9,7 +9,7 @@ use tracing::{debug, error, info};
 
 use crate::{
     config,
-    flushing::InvocationDeadline,
+    flushing::{InvocationDeadline, compute_flush_cap_from},
     tags::provider,
     traces::{
         DD_ADDITIONAL_TAGS_HEADER,
@@ -33,7 +33,6 @@ pub struct Flusher {
     headers: OnceCell<HeaderMap>,
     /// Shared current Lambda invocation deadline (epoch ms). Read at send
     /// time to derive an adaptive per-request timeout via `compute_flush_cap`.
-    #[allow(dead_code)] // Consumed by the per-request timeout wrapper in a follow-up commit.
     invocation_deadline: InvocationDeadline,
 }
 
@@ -114,7 +113,11 @@ impl Flusher {
 
         let max_attempts = self.config.flush_retry_attempts;
         for request in requests {
-            join_set.spawn(async move { Self::send(request, max_attempts).await });
+            let deadline = self.invocation_deadline.clone();
+            let config = self.config.clone();
+            join_set.spawn(
+                async move { Self::send(request, max_attempts, deadline, config).await },
+            );
         }
 
         let send_results = join_set.join_all().await;
@@ -145,6 +148,8 @@ impl Flusher {
     async fn send(
         request: reqwest::RequestBuilder,
         max_attempts: u32,
+        invocation_deadline: InvocationDeadline,
+        config: Arc<config::Config>,
     ) -> Result<(), Box<dyn Error + Send>> {
         debug!("PROXY_FLUSHER | Attempting to send request");
         let mut attempts: u32 = 0;
@@ -152,16 +157,37 @@ impl Flusher {
         loop {
             attempts += 1;
 
+            // Compute the per-attempt cap *fresh* each iteration so retries
+            // tighten as the Lambda deadline approaches. When there's no budget
+            // left we bail immediately so the payload can be queued for retry
+            // on the next invocation instead of risking a Lambda timeout.
+            let cap = compute_flush_cap_from(
+                &invocation_deadline,
+                config.flush_timeout,
+                config.flush_deadline_margin_ms,
+            );
+            if cap.is_zero() {
+                debug!(
+                    "PROXY_FLUSHER | Insufficient remaining invocation budget for attempt {attempts}; deferring for retry"
+                );
+                return Err(Box::new(FailedProxyRequestError {
+                    request,
+                    message: format!(
+                        "Deferred after {attempts} attempts: no remaining invocation budget"
+                    ),
+                }));
+            }
+
             let Some(cloned_request) = request.try_clone() else {
                 return Err(Box::new(std::io::Error::other("can't clone proxy request")));
             };
 
             let time = std::time::Instant::now();
-            let response = cloned_request.send().await;
+            let response = tokio::time::timeout(cap, cloned_request.send()).await;
             let elapsed = time.elapsed();
 
             match response {
-                Ok(r) => {
+                Ok(Ok(r)) => {
                     let url = r.url().to_string();
                     let status = r.status();
                     let body = r.text().await;
@@ -187,7 +213,7 @@ impl Flusher {
                         "PROXY_FLUSHER | Request failed with status {status} to {url}: {body:?} (attempt {attempts}/{max_attempts})"
                     );
                 }
-                Err(e) => {
+                Ok(Err(e)) => {
                     if attempts >= max_attempts {
                         error!(
                             "PROXY_FLUSHER | Failed to send request after {} attempts: {:?}",
@@ -197,6 +223,25 @@ impl Flusher {
                         return Err(Box::new(FailedProxyRequestError {
                             request,
                             message: e.to_string(),
+                        }));
+                    }
+                }
+                Err(_elapsed) => {
+                    // Per-request deadline elapsed (tokio::time::timeout fired).
+                    if attempts >= max_attempts {
+                        error!(
+                            "PROXY_FLUSHER | Request timed out after {} ms (cap {} ms) on attempt {} of {}",
+                            elapsed.as_millis(),
+                            cap.as_millis(),
+                            attempts,
+                            max_attempts
+                        );
+                        return Err(Box::new(FailedProxyRequestError {
+                            request,
+                            message: format!(
+                                "Timed out after {attempts} attempts (cap {} ms)",
+                                cap.as_millis()
+                            ),
                         }));
                     }
                 }

--- a/bottlecap/src/traces/stats_flusher.rs
+++ b/bottlecap/src/traces/stats_flusher.rs
@@ -7,8 +7,7 @@ use tokio::sync::Mutex;
 use tokio::sync::OnceCell;
 
 use crate::config;
-use crate::flushing::InvocationDeadline;
-use crate::lifecycle::invocation::processor::S_TO_MS;
+use crate::flushing::{InvocationDeadline, compute_flush_cap_from};
 use crate::traces::http_client::HttpClient;
 use crate::traces::stats_aggregator::StatsAggregator;
 use dogstatsd::api_key::ApiKeyFactory;
@@ -21,7 +20,10 @@ pub struct StatsFlusher {
     aggregator: Arc<Mutex<StatsAggregator>>,
     config: Arc<config::Config>,
     api_key_factory: Arc<ApiKeyFactory>,
-    endpoint: OnceCell<Endpoint>,
+    /// Cached parsed stats-intake URL. Computed once because `Uri::from_str`
+    /// allocates and validates; rebuilt into a fresh `Endpoint` per send so
+    /// `timeout_ms` can reflect the *current* invocation budget.
+    endpoint_url: OnceCell<hyper::Uri>,
     http_client: HttpClient,
     /// Shared current Lambda invocation deadline (epoch ms). Read at send
     /// time to derive an adaptive per-request timeout via `compute_flush_cap`.
@@ -41,7 +43,7 @@ impl StatsFlusher {
             aggregator,
             config,
             api_key_factory,
-            endpoint: OnceCell::new(),
+            endpoint_url: OnceCell::new(),
             http_client,
             invocation_deadline,
         }
@@ -64,20 +66,13 @@ impl StatsFlusher {
             return None;
         };
 
-        let api_key_clone = api_key.clone();
-        let endpoint = self
-            .endpoint
+        let endpoint_url = self
+            .endpoint_url
             .get_or_init({
-                move || async move {
+                || async move {
                     let stats_url = trace_stats_url(&self.config.site);
-                    Endpoint {
-                        url: hyper::Uri::from_str(&stats_url)
-                            .expect("can't make URI from stats url, exiting"),
-                        api_key: Some(api_key_clone.into()),
-                        timeout_ms: self.config.flush_timeout * S_TO_MS,
-                        test_token: None,
-                        use_system_resolver: false,
-                    }
+                    hyper::Uri::from_str(&stats_url)
+                        .expect("can't make URI from stats url, exiting")
                 }
             })
             .await;
@@ -101,10 +96,38 @@ impl StatsFlusher {
         let max_attempts = self.config.flush_retry_attempts;
 
         for attempt in 1..=max_attempts {
+            // Compute the per-attempt cap *fresh* so retries tighten as the
+            // Lambda deadline approaches. When there's no budget left we bail
+            // immediately so the payload can be redriven on the next
+            // invocation instead of risking a Lambda timeout.
+            let cap = compute_flush_cap_from(
+                &self.invocation_deadline,
+                self.config.flush_timeout,
+                self.config.flush_deadline_margin_ms,
+            );
+            if cap.is_zero() {
+                debug!(
+                    "STATS | Insufficient remaining invocation budget on attempt {attempt}; deferring for redrive"
+                );
+                return Some(stats);
+            }
+
+            // Build a fresh Endpoint per attempt so its `timeout_ms` (consumed
+            // by `tokio::time::timeout` inside `send_with_retry`) reflects the
+            // current remaining budget.
+            #[allow(clippy::cast_possible_truncation)]
+            let endpoint = Endpoint {
+                url: endpoint_url.clone(),
+                api_key: Some(api_key.clone().into()),
+                timeout_ms: cap.as_millis().min(u64::MAX as u128) as u64,
+                test_token: None,
+                use_system_resolver: false,
+            };
+
             let start = std::time::Instant::now();
             let resp = stats_utils::send_stats_payload_with_client(
                 serialized_stats_payload.clone(),
-                endpoint,
+                &endpoint,
                 api_key.as_str(),
                 Some(&self.http_client),
             )
@@ -114,15 +137,17 @@ impl StatsFlusher {
             match resp {
                 Ok(()) => {
                     debug!(
-                        "STATS | Successfully flushed stats to {stats_url} in {} ms (attempt {attempt}/{max_attempts})",
-                        elapsed.as_millis()
+                        "STATS | Successfully flushed stats to {stats_url} in {} ms (attempt {attempt}/{max_attempts}, cap {} ms)",
+                        elapsed.as_millis(),
+                        cap.as_millis()
                     );
                     return None;
                 }
                 Err(e) => {
                     debug!(
-                        "STATS | Failed to send stats to {stats_url} in {} ms (attempt {attempt}/{max_attempts}): {e:?}",
-                        elapsed.as_millis()
+                        "STATS | Failed to send stats to {stats_url} in {} ms (attempt {attempt}/{max_attempts}, cap {} ms): {e:?}",
+                        elapsed.as_millis(),
+                        cap.as_millis()
                     );
                 }
             }

--- a/bottlecap/src/traces/trace_flusher.rs
+++ b/bottlecap/src/traces/trace_flusher.rs
@@ -16,7 +16,7 @@ use tokio::task::JoinSet;
 use tracing::{debug, error};
 
 use crate::config::Config;
-use crate::flushing::InvocationDeadline;
+use crate::flushing::{InvocationDeadline, compute_flush_cap_from};
 use crate::lifecycle::invocation::processor::S_TO_MS;
 use crate::traces::http_client::HttpClient;
 use crate::traces::trace_aggregator_service::AggregatorHandle;
@@ -102,11 +102,30 @@ impl TraceFlusher {
 
         let http_client = &self.http_client;
 
+        // Compute the adaptive per-request cap from the current Lambda
+        // invocation deadline. When there's no budget left, bail and return
+        // everything for redrive on the next invocation instead of risking a
+        // Lambda timeout.
+        let cap = compute_flush_cap_from(
+            &self.invocation_deadline,
+            self.config.flush_timeout,
+            self.config.flush_deadline_margin_ms,
+        );
+        #[allow(clippy::cast_possible_truncation)]
+        let cap_ms = cap.as_millis().min(u64::MAX as u128) as u64;
+
         let mut failed_batch: Vec<SendData> = Vec::new();
 
         if let Some(traces) = failed_traces {
             // If we have traces from a previous failed attempt, try to send those first.
             if !traces.is_empty() {
+                if cap.is_zero() {
+                    debug!(
+                        "TRACES | Insufficient remaining invocation budget; deferring {} failed batches for redrive",
+                        traces.len()
+                    );
+                    return Some(traces);
+                }
                 debug!(
                     "TRACES | Retrying to send {} previously failed batches",
                     traces.len()
@@ -127,6 +146,34 @@ impl TraceFlusher {
             }
         };
 
+        if cap.is_zero() && !all_batches.is_empty() {
+            // Re-build the SendData objects from the freshly drained batches
+            // and return them for redrive — they're the same payloads we would
+            // have sent, just deferred to the next invocation. Note: the
+            // primary endpoint's `timeout_ms` is set at trace-process time and
+            // still uses `config.flush_timeout` (a follow-up will add an
+            // upstream `SendDataBuilder::with_timeout_ms` so this can be made
+            // adaptive too).
+            debug!(
+                "TRACES | Insufficient remaining invocation budget; deferring fresh batches for redrive"
+            );
+            let mut deferred: Vec<SendData> = Vec::new();
+            for trace_builders in all_batches {
+                for info in trace_builders {
+                    deferred.push(
+                        info.builder
+                            .with_api_key(api_key.as_str())
+                            .with_retry_strategy(trace_retry_strategy(&self.config))
+                            .build(),
+                    );
+                }
+            }
+            if deferred.is_empty() {
+                return None;
+            }
+            return Some(deferred);
+        }
+
         let mut batch_tasks = JoinSet::new();
 
         for trace_builders in all_batches {
@@ -145,7 +192,10 @@ impl TraceFlusher {
             // Send to ADDITIONAL endpoints for dual-shipping.
             // Construct separate SendData objects per endpoint by cloning the inner
             // V07 payload data (TracerPayload is Clone, but SendData is not).
-            for endpoint in self.additional_endpoints.clone() {
+            for mut endpoint in self.additional_endpoints.clone() {
+                // Apply the adaptive per-request timeout to dual-shipping
+                // endpoints too.
+                endpoint.timeout_ms = cap_ms;
                 let additional_traces: Vec<_> = traces_with_tags
                     .iter()
                     .filter_map(|(trace, tags)| match trace.get_payloads() {


### PR DESCRIPTION
## Summary

This is the first behavior-changing PR in the stack. It wraps every flusher HTTP send in a per-attempt `tokio::time::timeout(cap, ...)` where `cap` is derived from the current Lambda invocation's `deadline_ms`. When the remaining invocation budget is exhausted, the flusher bails immediately and the payload is returned for redrive on the next invocation instead of risking a Lambda timeout.

> [!NOTE]
> Stacked on #1226 — base set to `rey.abolofia/flush-deadline-plumbing`.

## The cap formula

```
cap = min(DD_FLUSH_TIMEOUT, deadline_ms - now_ms - DD_FLUSH_DEADLINE_MARGIN_MS)
```

Defaults: `DD_FLUSH_TIMEOUT=30s` (unchanged), `DD_FLUSH_DEADLINE_MARGIN_MS=100ms`. Each retry attempt recomputes `cap` fresh so timeouts tighten as the deadline approaches. `cap == 0` (or no deadline known, e.g. before the first INVOKE) returns the payload for redrive **without** making the HTTP call.

## What's wrapped

| Flusher | Mechanism |
|---|---|
| **Logs** (`bottlecap/src/logs/flusher.rs`) | `Flusher::send` wraps `cloned_req.send()` in `tokio::time::timeout(cap, ...)` |
| **EVP-proxy / llmobs / profile / etc.** (`bottlecap/src/traces/proxy_flusher.rs`) | Same wrap pattern on the proxy `send()` |
| **Stats** (`bottlecap/src/traces/stats_flusher.rs`) | Builds a fresh `Endpoint` per attempt with `timeout_ms = cap`; `libdd_trace_utils::send_with_retry` enforces it internally via `tokio::time::timeout`. `OnceCell<Endpoint>` changed to `OnceCell<hyper::Uri>` (only the URL parsing is cached). |
| **Traces** — **dual-shipping endpoints** (`bottlecap/src/traces/trace_flusher.rs`) | Mutates `endpoint.timeout_ms = cap_ms` on each cloned additional endpoint before constructing `SendData` |
| **Traces** — **primary endpoint** | ⚠ **Not yet adaptive.** Stays on the static `config.flush_timeout * S_TO_MS` set at trace-process time. Needs an upstream `SendDataBuilder::with_timeout_ms` in `libdatadog`. Follow-up PR will bump the rev. |

## Failure modes

Each wrapped `send()` now distinguishes three outcomes:

- **`Ok(Ok(resp))`** — success / non-fatal HTTP error (retried if `attempts < max_attempts`).
- **`Ok(Err(reqwest_err))`** — connection / transport error (same as before).
- **`Err(elapsed)`** — `tokio::time::timeout` fired before `send()` completed. New branch logged as `\"timed out after X ms (cap Y ms)\"` and counted as an attempt.

After exhausting `flush_retry_attempts`, the failure path returns the payload through the existing `FailedRequestError` / `FailedProxyRequestError` channel (no new error types).

## What's intentionally out of scope

- **Metrics path** (`dogstatsd` in `serverless-components`) — needs an upstream PR adding `.timeout(...)` on the `RequestBuilder` in `ship_data`. Tracked separately.
- **Primary trace endpoint** — needs upstream `libdd-trace-utils::SendDataBuilder::with_timeout_ms`. Tracked separately.
- **DLQ persistence across invocations** — next PR in this stack.
- **SHUTDOWN final-drain + drop logging** — also next.

## Test plan

- [x] `cargo test --lib` — all **532 tests pass** (no regressions; new branches covered by existing retry/redrive tests).
- [x] `cargo check` clean — no warnings.
- [ ] Local repro: rebuild layer with this PR, set up a hung HTTPS endpoint for one of the wrapped paths, confirm function completes within Lambda budget instead of timing out. Will run before merging the full stack.