### PR TITLE
fix(test): repair broken cold-start tests from #1254

### DIFF
--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -2477,8 +2477,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn enrich_ctx_keeps_tracer_set_cold_start_trace_id_without_tracer_detected() {
+    #[tokio::test]
+    async fn enrich_ctx_keeps_tracer_set_cold_start_trace_id_without_tracer_detected() {
         let mut p = setup();
         let request_id = String::from("node-python-cold-start");
         let mut cold_start_span = create_empty_span(

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -2435,6 +2435,9 @@ mod tests {
             LAMBDA_RUNTIME_SLUG.to_string(),
             &HashMap::from([("function_arn".to_string(), "test-arn".to_string())]),
         ));
+        // Keep `trace_sender` owned by the test (pass a clone) so the channel stays
+        // connected through the assertion below; otherwise try_recv would report
+        // Disconnected instead of Empty.
         let (trace_sender, mut trace_rx) = make_trace_sender_with_rx(config);
 
         p.on_platform_runtime_done(
@@ -2446,7 +2449,7 @@ mod tests {
             Status::Timeout,
             None,
             tags_provider,
-            trace_sender,
+            Arc::clone(&trace_sender),
             chrono::Utc::now().timestamp(),
         )
         .await;
@@ -2475,6 +2478,7 @@ mod tests {
             ),
             "cold start span must not be sent when no tracer set its trace ID"
         );
+        drop(trace_sender);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Overview

Two tests added in #1254 were failing on `main`. The Rust "Test Suite" CI job is not a required check (only `devflow/mergegate` is), so the red suite did not block #1254 from merging.

### 1. `enrich_ctx_keeps_tracer_set_cold_start_trace_id_without_tracer_detected`
Annotated `#[test]` but calls `setup()`, which spawns a Tokio task via `tokio::spawn(service.run())`. Running it panicked with `there is no reactor running, must be called from the context of a Tokio 1.x runtime`. Changed to `#[tokio::test] async fn` to match its sibling tests.

### 2. `timeout_without_tracer_does_not_send_cold_start_span`
Passed its `trace_sender` by value into `on_platform_runtime_done`, dropping the only `Arc<SendingTraceProcessor>` before `try_recv()`. The receiver then reported `Disconnected`, but the test asserted `Empty`, so it failed even though the production code correctly never sent the cold start span. Fixed by passing a clone and holding the sender until after the assertion so the channel stays connected.

No production code changes; both fixes are test-only.

> *"A test that drops its own sender and then complains the line went dead: the unit-testing equivalent of cutting the phone cord and filing a complaint about the silence."* — Claude 🤖
