### PR TITLE
fix: remove noisy per-PID trace logs from fd usage collection

### DIFF
--- a/bottlecap/src/proc/mod.rs
+++ b/bottlecap/src/proc/mod.rs
@@ -12,7 +12,7 @@ use constants::{
     PROC_NET_DEV_PATH, PROC_PATH, PROC_STAT_PATH, PROC_UPTIME_PATH,
 };
 use regex::Regex;
-use tracing::{debug, trace};
+use tracing::debug;
 
 #[must_use]
 pub fn get_pid_list() -> Vec<i64> {
@@ -258,14 +258,9 @@ fn get_fd_use_data_from_path(path: &str, pids: &[i64]) -> f64 {
     for &pid in pids {
         let fd_path = format!("{path}/{pid}/fd");
         let Ok(files) = fs::read_dir(&fd_path) else {
-            trace!(
-                "File descriptor use data not found in path {} with pid {}",
-                fd_path, pid
-            );
             continue;
         };
-        let count = files.count();
-        fd_use += count;
+        fd_use += files.count();
     }
 
     fd_use as f64


### PR DESCRIPTION
## What does this PR do?

The usage-metrics monitoring loop polls `/proc` every 10ms and reads `/proc/{pid}/fd` for every PID each tick. When `read_dir` fails (e.g. `/proc/1/fd` is not readable by the extension), the existing code logged a `trace!` message per unreadable PID per tick. At ~40 ticks per invocation (tested with a Hello World golang function), a single persistently-unreadable PID produced ~40 trace messages per invocation (~4000 per 100 invocations).

These failures are benign — a PID's `fd` directory may be unreadable while the process is otherwise alive (typically a permission issue). The other `/proc/{pid}` readers (`fd_max`, `threads_max`, `threads_use`) already fail silently with `continue`. This change makes `get_fd_use_data_from_path` consistent with that behavior by removing the trace logging and dropping the now-unused `trace` import.

## Motivation

Observed ~4000 noisy log messages per 100 invocations when trace logging was enabled, making trace output unusable for debugging.

## Testing

- `cargo build` — clean compile, no unused-import warnings
- `cargo test proc` — all 8 proc tests pass, including `test_get_fd_use_data`
- `cargo clippy` — clean

## Checklist
- [x] PR description is filled out
- [x] Tests pass