### PR TITLE
test(integ): add SSM Parameter Store API key resolution test

### DIFF
--- a/.gitlab/datasources/test-suites.yaml
+++ b/.gitlab/datasources/test-suites.yaml
@@ -3,4 +3,4 @@ test_suites:
   - name: otlp
   - name: snapstart
   - name: lmi
-  - name: auth
+  - name: api-key

--- a/integration-tests/bin/app.ts
+++ b/integration-tests/bin/app.ts
@@ -5,7 +5,7 @@ import {OnDemand} from '../lib/stacks/on-demand';
 import {Otlp} from '../lib/stacks/otlp';
 import {Snapstart} from '../lib/stacks/snapstart';
 import {LambdaManagedInstancesStack} from '../lib/stacks/lmi';
-import {AuthStack} from '../lib/stacks/auth';
+import {ApiKeyStack} from '../lib/stacks/api-key';
 import {AuthRoleStack} from '../lib/auth-role';
 import {ACCOUNT, getIdentifier, REGION} from '../config';
 import {CapacityProviderStack} from "../lib/capacity-provider";
@@ -37,7 +37,7 @@ const stacks = [
     new LambdaManagedInstancesStack(app, `integ-${identifier}-lmi`, {
         env,
     }),
-    new AuthStack(app, `integ-${identifier}-auth`, {
+    new ApiKeyStack(app, `integ-${identifier}-api-key`, {
         env,
     }),
 ]

--- a/integration-tests/lib/stacks/api-key.ts
+++ b/integration-tests/lib/stacks/api-key.ts
@@ -4,27 +4,35 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
 import {
   createLogGroup,
+  datadogSsmParameterArn,
+  defaultDatadogSsmPolicy,
   getExtensionLayer,
   getDefaultJavaLayer,
+  getDefaultNodeLayer,
   defaultNodeRuntime,
   defaultJavaRuntime,
 } from '../util';
 import { AUTH_ROLE_NAME } from '../auth-role';
 
 /**
- * CDK Stack for Authentication Integration Tests
+ * CDK Stack for API Key Resolution Integration Tests
  *
- * Tests delegated authentication - Lambda uses IAM role to obtain API key.
- * Includes on-demand (Node) and SnapStart (Java) functions.
+ * Exercises each path the extension can use to authenticate to Datadog:
+ *   - Delegated auth (on-demand Node + SnapStart Java) - no API key; uses a
+ *     shared IAM role from AuthRoleStack so the intake mapping is stable.
+ *   - API key sourced from SSM Parameter Store (on-demand Node) - uses its own
+ *     default role with ssm:GetParameter on the integration-tests parameter.
  *
- * Uses a shared IAM role (from AuthRoleStack) so the intake mapping is stable.
+ * Additional sources (Secrets Manager, KMS-encrypted env var) can be added
+ * here as further Lambda functions.
  */
-export class AuthStack extends cdk.Stack {
+export class ApiKeyStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: cdk.StackProps) {
     super(scope, id, props);
 
     const extensionLayer = getExtensionLayer(this);
     const javaLayer = getDefaultJavaLayer(this);
+    const nodeLayer = getDefaultNodeLayer(this);
 
     const role = iam.Role.fromRoleName(this, 'AuthRole', AUTH_ROLE_NAME);
 
@@ -85,5 +93,37 @@ export class AuthStack extends cdk.Stack {
       aliasName: 'snapstart',
       version: javaVersion,
     });
+
+    const ssmAuthEnv = {
+      DD_API_KEY_SSM_ARN: datadogSsmParameterArn,
+      DD_SITE: 'datadoghq.com',
+      DD_ENV: 'integration',
+      DD_VERSION: '1.0.0',
+      DD_SERVERLESS_FLUSH_STRATEGY: 'end',
+      DD_SERVERLESS_LOGS_ENABLED: 'true',
+      DD_LOG_LEVEL: 'debug',
+      TS: Date.now().toString(),
+    };
+
+    const ssmNodeFunctionName = `${id}-ssm-node`;
+    const ssmNodeFn = new lambda.Function(this, ssmNodeFunctionName, {
+      runtime: defaultNodeRuntime,
+      architecture: lambda.Architecture.ARM_64,
+      handler: '/opt/nodejs/node_modules/datadog-lambda-js/handler.handler',
+      code: lambda.Code.fromAsset('./lambda/default-node'),
+      functionName: ssmNodeFunctionName,
+      timeout: cdk.Duration.seconds(30),
+      memorySize: 256,
+      environment: {
+        ...ssmAuthEnv,
+        DD_SERVICE: ssmNodeFunctionName,
+        DD_TRACE_ENABLED: 'true',
+        DD_LAMBDA_HANDLER: 'index.handler',
+      },
+      logGroup: createLogGroup(this, ssmNodeFunctionName),
+    });
+    ssmNodeFn.addToRolePolicy(defaultDatadogSsmPolicy);
+    ssmNodeFn.addLayers(extensionLayer);
+    ssmNodeFn.addLayers(nodeLayer);
   }
 }

