### PR TITLE
[SVLS-8704] feat: rename durable function span tags to aws.durable.*

### DIFF
--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -52,12 +52,10 @@ const ACCOUNT_ID_KEY: &str = "account_id";
 
 // Span tag keys for durable function execution context
 pub const REQUEST_ID_KEY: &str = "request_id";
-pub const DURABLE_EXECUTION_ID_KEY: &str = "aws_lambda.durable_function.execution_id";
-pub const DURABLE_EXECUTION_NAME_KEY: &str = "aws_lambda.durable_function.execution_name";
-pub const DURABLE_FUNCTION_FIRST_INVOCATION_KEY: &str =
-    "aws_lambda.durable_function.first_invocation";
-pub const DURABLE_FUNCTION_EXECUTION_STATUS_KEY: &str =
-    "aws_lambda.durable_function.execution_status";
+pub const DURABLE_EXECUTION_ID_KEY: &str = "aws.durable.execution_id";
+pub const DURABLE_EXECUTION_NAME_KEY: &str = "aws.durable.execution_name";
+pub const DURABLE_FUNCTION_FIRST_INVOCATION_KEY: &str = "aws.durable.first_invocation";
+pub const DURABLE_FUNCTION_EXECUTION_STATUS_KEY: &str = "aws.durable.execution_status";
 
 const AWS_ACCOUNT_KEY: &str = "aws_account";
 const RESOURCE_KEY: &str = "resource";


### PR DESCRIPTION
## Summary
- Renames the `aws.lambda` span tag keys from `aws_lambda.durable_function.*` to `aws.durable.*` to match the upstream tracer-side rename.
- Affected keys: `execution_id`, `execution_name`, `first_invocation`, `execution_status`.
- Rust constant names are unchanged; only the emitted tag strings move.

Log payload field names in `logs/lambda/mod.rs` (`durable_function.*`) are not span tags on `aws.lambda` and are intentionally left untouched.

## Motivation
Suggested by @joeyzhao2018 and @pablomartinezbernardo . Slack: https://dd.slack.com/archives/C09N4B181G9/p1779297316670489

## Related PRs
https://github.com/DataDog/datadog-lambda-python/pull/829
https://github.com/DataDog/datadog-lambda-js/pull/778

## Test plan
Didn't do a manual e2e test since this change is trivial. Will do a manual test together with other changes later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)