### PR TITLE
feat(flushing): deadline-aware timeout for flush_blocking

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -438,8 +438,8 @@ async fn extension_loop_active(
         let stats_flusher_clone = Arc::clone(&stats_flusher);
         let proxy_flusher_clone = proxy_flusher.clone();
         let metrics_aggr_handle_clone = metrics_aggregator_handle.clone();
-        let shutdown_deadline_ms = Arc::new(AtomicU64::new(0));
-        let shutdown_deadline_ms_flush = Arc::clone(&shutdown_deadline_ms);
+        let shutdown_deadline_ms_flush = Arc::new(AtomicU64::new(0));
+        let shutdown_deadline_ms_shutdown = Arc::clone(&shutdown_deadline_ms_flush);
 
         // In Managed Instance mode, create a separate interval for the background flusher task.
         // We don't reuse race_flush_interval because we need to configure the missed tick
@@ -503,7 +503,7 @@ async fn extension_loop_active(
         let runtime_api_clone = aws_config.runtime_api.clone();
         let extension_id_clone = r.extension_id.clone();
         let client_clone = client.clone();
-        let shutdown_deadline_ms_clone = Arc::clone(&shutdown_deadline_ms);
+        let shutdown_deadline_ms_clone = shutdown_deadline_ms_shutdown;
 
         // Main event loop for Managed Instance mode: process telemetry events until shutdown
         //

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -97,7 +97,16 @@ use dogstatsd::{
 };
 use libdd_trace_obfuscation::obfuscation_config;
 use reqwest::Client;
-use std::{collections::hash_map, env, path::Path, str::FromStr, sync::Arc};
+use std::{
+    collections::hash_map,
+    env,
+    path::Path,
+    str::FromStr,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
 use tokio::time::Instant;
 use tokio::{sync::Mutex as TokioMutex, sync::mpsc::Sender};
 use tokio_util::sync::CancellationToken;
@@ -429,7 +438,8 @@ async fn extension_loop_active(
         let stats_flusher_clone = Arc::clone(&stats_flusher);
         let proxy_flusher_clone = proxy_flusher.clone();
         let metrics_aggr_handle_clone = metrics_aggregator_handle.clone();
-        let flush_timeout_clone = std::time::Duration::from_secs(config.flush_timeout);
+        let shutdown_deadline_ms = Arc::new(AtomicU64::new(0));
+        let shutdown_deadline_ms_flush = Arc::clone(&shutdown_deadline_ms);
 
         // In Managed Instance mode, create a separate interval for the background flusher task.
         // We don't reuse race_flush_interval because we need to configure the missed tick
@@ -460,7 +470,6 @@ async fn extension_loop_active(
                 proxy_flusher_clone,
                 metrics_flushers_clone,
                 metrics_aggr_handle_clone,
-                flush_timeout_clone,
             );
 
             loop {
@@ -477,7 +486,7 @@ async fn extension_loop_active(
                         flushing_service.await_handles().await;
                         // Final flush to capture any data that accumulated since the last
                         // spawn_non_blocking(). This is our last opportunity to send data.
-                        flushing_service.flush_blocking_final().await;
+                        flushing_service.flush_blocking_final(shutdown_deadline_ms_flush.load(Ordering::Relaxed)).await;
                         break;
                     }
                 }
@@ -494,6 +503,7 @@ async fn extension_loop_active(
         let runtime_api_clone = aws_config.runtime_api.clone();
         let extension_id_clone = r.extension_id.clone();
         let client_clone = client.clone();
+        let shutdown_deadline_ms_clone = Arc::clone(&shutdown_deadline_ms);
 
         // Main event loop for Managed Instance mode: process telemetry events until shutdown
         //
@@ -519,8 +529,9 @@ async fn extension_loop_active(
                         .await;
 
                 match next_response {
-                    Ok(NextEventResponse::Shutdown { .. }) => {
+                    Ok(NextEventResponse::Shutdown { deadline_ms, .. }) => {
                         debug!("Shutdown event received, stopping extension loop");
+                        shutdown_deadline_ms_clone.store(deadline_ms, Ordering::Relaxed);
                         // Notify the invocation processor about shutdown
                         if let Err(e) = invocation_processor_handle_clone.on_shutdown_event().await
                         {
@@ -635,9 +646,10 @@ async fn extension_loop_active(
         proxy_flusher.clone(),
         Arc::clone(&metrics_flushers),
         metrics_aggregator_handle.clone(),
-        std::time::Duration::from_secs(config.flush_timeout),
     );
-    handle_next_invocation(next_lambda_response, &invocation_processor_handle).await;
+    let first_event =
+        handle_next_invocation(next_lambda_response, &invocation_processor_handle).await;
+    let mut current_deadline_ms = first_event.deadline_ms();
     loop {
         let maybe_shutdown_event;
 
@@ -658,18 +670,19 @@ async fn extension_loop_active(
                                 }
                         }
                         _ = race_flush_interval.tick() => {
-                            flushing_service.flush_blocking().await;
+                            flushing_service.flush_blocking(current_deadline_ms).await;
                             race_flush_interval.reset();
                         }
                     }
                 }
                 // flush
-                flushing_service.flush_blocking().await;
+                flushing_service.flush_blocking(current_deadline_ms).await;
                 race_flush_interval.reset();
                 let next_response =
                     extension::next_event(client, &aws_config.runtime_api, &r.extension_id).await;
                 maybe_shutdown_event =
                     handle_next_invocation(next_response, &invocation_processor_handle).await;
+                current_deadline_ms = maybe_shutdown_event.deadline_ms();
             }
             FlushDecision::Continuous | FlushDecision::Periodic | FlushDecision::Dont => {
                 match current_flush_decision {
@@ -681,7 +694,7 @@ async fn extension_loop_active(
                         }
                     }
                     FlushDecision::Periodic => {
-                        flushing_service.flush_blocking().await;
+                        flushing_service.flush_blocking(current_deadline_ms).await;
                         race_flush_interval.reset();
                     }
                     _ => {
@@ -701,6 +714,7 @@ async fn extension_loop_active(
                     biased;
                         next_response = &mut next_lambda_response => {
                             maybe_shutdown_event = handle_next_invocation(next_response, &invocation_processor_handle).await;
+                            current_deadline_ms = maybe_shutdown_event.deadline_ms();
                             // Need to break here to re-call next
                             break 'next_invocation;
                         }
@@ -709,7 +723,7 @@ async fn extension_loop_active(
                         }
                         _ = race_flush_interval.tick() => {
                             if flush_control.flush_strategy == FlushStrategy::Default {
-                                flushing_service.flush_blocking().await;
+                                flushing_service.flush_blocking(current_deadline_ms).await;
                                 race_flush_interval.reset();
                             }
                         }
@@ -718,7 +732,7 @@ async fn extension_loop_active(
             }
         }
 
-        if let NextEventResponse::Shutdown { .. } = maybe_shutdown_event {
+        if let NextEventResponse::Shutdown { deadline_ms, .. } = maybe_shutdown_event {
             // Cancel Telemetry API listener
             // Important to do this first, so we can receive the Tombstone event which signals
             // that there are no more Telemetry events to process
@@ -756,7 +770,7 @@ async fn extension_loop_active(
             );
 
             // Final flush - this is our last opportunity to send data before shutdown
-            flushing_service.flush_blocking_final().await;
+            flushing_service.flush_blocking_final(deadline_ms).await;
 
             // Even though we're shutting down, we need to reset the flush interval to prevent any future flushes
             race_flush_interval.reset();

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -429,6 +429,7 @@ async fn extension_loop_active(
         let stats_flusher_clone = Arc::clone(&stats_flusher);
         let proxy_flusher_clone = proxy_flusher.clone();
         let metrics_aggr_handle_clone = metrics_aggregator_handle.clone();
+        let flush_timeout_clone = std::time::Duration::from_secs(config.flush_timeout);
 
         // In Managed Instance mode, create a separate interval for the background flusher task.
         // We don't reuse race_flush_interval because we need to configure the missed tick
@@ -459,6 +460,7 @@ async fn extension_loop_active(
                 proxy_flusher_clone,
                 metrics_flushers_clone,
                 metrics_aggr_handle_clone,
+                flush_timeout_clone,
             );
 
             loop {
@@ -633,6 +635,7 @@ async fn extension_loop_active(
         proxy_flusher.clone(),
         Arc::clone(&metrics_flushers),
         metrics_aggregator_handle.clone(),
+        std::time::Duration::from_secs(config.flush_timeout),
     );
     handle_next_invocation(next_lambda_response, &invocation_processor_handle).await;
     loop {

--- a/bottlecap/src/extension/mod.rs
+++ b/bottlecap/src/extension/mod.rs
@@ -76,6 +76,16 @@ pub enum NextEventResponse {
     },
 }
 
+impl NextEventResponse {
+    #[must_use]
+    pub fn deadline_ms(&self) -> u64 {
+        match self {
+            NextEventResponse::Invoke { deadline_ms, .. }
+            | NextEventResponse::Shutdown { deadline_ms, .. } => *deadline_ms,
+        }
+    }
+}
+
 /// Return the base URL for the Lambda Runtime API
 ///
 #[must_use]

--- a/bottlecap/src/flushing/service.rs
+++ b/bottlecap/src/flushing/service.rs
@@ -1,7 +1,7 @@
 //! `FlushingService` for coordinating flush operations across multiple flusher types.
 
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use tracing::{debug, error};
 
@@ -35,8 +35,6 @@ pub struct FlushingService {
 
     // Pending flush handles
     handles: FlushHandles,
-
-    flush_timeout: Duration,
 }
 
 impl FlushingService {
@@ -49,7 +47,6 @@ impl FlushingService {
         proxy_flusher: Arc<ProxyFlusher>,
         metrics_flushers: Arc<Vec<MetricsFlusher>>,
         metrics_aggr_handle: MetricsAggregatorHandle,
-        flush_timeout: Duration,
     ) -> Self {
         Self {
             logs_flusher,
@@ -59,7 +56,6 @@ impl FlushingService {
             metrics_flushers,
             metrics_aggr_handle,
             handles: FlushHandles::new(),
-            flush_timeout,
         }
     }
 
@@ -293,8 +289,8 @@ impl FlushingService {
     ///
     /// The stats flusher respects its normal timing constraints (time-based bucketing),
     /// which may result in some stats being held back until the next flush cycle.
-    pub async fn flush_blocking(&self) {
-        self.flush_blocking_inner(false).await;
+    pub async fn flush_blocking(&self, deadline_ms: u64) {
+        self.flush_blocking_inner(false, deadline_ms).await;
     }
 
     /// Performs a final blocking flush of all telemetry data before shutdown.
@@ -304,14 +300,14 @@ impl FlushingService {
     /// flush immediately regardless of its normal timing constraints.
     ///
     /// Use this during shutdown when this is the last opportunity to send data.
-    pub async fn flush_blocking_final(&self) {
-        self.flush_blocking_inner(true).await;
+    pub async fn flush_blocking_final(&self, deadline_ms: u64) {
+        self.flush_blocking_inner(true, deadline_ms).await;
     }
 
     /// Internal implementation for blocking flush operations.
     ///
     /// Fetches metrics from the aggregator and flushes all data types in parallel.
-    async fn flush_blocking_inner(&self, force_stats: bool) {
+    async fn flush_blocking_inner(&self, force_stats: bool, deadline_ms: u64) {
         let flush_response = self
             .metrics_aggr_handle
             .flush()
@@ -329,6 +325,12 @@ impl FlushingService {
             })
             .collect();
 
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        let remaining = Duration::from_millis(deadline_ms.saturating_sub(now_ms));
+
         let flush = async {
             tokio::join!(
                 self.logs_flusher.flush(None),
@@ -340,9 +342,8 @@ impl FlushingService {
         };
         tokio::pin!(flush);
 
-        let timeout = self.flush_timeout;
-        let warn_at = tokio::time::sleep(timeout.saturating_sub(Duration::from_millis(50)));
-        let cancel_at = tokio::time::sleep(timeout);
+        let warn_at = tokio::time::sleep(remaining.saturating_sub(Duration::from_millis(50)));
+        let cancel_at = tokio::time::sleep(remaining);
         tokio::pin!(warn_at);
         tokio::pin!(cancel_at);
 
@@ -355,7 +356,7 @@ impl FlushingService {
                     error!("FLUSHING_SERVICE | flush approaching timeout, canceling in 50ms, data will be dropped");
                 }
                 _ = &mut cancel_at => {
-                    error!("FLUSHING_SERVICE | flush timed out after {:?}, canceling all in-flight requests", timeout);
+                    error!("FLUSHING_SERVICE | flush timed out, canceling all in-flight requests");
                     break;
                 }
             }

--- a/bottlecap/src/flushing/service.rs
+++ b/bottlecap/src/flushing/service.rs
@@ -348,7 +348,9 @@ impl FlushingService {
             .await
             .is_err()
         {
-            error!("FLUSHING_SERVICE | flush canceled: Lambda deadline exceeded, in-flight requests dropped");
+            error!(
+                "FLUSHING_SERVICE | flush canceled: Lambda deadline exceeded, in-flight requests dropped"
+            );
         }
     }
 }

--- a/bottlecap/src/flushing/service.rs
+++ b/bottlecap/src/flushing/service.rs
@@ -1,6 +1,7 @@
 //! `FlushingService` for coordinating flush operations across multiple flusher types.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use tracing::{debug, error};
 
@@ -34,6 +35,8 @@ pub struct FlushingService {
 
     // Pending flush handles
     handles: FlushHandles,
+
+    flush_timeout: Duration,
 }
 
 impl FlushingService {
@@ -46,6 +49,7 @@ impl FlushingService {
         proxy_flusher: Arc<ProxyFlusher>,
         metrics_flushers: Arc<Vec<MetricsFlusher>>,
         metrics_aggr_handle: MetricsAggregatorHandle,
+        flush_timeout: Duration,
     ) -> Self {
         Self {
             logs_flusher,
@@ -55,6 +59,7 @@ impl FlushingService {
             metrics_flushers,
             metrics_aggr_handle,
             handles: FlushHandles::new(),
+            flush_timeout,
         }
     }
 
@@ -324,13 +329,37 @@ impl FlushingService {
             })
             .collect();
 
-        tokio::join!(
-            self.logs_flusher.flush(None),
-            futures::future::join_all(metrics_futures),
-            self.trace_flusher.flush(None),
-            self.stats_flusher.flush(force_stats, None),
-            self.proxy_flusher.flush(None),
-        );
+        let flush = async {
+            tokio::join!(
+                self.logs_flusher.flush(None),
+                futures::future::join_all(metrics_futures),
+                self.trace_flusher.flush(None),
+                self.stats_flusher.flush(force_stats, None),
+                self.proxy_flusher.flush(None),
+            );
+        };
+        tokio::pin!(flush);
+
+        let timeout = self.flush_timeout;
+        let warn_at = tokio::time::sleep(timeout.saturating_sub(Duration::from_millis(50)));
+        let cancel_at = tokio::time::sleep(timeout);
+        tokio::pin!(warn_at);
+        tokio::pin!(cancel_at);
+
+        let mut warned = false;
+        loop {
+            tokio::select! {
+                _ = &mut flush => break,
+                _ = &mut warn_at, if !warned => {
+                    warned = true;
+                    error!("FLUSHING_SERVICE | flush approaching timeout, canceling in 50ms, data will be dropped");
+                }
+                _ = &mut cancel_at => {
+                    error!("FLUSHING_SERVICE | flush timed out after {:?}, canceling all in-flight requests", timeout);
+                    break;
+                }
+            }
+        }
     }
 }
 

--- a/bottlecap/src/flushing/service.rs
+++ b/bottlecap/src/flushing/service.rs
@@ -335,8 +335,6 @@ impl FlushingService {
                 .as_millis(),
         )
         .unwrap_or(u64::MAX);
-        let remaining = Duration::from_millis(deadline_ms.saturating_sub(now_ms));
-
         let flush = async {
             tokio::join!(
                 self.logs_flusher.flush(None),
@@ -347,6 +345,12 @@ impl FlushingService {
             );
         };
 
+        if now_ms >= deadline_ms {
+            flush.await;
+            return;
+        }
+
+        let remaining = Duration::from_millis(deadline_ms - now_ms);
         if tokio::time::timeout(remaining.saturating_sub(FLUSH_CANCEL_GAP), flush)
             .await
             .is_err()

--- a/bottlecap/src/flushing/service.rs
+++ b/bottlecap/src/flushing/service.rs
@@ -16,10 +16,8 @@ use crate::traces::{
     trace_flusher::TraceFlusher,
 };
 
-/// How far before the Lambda deadline to emit the pre-cancellation warning.
-const FLUSH_WARN_GAP: Duration = Duration::from_millis(50);
 /// How far before the Lambda deadline to cancel all in-flight flush requests.
-const FLUSH_CANCEL_GAP: Duration = Duration::from_millis(0);
+const FLUSH_CANCEL_GAP: Duration = Duration::from_millis(100);
 
 /// Service for coordinating flush operations across all flusher types.
 ///
@@ -345,26 +343,12 @@ impl FlushingService {
                 self.proxy_flusher.flush(None),
             );
         };
-        tokio::pin!(flush);
 
-        let warn_at = tokio::time::sleep(remaining.saturating_sub(FLUSH_WARN_GAP));
-        let cancel_at = tokio::time::sleep(remaining.saturating_sub(FLUSH_CANCEL_GAP));
-        tokio::pin!(warn_at);
-        tokio::pin!(cancel_at);
-
-        let mut warned = false;
-        loop {
-            tokio::select! {
-                _ = &mut flush => break,
-                _ = &mut warn_at, if !warned => {
-                    warned = true;
-                    error!("FLUSHING_SERVICE | flush approaching timeout, canceling in 50ms, data will be dropped");
-                }
-                _ = &mut cancel_at => {
-                    error!("FLUSHING_SERVICE | flush timed out, canceling all in-flight requests");
-                    break;
-                }
-            }
+        if tokio::time::timeout(remaining.saturating_sub(FLUSH_CANCEL_GAP), flush)
+            .await
+            .is_err()
+        {
+            error!("FLUSHING_SERVICE | flush canceled: Lambda deadline exceeded, in-flight requests dropped");
         }
     }
 }

--- a/bottlecap/src/flushing/service.rs
+++ b/bottlecap/src/flushing/service.rs
@@ -328,10 +328,13 @@ impl FlushingService {
             })
             .collect();
 
-        let now_ms = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
+        let now_ms = u64::try_from(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis(),
+        )
+        .unwrap_or(u64::MAX);
         let remaining = Duration::from_millis(deadline_ms.saturating_sub(now_ms));
 
         let flush = async {

--- a/bottlecap/src/flushing/service.rs
+++ b/bottlecap/src/flushing/service.rs
@@ -16,6 +16,11 @@ use crate::traces::{
     trace_flusher::TraceFlusher,
 };
 
+/// How far before the Lambda deadline to emit the pre-cancellation warning.
+const FLUSH_WARN_GAP: Duration = Duration::from_millis(50);
+/// How far before the Lambda deadline to cancel all in-flight flush requests.
+const FLUSH_CANCEL_GAP: Duration = Duration::from_millis(0);
+
 /// Service for coordinating flush operations across all flusher types.
 ///
 /// This service provides a unified interface for:
@@ -342,8 +347,8 @@ impl FlushingService {
         };
         tokio::pin!(flush);
 
-        let warn_at = tokio::time::sleep(remaining.saturating_sub(Duration::from_millis(50)));
-        let cancel_at = tokio::time::sleep(remaining);
+        let warn_at = tokio::time::sleep(remaining.saturating_sub(FLUSH_WARN_GAP));
+        let cancel_at = tokio::time::sleep(remaining.saturating_sub(FLUSH_CANCEL_GAP));
         tokio::pin!(warn_at);
         tokio::pin!(cancel_at);
 


### PR DESCRIPTION
## What

`flush_blocking` and `flush_blocking_final` previously used a bare `tokio::join!` with no overall timeout. If any flusher stalled, the join blocked indefinitely — risking Lambda killing the process mid-flush with no signal or log.

## How

`flush_blocking_inner` now computes the time remaining until the Lambda deadline (`deadline_ms` from the Extensions API `/next` response) and wraps all parallel flushers in a `tokio::time::timeout`. If the deadline is exceeded, in-flight HTTP requests are dropped and an error is logged.

```rust
// FLUSH_CANCEL_GAP = 100ms safety margin before the hard Lambda deadline
if tokio::time::timeout(remaining.saturating_sub(FLUSH_CANCEL_GAP), flush)
    .await
    .is_err()
{
    error!("FLUSHING_SERVICE | flush canceled: Lambda deadline exceeded, in-flight requests dropped");
}
```

The 100ms gap matches the `dd-trace-py`/`dd-trace-js` precedent and is conservative for Rust, which tears down async futures faster than Python.

## Changes

- **`flushing/service.rs`**: wraps `tokio::join!` in `tokio::time::timeout`; adds `FLUSH_CANCEL_GAP = 100ms`; `flush_blocking` / `flush_blocking_final` now accept `deadline_ms: u64`
- **`extension/mod.rs`**: adds `NextEventResponse::deadline_ms()` helper to extract the deadline from either event variant
- **`main.rs` (OnDemand mode)**: tracks `current_deadline_ms` from each `NextEventResponse` and passes it to every `flush_blocking` call site
- **`main.rs` (Managed Instance mode)**: shares `deadline_ms` from the shutdown task to the flush task via `Arc<AtomicU64>` (the two tasks are separate `tokio::spawn`s and cannot share a stack variable)

## Test plan

- [ ] `cargo build -p bottlecap` passes (verified locally)
- [ ] Timeout regression test (follow-up): construct `FlushingService` with httpmock servers that never respond and a short `deadline_ms`, assert `flush_blocking` returns in bounded time and logs the cancel message