### PR TITLE
chore: make `clippy`+`fmt` commit hook `cd` relative to project root

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd bottlecap && cargo clippy --workspace --all-targets --features default && cargo fmt --all -- --check || exit 2",
+            "command": "cd \"$CLAUDE_PROJECT_DIR/bottlecap\" && cargo clippy --workspace --all-targets --features default && cargo fmt --all -- --check || exit 2",
             "if": "Bash(git commit*)",
             "timeout": 60,
             "statusMessage": "Running cargo clippy + fmt"


### PR DESCRIPTION
The `clippy` + `fmt` pre-commit hook in `.claude/settings.json` used a bare `cd bottlecap`, which only resolved from the repo root. Switched to `cd "$CLAUDE_PROJECT_DIR/bottlecap"` so it works from subdirectories too.