--- a/integration-tests/lib/stacks/api-key.ts
+++ b/integration-tests/lib/stacks/api-key.ts
@@ -4,8 +4,6 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
 import {
   createLogGroup,
-  datadogSsmParameterArn,
-  defaultDatadogSsmPolicy,
   getExtensionLayer,
   getDefaultJavaLayer,
   getDefaultNodeLayer,
@@ -13,6 +11,18 @@ import {
   defaultJavaRuntime,
 } from '../util';
 import { AUTH_ROLE_NAME } from '../auth-role';
+
+const datadogSsmParameterArn = process.env.DATADOG_API_SSM_PARAMETER_ARN
+  || 'arn:aws:ssm:us-east-1:425362996713:parameter/extension-integration-tests/api-key';
+
+const datadogSsmPolicy = new iam.PolicyStatement({
+  effect: iam.Effect.ALLOW,
+  actions: [
+    'ssm:GetParameter',
+    'ssm:GetParameters',
+  ],
+  resources: [datadogSsmParameterArn],
+});
 
 /**
  * CDK Stack for API Key Resolution Integration Tests
@@ -122,7 +132,7 @@ export class ApiKeyStack extends cdk.Stack {
       },
       logGroup: createLogGroup(this, ssmNodeFunctionName),
     });
-    ssmNodeFn.addToRolePolicy(defaultDatadogSsmPolicy);
+    ssmNodeFn.addToRolePolicy(datadogSsmPolicy);
     ssmNodeFn.addLayers(extensionLayer);
     ssmNodeFn.addLayers(nodeLayer);
   }

--- a/integration-tests/lib/util.ts
+++ b/integration-tests/lib/util.ts
@@ -7,6 +7,8 @@ import { LayerVersion } from "aws-cdk-lib/aws-lambda";
 import {ACCOUNT, REGION} from "../config";
 
 export const datadogSecretArn = 'arn:aws:secretsmanager:us-east-1:425362996713:secret:extension-integration-tests-api-key-PnEPHz';
+export const datadogSsmParameterArn = process.env.DATADOG_API_SSM_PARAMETER_ARN
+  || 'arn:aws:ssm:us-east-1:425362996713:parameter/extension-integration-tests/api-key';
 export const extensionLayerArn = process.env.EXTENSION_LAYER_ARN!;
 
 export const defaultNodeRuntime = lambda.Runtime.NODEJS_24_X;
@@ -37,6 +39,15 @@ export const defaultDatadogSecretPolicy = new iam.PolicyStatement({
     'secretsmanager:DescribeSecret',
   ],
   resources: [datadogSecretArn],
+});
+
+export const defaultDatadogSsmPolicy = new iam.PolicyStatement({
+  effect: iam.Effect.ALLOW,
+  actions: [
+    'ssm:GetParameter',
+    'ssm:GetParameters',
+  ],
+  resources: [datadogSsmParameterArn],
 });
 
 export const createLogGroup = (scope: Construct, functionName: string) => {

--- a/integration-tests/lib/util.ts
+++ b/integration-tests/lib/util.ts
@@ -7,8 +7,6 @@ import { LayerVersion } from "aws-cdk-lib/aws-lambda";
 import {ACCOUNT, REGION} from "../config";
 
 export const datadogSecretArn = 'arn:aws:secretsmanager:us-east-1:425362996713:secret:extension-integration-tests-api-key-PnEPHz';
-export const datadogSsmParameterArn = process.env.DATADOG_API_SSM_PARAMETER_ARN
-  || 'arn:aws:ssm:us-east-1:425362996713:parameter/extension-integration-tests/api-key';
 export const extensionLayerArn = process.env.EXTENSION_LAYER_ARN!;
 
 export const defaultNodeRuntime = lambda.Runtime.NODEJS_24_X;
@@ -39,15 +37,6 @@ export const defaultDatadogSecretPolicy = new iam.PolicyStatement({
     'secretsmanager:DescribeSecret',
   ],
   resources: [datadogSecretArn],
-});
-
-export const defaultDatadogSsmPolicy = new iam.PolicyStatement({
-  effect: iam.Effect.ALLOW,
-  actions: [
-    'ssm:GetParameter',
-    'ssm:GetParameters',
-  ],
-  resources: [datadogSsmParameterArn],
 });
 
 export const createLogGroup = (scope: Construct, functionName: string) => {

--- a/integration-tests/tests/api-key.test.ts
+++ b/integration-tests/tests/api-key.test.ts
@@ -4,9 +4,9 @@ import { forceColdStart, publishVersion, waitForSnapStartReady } from './utils/l
 import { getIdentifier } from '../config';
 
 const identifier = getIdentifier();
-const stackName = `integ-${identifier}-auth`;
+const stackName = `integ-${identifier}-api-key`;
 
-describe('Auth Integration Tests', () => {
+describe('API Key Resolution Integration Tests', () => {
   let telemetry: Record<string, DatadogTelemetry>;
 
   const getFirstInvocation = (runtime: string) => telemetry[runtime]?.threads[0]?.[0];
@@ -14,8 +14,12 @@ describe('Auth Integration Tests', () => {
   beforeAll(async () => {
     const nodeFunctionName = `${stackName}-node`;
     const javaFunctionName = `${stackName}-java`;
+    const ssmNodeFunctionName = `${stackName}-ssm-node`;
 
-    await forceColdStart(nodeFunctionName);
+    await Promise.all([
+      forceColdStart(nodeFunctionName),
+      forceColdStart(ssmNodeFunctionName),
+    ]);
 
     const javaVersion = await publishVersion(javaFunctionName);
     await waitForSnapStartReady(javaFunctionName, javaVersion);
@@ -23,6 +27,7 @@ describe('Auth Integration Tests', () => {
     const functions: FunctionConfig[] = [
       { functionName: nodeFunctionName, runtime: 'node' },
       { functionName: `${javaFunctionName}:${javaVersion}`, runtime: 'java' },
+      { functionName: ssmNodeFunctionName, runtime: 'ssm-node' },
     ];
 
     telemetry = await invokeAndCollectTelemetry(functions, 1);
@@ -30,7 +35,7 @@ describe('Auth Integration Tests', () => {
     console.log('All invocations and data fetching completed');
   }, 600000);
 
-  describe('on-demand (node)', () => {
+  describe('delegated auth (node)', () => {
     it('should invoke Lambda successfully', () => {
       const result = getFirstInvocation('node');
       expect(result).toBeDefined();
@@ -44,7 +49,7 @@ describe('Auth Integration Tests', () => {
     });
   });
 
-  describe('snapstart (java)', () => {
+  describe('delegated auth (java, snapstart)', () => {
     it('should invoke Lambda successfully', () => {
       const result = getFirstInvocation('java');
       expect(result).toBeDefined();
@@ -55,6 +60,28 @@ describe('Auth Integration Tests', () => {
       const result = getFirstInvocation('java');
       expect(result).toBeDefined();
       expect(result.logs!.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('SSM Parameter Store API key (node)', () => {
+    const getInvocation = () => getFirstInvocation('ssm-node');
+
+    it('should invoke Lambda successfully when API key is sourced from SSM', () => {
+      const result = getInvocation();
+      expect(result).toBeDefined();
+      expect(result.statusCode).toBe(200);
+    });
+
+    it('should send logs to Datadog using API key fetched from SSM', () => {
+      const result = getInvocation();
+      expect(result).toBeDefined();
+      expect(result.logs!.length).toBeGreaterThan(0);
+    });
+
+    it('should send traces to Datadog using API key fetched from SSM', () => {
+      const result = getInvocation();
+      expect(result).toBeDefined();
+      expect(result.traces?.length).toBeGreaterThan(0);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds an integration test that exercises the extension fetching its Datadog API key from SSM Parameter Store at startup (`DD_API_KEY_SSM_ARN`, `WithDecryption=true` on a `SecureString`).
- Renames `AuthStack` → `ApiKeyStack` so the stack scope reads naturally as *everything the extension can do to obtain Datadog intake credentials* (delegated auth today, SSM added here, Secrets Manager / KMS can land alongside as additional functions later).
- The SSM parameter ARN and IAM policy live as local consts in `lib/stacks/api-key.ts`.
- Renames the GitLab suite from `auth` to `api-key` since we are now testing different ways to resolve an API key.

