### PR TITLE
[SVLS-9189] feat(logs): add config param DD_LAMBDA_DURABLE_FUNCTION_LOG_BUFFER_SIZE

### DIFF
--- a/bottlecap/src/config/env.rs
+++ b/bottlecap/src/config/env.rs
@@ -489,14 +489,14 @@ pub struct EnvConfig {
     #[serde(deserialize_with = "deserialize_string_or_int")]
     pub org_uuid: Option<String>,
 
-    /// @env `DD_DURABLE_FUNCTION_LOG_BUFFER_SIZE`
+    /// @env `DD_LAMBDA_DURABLE_FUNCTION_LOG_BUFFER_SIZE`
     ///
     /// Maximum number of request IDs whose logs are held waiting for durable execution
     /// context. Set to 0 to disable log holding; logs will be sent immediately without
     /// durable execution context enrichment. Useful when the tracer is not installed.
     /// Default is `0`.
     #[serde(deserialize_with = "deserialize_option_lossless")]
-    pub durable_function_log_buffer_size: Option<usize>,
+    pub lambda_durable_function_log_buffer_size: Option<usize>,
 }
 
 #[allow(clippy::too_many_lines)]
@@ -701,7 +701,7 @@ fn merge_config(config: &mut Config, env_config: &EnvConfig) {
     merge_option_to_value!(config, env_config, api_security_sample_delay);
 
     merge_string!(config, dd_org_uuid, env_config, org_uuid);
-    merge_option_to_value!(config, env_config, durable_function_log_buffer_size);
+    merge_option_to_value!(config, env_config, lambda_durable_function_log_buffer_size);
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -1064,7 +1064,7 @@ mod tests {
                 api_security_sample_delay: Duration::from_secs(60),
 
                 dd_org_uuid: String::default(),
-                durable_function_log_buffer_size: 0,
+                lambda_durable_function_log_buffer_size: 0,
             };
 
             assert_eq!(config, expected_config);

--- a/bottlecap/src/config/env.rs
+++ b/bottlecap/src/config/env.rs
@@ -488,6 +488,15 @@ pub struct EnvConfig {
     /// The Datadog organization UUID. When set, delegated auth is auto-enabled.
     #[serde(deserialize_with = "deserialize_string_or_int")]
     pub org_uuid: Option<String>,
+
+    /// @env `DD_DURABLE_FUNCTION_LOG_BUFFER_SIZE`
+    ///
+    /// Maximum number of request IDs whose logs are held waiting for durable execution
+    /// context. Set to 0 to disable log holding; logs will be sent immediately without
+    /// durable execution context enrichment. Useful when the tracer is not installed.
+    /// Default is `50`.
+    #[serde(deserialize_with = "deserialize_option_lossless")]
+    pub durable_function_log_buffer_size: Option<usize>,
 }
 
 #[allow(clippy::too_many_lines)]
@@ -692,6 +701,7 @@ fn merge_config(config: &mut Config, env_config: &EnvConfig) {
     merge_option_to_value!(config, env_config, api_security_sample_delay);
 
     merge_string!(config, dd_org_uuid, env_config, org_uuid);
+    merge_option_to_value!(config, env_config, durable_function_log_buffer_size);
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -1054,6 +1064,7 @@ mod tests {
                 api_security_sample_delay: Duration::from_secs(60),
 
                 dd_org_uuid: String::default(),
+                durable_function_log_buffer_size: 50,
             };
 
             assert_eq!(config, expected_config);

--- a/bottlecap/src/config/env.rs
+++ b/bottlecap/src/config/env.rs
@@ -494,7 +494,7 @@ pub struct EnvConfig {
     /// Maximum number of request IDs whose logs are held waiting for durable execution
     /// context. Set to 0 to disable log holding; logs will be sent immediately without
     /// durable execution context enrichment. Useful when the tracer is not installed.
-    /// Default is `50`.
+    /// Default is `0`.
     #[serde(deserialize_with = "deserialize_option_lossless")]
     pub durable_function_log_buffer_size: Option<usize>,
 }
@@ -1064,7 +1064,7 @@ mod tests {
                 api_security_sample_delay: Duration::from_secs(60),
 
                 dd_org_uuid: String::default(),
-                durable_function_log_buffer_size: 50,
+                durable_function_log_buffer_size: 0,
             };
 
             assert_eq!(config, expected_config);

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -376,7 +376,7 @@ pub struct Config {
     /// execution context. Set to 0 to disable log holding; logs will be flushed immediately
     /// without durable execution context enrichment. Defaults to 0 until the tracer-side
     /// durable execution support is released; set to 50 to re-enable enrichment.
-    pub durable_function_log_buffer_size: usize,
+    pub lambda_durable_function_log_buffer_size: usize,
 }
 
 impl Default for Config {
@@ -495,7 +495,7 @@ impl Default for Config {
             api_security_enabled: true,
             api_security_sample_delay: Duration::from_secs(30),
 
-            durable_function_log_buffer_size: 0,
+            lambda_durable_function_log_buffer_size: 0,
         }
     }
 }

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -371,6 +371,11 @@ pub struct Config {
     pub appsec_waf_timeout: Duration,
     pub api_security_enabled: bool,
     pub api_security_sample_delay: Duration,
+
+    /// Maximum number of request IDs whose logs are held in `held_logs` waiting for durable
+    /// execution context. Set to 0 to disable log holding; logs will be flushed immediately
+    /// without durable execution context enrichment. Useful when the tracer is not installed.
+    pub durable_function_log_buffer_size: usize,
 }
 
 impl Default for Config {
@@ -488,6 +493,8 @@ impl Default for Config {
             appsec_waf_timeout: Duration::from_millis(5),
             api_security_enabled: true,
             api_security_sample_delay: Duration::from_secs(30),
+
+            durable_function_log_buffer_size: 50,
         }
     }
 }

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -374,7 +374,8 @@ pub struct Config {
 
     /// Maximum number of request IDs whose logs are held in `held_logs` waiting for durable
     /// execution context. Set to 0 to disable log holding; logs will be flushed immediately
-    /// without durable execution context enrichment. Useful when the tracer is not installed.
+    /// without durable execution context enrichment. Defaults to 0 until the tracer-side
+    /// durable execution support is released; set to 50 to re-enable enrichment.
     pub durable_function_log_buffer_size: usize,
 }
 
