### PR TITLE
[SVLS-9169] fix: lower log level to DEBUG for a trace failure

### DIFF
--- a/bottlecap/src/traces/trace_agent.rs
+++ b/bottlecap/src/traces/trace_agent.rs
@@ -479,8 +479,8 @@ impl TraceAgent {
         let (parts, body) = match extract_request_body(request).await {
             Ok(r) => r,
             Err(e) => {
-                // Usually the tracer connection closing mid-transfer when the
-                // sandbox freezes — external, not an extension fault. See #1232.
+                // Using DEBUG level because this is usually the tracer connection closing mid-transfer when the
+                // sandbox freezes, which is not actionable.
                 return debug_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     format!("TRACE_AGENT | handle_traces | Error extracting request body: {e}"),

--- a/bottlecap/src/traces/trace_agent.rs
+++ b/bottlecap/src/traces/trace_agent.rs
@@ -479,7 +479,9 @@ impl TraceAgent {
         let (parts, body) = match extract_request_body(request).await {
             Ok(r) => r,
             Err(e) => {
-                return error_response(
+                // Usually the tracer connection closing mid-transfer when the
+                // sandbox freezes — external, not an extension fault. See #1232.
+                return debug_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     format!("TRACE_AGENT | handle_traces | Error extracting request body: {e}"),
                 );
@@ -758,6 +760,13 @@ fn error_response<E: std::fmt::Display>(status: StatusCode, error: E) -> Respons
 /// external event (e.g. client disconnected) rather than a bug in the extension itself.
 fn warn_response<E: std::fmt::Display>(status: StatusCode, error: E) -> Response {
     warn!("{}", error);
+    (status, error.to_string()).into_response()
+}
+
+/// Like [`error_response`], but logs at DEBUG level. Use for expected external events
+/// (e.g. client disconnected mid-request) that are too noisy even at WARN.
+fn debug_response<E: std::fmt::Display>(status: StatusCode, error: E) -> Response {
+    debug!("{}", error);
     (status, error.to_string()).into_response()
 }
 


### PR DESCRIPTION
## What

Log the `handle_traces` request-body-read failure at **DEBUG** instead of **ERROR**.

Fixes #1232.

## Why
This failure happens probably because the execution environment is frozen when tracer sends traces to extension, causing timeout for TCP connections, which is not actionable on extension side. Lowering the log level to reduce noise.

## Notes
If any customer sees other issues such as missing traces, let us know and we will treat it as a separate issue. 