### PR TITLE
fix(appsec): remove http method from 'http.route' span tag

### DIFF
--- a/bottlecap/src/appsec/processor/mod.rs
+++ b/bottlecap/src/appsec/processor/mod.rs
@@ -455,23 +455,17 @@ impl InvocationPayload for IdentifiedTrigger {
     }
     fn route(&self) -> Option<String> {
         match self {
-            Self::APIGatewayHttpEvent(t) => Some(t.route_key.clone()),
-            Self::APIGatewayRestEvent(t) => Some(format!(
-                "{method} {resource}",
-                method = t.request_context.method,
-                resource = t.request_context.resource_path
-            )),
+            Self::APIGatewayHttpEvent(t) => Some(
+                t.route_key
+                    .split_whitespace()
+                    .last()
+                    .unwrap_or(t.route_key.as_str())
+                    .to_string(),
+            ),
+            Self::APIGatewayRestEvent(t) => Some(t.request_context.resource_path.clone()),
             Self::APIGatewayWebSocketEvent(t) => Some(t.request_context.route_key.clone()),
-            Self::ALBEvent(t) => Some(format!(
-                "{method} {path}",
-                method = t.http_method,
-                path = t.path.as_ref().map_or("", |s| s.as_str()),
-            )),
-            Self::LambdaFunctionUrlEvent(t) => Some(format!(
-                "{method} {path}",
-                method = t.request_context.http.method,
-                path = t.request_context.http.path
-            )),
+            Self::ALBEvent(t) => Some(t.path.as_ref().map_or("", |s| s.as_str()).to_string()),
+            Self::LambdaFunctionUrlEvent(t) => Some(t.request_context.http.path.clone()),
             // Events that are not relevant to App & API Protection
             Self::MSKEvent(_)
             | Self::SqsRecord(_)

--- a/bottlecap/src/appsec/processor/mod.rs
+++ b/bottlecap/src/appsec/processor/mod.rs
@@ -470,7 +470,7 @@ impl InvocationPayload for IdentifiedTrigger {
             }
             Self::APIGatewayRestEvent(t) => Some(t.request_context.resource_path.clone()),
             Self::APIGatewayWebSocketEvent(t) => Some(t.request_context.route_key.clone()),
-            Self::ALBEvent(t) => Some(t.path.as_ref().map_or("", |s| s.as_str()).to_string()),
+            Self::ALBEvent(t) => t.path.clone().filter(|p| !p.is_empty()),
             Self::LambdaFunctionUrlEvent(t) => Some(t.request_context.http.path.clone()),
             // Events that are not relevant to App & API Protection
             Self::MSKEvent(_)

--- a/bottlecap/src/appsec/processor/mod.rs
+++ b/bottlecap/src/appsec/processor/mod.rs
@@ -455,13 +455,19 @@ impl InvocationPayload for IdentifiedTrigger {
     }
     fn route(&self) -> Option<String> {
         match self {
-            Self::APIGatewayHttpEvent(t) => Some(
-                t.route_key
-                    .split_whitespace()
-                    .last()
-                    .unwrap_or(t.route_key.as_str())
-                    .to_string(),
-            ),
+            Self::APIGatewayHttpEvent(t) => {
+                if t.route_key.is_empty() {
+                    None
+                } else {
+                    Some(
+                        t.route_key
+                            .split_whitespace()
+                            .last()
+                            .unwrap_or(t.route_key.as_str())
+                            .to_string(),
+                    )
+                }
+            }
             Self::APIGatewayRestEvent(t) => Some(t.request_context.resource_path.clone()),
             Self::APIGatewayWebSocketEvent(t) => Some(t.request_context.route_key.clone()),
             Self::ALBEvent(t) => Some(t.path.as_ref().map_or("", |s| s.as_str()).to_string()),

--- a/bottlecap/tests/appsec_processor_test.rs
+++ b/bottlecap/tests/appsec_processor_test.rs
@@ -322,7 +322,7 @@ async fn test_processor() {
                 "http.request.headers.user-agent": "Arachni/v2",
                 "http.request.headers.x-amzn-trace-id": "Root=1-613a52fb-4c43cfc95e0241c1471bfa05",
                 "http.request.headers.x-forwarded-for": "38.122.226.210",
-                "http.route": "POST /httpapi/post",
+                "http.route": "/httpapi/post",
                 "http.url": "x02yirxc7a.execute-api.sa-east-1.amazonaws.com/httpapi/post",
                 "http.status_code": "200",
                 "network.client.ip": "38.122.226.210",


### PR DESCRIPTION
## Overview

Currently the appsec span processor sets the `http.route` tag to `{method} {route}` instead of just `{route}` (ex: `GET /echo` instead of `/echo`). This does not match the APM spec as well as the tag extracted by the lifecycle processor on the http triggers. 

## Testing 

- updated existing test

- e2e tests are failing but I think it is unrelated