@@ -494,7 +495,7 @@ impl Default for Config {
             api_security_enabled: true,
             api_security_sample_delay: Duration::from_secs(30),
 
-            durable_function_log_buffer_size: 50,
+            durable_function_log_buffer_size: 0,
         }
     }
 }

--- a/bottlecap/src/config/yaml.rs
+++ b/bottlecap/src/config/yaml.rs
@@ -1038,7 +1038,7 @@ api_security_sample_delay: 60 # Seconds
                 dogstatsd_queue_size: Some(2048),
 
                 dd_org_uuid: String::default(),
-                durable_function_log_buffer_size: 0,
+                lambda_durable_function_log_buffer_size: 0,
             };
 
             // Assert that

--- a/bottlecap/src/config/yaml.rs
+++ b/bottlecap/src/config/yaml.rs
@@ -1038,6 +1038,7 @@ api_security_sample_delay: 60 # Seconds
                 dogstatsd_queue_size: Some(2048),
 
                 dd_org_uuid: String::default(),
+                durable_function_log_buffer_size: 50,
             };
 
             // Assert that

--- a/bottlecap/src/config/yaml.rs
+++ b/bottlecap/src/config/yaml.rs
@@ -1038,7 +1038,7 @@ api_security_sample_delay: 60 # Seconds
                 dogstatsd_queue_size: Some(2048),
 
                 dd_org_uuid: String::default(),
-                durable_function_log_buffer_size: 50,
+                durable_function_log_buffer_size: 0,
             };
 
             // Assert that

--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -60,15 +60,13 @@ pub struct LambdaProcessor {
     durable_context_map: HashMap<String, DurableExecutionContext>,
     // Insertion order for FIFO eviction when map reaches capacity
     durable_context_order: VecDeque<String>,
+    // Max number of request ID keys in held_logs. 0 disables holding entirely.
+    held_logs_max_keys: usize,
 }
 
 // Matches `lifecycle::invocation::ContextBuffer` default capacity: sized to absorb async
 // event backlog where invocation contexts may arrive out of order.
 const DURABLE_CONTEXT_MAP_CAPACITY: usize = 500;
-// Kept intentionally small: at shutdown, all held logs are flushed without durable context.
-// A large cap would mean a large batch sent in one shot, increasing the risk of the final
-// flush timing out when the tracer is not installed.
-const HELD_LOGS_MAX_KEYS: usize = 50;
 
 const OOM_ERRORS: [&str; 7] = [
     "fatal error: runtime: out of memory",       // Go
@@ -143,6 +141,7 @@ impl LambdaProcessor {
 
         let processing_rules = &datadog_config.logs_config_processing_rules;
         let logs_enabled = datadog_config.serverless_logs_enabled;
+        let held_logs_max_keys = datadog_config.durable_function_log_buffer_size;
         let rules = LambdaProcessor::compile_rules(processing_rules);
         LambdaProcessor {
             function_arn,
@@ -160,6 +159,7 @@ impl LambdaProcessor {
             held_logs_order: VecDeque::new(),
             durable_context_map: HashMap::with_capacity(DURABLE_CONTEXT_MAP_CAPACITY),
             durable_context_order: VecDeque::with_capacity(DURABLE_CONTEXT_MAP_CAPACITY),
+            held_logs_max_keys,
         }
     }
 
@@ -684,7 +684,7 @@ impl LambdaProcessor {
     /// arrives.
     fn hold_log(&mut self, request_id: String, log: IntakeLog) {
         if !self.held_logs.contains_key(&request_id) {
-            while self.held_logs.len() >= HELD_LOGS_MAX_KEYS {
+            while self.held_logs.len() >= self.held_logs_max_keys {
                 // Evict the oldest key to ready_logs (without durable context tags).
                 if let Some(oldest) = self.held_logs_order.pop_front()
                     && let Some(evicted) = self.held_logs.remove(&oldest)
@@ -716,6 +716,16 @@ impl LambdaProcessor {
     fn queue_log_after_rules(&mut self, log: IntakeLog) {
         // Durable execution SDK logs already carry execution context extracted from executionArn.
         if log.message.lambda.durable_execution_id.is_some() {
+            if let Ok(serialized_log) = serde_json::to_string(&log) {
+                drop(log);
+                self.ready_logs.push(serialized_log);
+            }
+            return;
+        }
+
+        // When the buffer is disabled, skip holding and send logs immediately without
+        // durable execution context enrichment.
+        if self.held_logs_max_keys == 0 {
             if let Ok(serialized_log) = serde_json::to_string(&log) {
                 drop(log);
                 self.ready_logs.push(serialized_log);

--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -142,7 +142,7 @@ impl LambdaProcessor {
         let processing_rules = &datadog_config.logs_config_processing_rules;
         let logs_enabled = datadog_config.serverless_logs_enabled;
         let lambda_durable_function_log_buffer_size =
-            datadog_config.durable_function_log_buffer_size;
+            datadog_config.lambda_durable_function_log_buffer_size;
         let rules = LambdaProcessor::compile_rules(processing_rules);
         LambdaProcessor {
             function_arn,

--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -683,7 +683,13 @@ impl LambdaProcessor {
     /// its logs are drained to `ready_logs` without durable context tags. This ensures logs are
     /// always eventually sent to Datadog even if the tracer is not installed and context never
     /// arrives.
+    ///
+    /// Callers must ensure `self.lambda_durable_function_log_buffer_size > 0` before invoking
+    /// this function. A safety net at the top returns early if the invariant is violated.
     fn hold_log(&mut self, request_id: String, log: IntakeLog) {
+        if self.lambda_durable_function_log_buffer_size == 0 {
+            return;
+        }
         if !self.held_logs.contains_key(&request_id) {
             while self.held_logs.len() >= self.lambda_durable_function_log_buffer_size {
                 // Evict the oldest key to ready_logs (without durable context tags).

--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -61,7 +61,7 @@ pub struct LambdaProcessor {
     // Insertion order for FIFO eviction when map reaches capacity
     durable_context_order: VecDeque<String>,
     // Max number of request ID keys in held_logs. 0 disables holding entirely.
-    held_logs_max_keys: usize,
+    lambda_durable_function_log_buffer_size: usize,
 }
 
 // Matches `lifecycle::invocation::ContextBuffer` default capacity: sized to absorb async
@@ -141,7 +141,7 @@ impl LambdaProcessor {
 
         let processing_rules = &datadog_config.logs_config_processing_rules;
         let logs_enabled = datadog_config.serverless_logs_enabled;
-        let held_logs_max_keys = datadog_config.durable_function_log_buffer_size;
+        let lambda_durable_function_log_buffer_size = datadog_config.durable_function_log_buffer_size;
         let rules = LambdaProcessor::compile_rules(processing_rules);
         LambdaProcessor {
             function_arn,
@@ -159,7 +159,7 @@ impl LambdaProcessor {
             held_logs_order: VecDeque::new(),
             durable_context_map: HashMap::with_capacity(DURABLE_CONTEXT_MAP_CAPACITY),
             durable_context_order: VecDeque::with_capacity(DURABLE_CONTEXT_MAP_CAPACITY),
-            held_logs_max_keys,
+            lambda_durable_function_log_buffer_size,
         }
     }
 
@@ -684,7 +684,7 @@ impl LambdaProcessor {
     /// arrives.
     fn hold_log(&mut self, request_id: String, log: IntakeLog) {
         if !self.held_logs.contains_key(&request_id) {
-            while self.held_logs.len() >= self.held_logs_max_keys {
+            while self.held_logs.len() >= self.lambda_durable_function_log_buffer_size {
                 // Evict the oldest key to ready_logs (without durable context tags).
                 if let Some(oldest) = self.held_logs_order.pop_front()
                     && let Some(evicted) = self.held_logs.remove(&oldest)
@@ -725,7 +725,7 @@ impl LambdaProcessor {
 
         // When the buffer is disabled, skip holding and send logs immediately without
         // durable execution context enrichment.
-        if self.held_logs_max_keys == 0 {
+        if self.lambda_durable_function_log_buffer_size == 0 {
             if let Ok(serialized_log) = serde_json::to_string(&log) {
                 drop(log);
                 self.ready_logs.push(serialized_log);
@@ -2579,7 +2579,7 @@ mod tests {
     #[tokio::test]
     async fn test_function_log_without_execution_arn_is_held_in_durable_mode() {
         let mut processor = make_processor_for_durable_arn_tests();
-        processor.held_logs_max_keys = 50;
+        processor.lambda_durable_function_log_buffer_size = 50;
         processor.is_durable_function = Some(true);
         // Simulate a known request_id with no durable context yet
         processor.invocation_context.request_id = "req-123".to_string();
@@ -2605,7 +2605,7 @@ mod tests {
             (None, serde_json::Value::Null),
         ] {
             let mut processor = make_processor_for_durable_arn_tests();
-            processor.held_logs_max_keys = 50;
+            processor.lambda_durable_function_log_buffer_size = 50;
             processor.is_durable_function = Some(true);
             processor.invocation_context.request_id = "req-end".to_string();
             processor.insert_to_durable_context_map(

--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -141,7 +141,8 @@ impl LambdaProcessor {
 
         let processing_rules = &datadog_config.logs_config_processing_rules;
         let logs_enabled = datadog_config.serverless_logs_enabled;
-        let lambda_durable_function_log_buffer_size = datadog_config.durable_function_log_buffer_size;
+        let lambda_durable_function_log_buffer_size =
+            datadog_config.durable_function_log_buffer_size;
         let rules = LambdaProcessor::compile_rules(processing_rules);
         LambdaProcessor {
             function_arn,

--- a/bottlecap/src/logs/lambda/processor.rs
+++ b/bottlecap/src/logs/lambda/processor.rs
@@ -2579,6 +2579,7 @@ mod tests {
     #[tokio::test]
     async fn test_function_log_without_execution_arn_is_held_in_durable_mode() {
         let mut processor = make_processor_for_durable_arn_tests();
+        processor.held_logs_max_keys = 50;
         processor.is_durable_function = Some(true);
         // Simulate a known request_id with no durable context yet
         processor.invocation_context.request_id = "req-123".to_string();
@@ -2604,6 +2605,7 @@ mod tests {
             (None, serde_json::Value::Null),
         ] {
             let mut processor = make_processor_for_durable_arn_tests();
+            processor.held_logs_max_keys = 50;
             processor.is_durable_function = Some(true);
             processor.invocation_context.request_id = "req-end".to_string();
             processor.insert_to_durable_context_map(


### PR DESCRIPTION
## Background
For durable functions, the extension holds logs and waits to get the invocation context from the tracer so the extension can enrich the logs. 

## Problem
When tracing is off (which is not recommended for durable functions), logs are flushed when:
1. the buffer is full (buffer size is all logs for 50 invocations). This increases delay. Or
2. when extension shuts down. However, this is not guaranteed to happen due to race conditions, causing missing logs.

## This PR

- Adds `lambda_durable_function_log_buffer_size` config field (env var `DD_LAMBDA_DURABLE_FUNCTION_LOG_BUFFER_SIZE`, default: `0`) controlling the max number of request ID keys held in `held_logs`.
- When set to `0`, logs bypass the hold mechanism and are sent immediately without durable execution context enrichment.
- Setting the default to 0 for now because the tracer changes for durable functions are not released. Later, after tracer changes are released, we can change the default back to 50 and ask customers to install the tracer for durable functions.

## Test plan

### Steps
- Build an extension layer
- install it on a durable function
- execute the function
- wait for a few minutes until the environment shuts down

### Result

Before:
- No log appears in Datadog
- and the invocation doesn't appear either

After:
- The invocation appears
<img width="407" height="106" alt="image" src="https://github.com/user-attachments/assets/f2679f37-a80e-48ef-b84c-049beeb0f7b3" />

- Logs also appear
<img width="578" height="562" alt="image" src="https://github.com/user-attachments/assets/55ac197e-22fa-455e-a8eb-40a46ad99dce" />
