### PR TITLE
test(trace stats): assert trace stats aggregation values via fake-intake

### DIFF
--- a/bottlecap/tests/apm_integration_test.rs
+++ b/bottlecap/tests/apm_integration_test.rs
@@ -296,12 +296,13 @@ struct PipelineOutcome {
     stats: Vec<pb::StatsPayload>,
 }
 
-/// Drives one trace through `SendingTraceProcessor::send_processed_traces` with the given
+/// Drives `traces` through `SendingTraceProcessor::send_processed_traces` with the given
 /// `compute_trace_stats_on_extension` / `client_computed_stats`, then flushes both the trace
 /// and stats pipelines into a fresh fake-intake and returns what it captured.
-async fn run_processor_pipeline(
+async fn run_processor_pipeline_with_traces(
     compute_on_extension: bool,
     client_computed_stats: bool,
+    traces: Vec<Vec<pb::Span>>,
 ) -> PipelineOutcome {
     let fake_intake = FakeIntake::start().await;
 
@@ -345,28 +346,12 @@ async fn run_processor_pipeline(
         )]),
     ));
 
-    // A top-level root span so the concentrator produces stats.
-    let mut span = pb::Span {
-        service: "fake-intake-trace-service".to_string(),
-        name: "web.request".to_string(),
-        resource: "GET /fake".to_string(),
-        trace_id: 0x1111_1111_1111_1111,
-        span_id: 0x2222_2222_2222_2222,
-        parent_id: 0,
-        start: 1_700_000_000_000_000_000,
-        duration: 5_000_000,
-        error: 0,
-        r#type: "web".to_string(),
-        ..pb::Span::default()
-    };
-    span.metrics.insert("_top_level".to_string(), 1.0);
-
     sender
         .send_processed_traces(
             Arc::clone(&config),
             tags_provider,
             header_tags_with(client_computed_stats),
-            vec![vec![span]],
+            traces,
             100,
             None,
         )
@@ -413,6 +398,35 @@ async fn run_processor_pipeline(
         traces: fake_intake.trace_payloads(),
         stats: fake_intake.stats_payloads(),
     }
+}
+
+/// Single-root-span convenience wrapper used by the `_dd.compute_stats` tests below.
+async fn run_processor_pipeline(
+    compute_on_extension: bool,
+    client_computed_stats: bool,
+) -> PipelineOutcome {
+    // A top-level root span so the concentrator produces stats.
+    let mut span = pb::Span {
+        service: "fake-intake-trace-service".to_string(),
+        name: "web.request".to_string(),
+        resource: "GET /fake".to_string(),
+        trace_id: 0x1111_1111_1111_1111,
+        span_id: 0x2222_2222_2222_2222,
+        parent_id: 0,
+        start: 1_700_000_000_000_000_000,
+        duration: 5_000_000,
+        error: 0,
+        r#type: "web".to_string(),
+        ..pb::Span::default()
+    };
+    span.metrics.insert("_top_level".to_string(), 1.0);
+
+    run_processor_pipeline_with_traces(
+        compute_on_extension,
+        client_computed_stats,
+        vec![vec![span]],
+    )
+    .await
 }
 
 /// Finds the single span in the captured trace payloads and returns its `_dd.compute_stats`.
@@ -497,4 +511,121 @@ async fn e2e_client_computed_stats_absent_meta_and_no_stats() {
         "_dd.compute_stats must be absent",
     );
     assert!(outcome.stats.is_empty(), "no stats payloads must be sent",);
+}
+
+// ---------------------------------------------------------------------------
+// Stats aggregation correctness: route concrete spans through the real
+// SpanConcentrator and assert on the *computed* aggregate values (hits, errors,
+// duration, grouping) that reach the intake, not just on stats presence.
+//
+// All spans use a `start` well in the past relative to the concentrator's clock,
+// so they fold into the single oldest bucket and a `force_flush` returns exactly
+// one bucket. That keeps these assertions deterministic without controlling time.
+// ---------------------------------------------------------------------------
+
+/// Builds a single-span trace the concentrator will count toward stats.
+/// `parent_id: 0` makes it a trace root and the `_top_level` metric makes the
+/// concentrator include it (non-top-level, non-measured spans are otherwise skipped).
+/// Distinct `id` values keep trace/span ids unique across invocations.
+fn stats_trace(id: u64, resource: &str, duration: i64, error: i32) -> Vec<pb::Span> {
+    let mut span = pb::Span {
+        service: "fake-intake-trace-service".to_string(),
+        name: "web.request".to_string(),
+        resource: resource.to_string(),
+        trace_id: id,
+        span_id: id,
+        parent_id: 0,
+        start: 1_700_000_000_000_000_000,
+        duration,
+        error,
+        r#type: "web".to_string(),
+        ..pb::Span::default()
+    };
+    span.metrics.insert("_top_level".to_string(), 1.0);
+    vec![span]
+}
+
+/// Flattens every `ClientGroupedStats` across all buckets of the single captured stats payload.
+fn captured_grouped_stats(stats: &[pb::StatsPayload]) -> Vec<pb::ClientGroupedStats> {
+    assert_eq!(stats.len(), 1, "expected exactly one stats payload");
+    stats[0]
+        .stats
+        .iter()
+        .flat_map(|csp| &csp.stats)
+        .flat_map(|bucket| &bucket.stats)
+        .cloned()
+        .collect()
+}
+
+/// AGG-1: N identical top-level spans collapse into one group with `hits == N`.
+#[tokio::test]
+async fn e2e_stats_count_aggregates_identical_spans() {
+    let traces = vec![
+        stats_trace(1, "GET /fake", 1_000_000, 0),
+        stats_trace(2, "GET /fake", 1_000_000, 0),
+        stats_trace(3, "GET /fake", 1_000_000, 0),
+    ];
+    let outcome = run_processor_pipeline_with_traces(true, false, traces).await;
+    let grouped = captured_grouped_stats(&outcome.stats);
+    assert_eq!(
+        grouped.len(),
+        1,
+        "identical spans must collapse to one group"
+    );
+    assert_eq!(grouped[0].hits, 3);
+    assert_eq!(grouped[0].top_level_hits, 3);
+    assert_eq!(grouped[0].errors, 0);
+}
+
+/// AGG-2: `errors` counts only spans with `error != 0`; `hits` counts all of them.
+#[tokio::test]
+async fn e2e_stats_counts_errors_separately_from_hits() {
+    let traces = vec![
+        stats_trace(1, "GET /fake", 1_000_000, 0),
+        stats_trace(2, "GET /fake", 1_000_000, 1),
+        stats_trace(3, "GET /fake", 1_000_000, 1),
+    ];
+    let outcome = run_processor_pipeline_with_traces(true, false, traces).await;
+    let grouped = captured_grouped_stats(&outcome.stats);
+    assert_eq!(grouped.len(), 1);
+    assert_eq!(grouped[0].hits, 3);
+    assert_eq!(grouped[0].errors, 2);
+}
+
+/// AGG-3: `duration` is the nanosecond sum of every aggregated span's duration.
+#[tokio::test]
+async fn e2e_stats_sums_span_durations() {
+    let traces = vec![
+        stats_trace(1, "GET /fake", 1_000_000, 0),
+        stats_trace(2, "GET /fake", 2_000_000, 0),
+        stats_trace(3, "GET /fake", 3_000_000, 0),
+    ];
+    let outcome = run_processor_pipeline_with_traces(true, false, traces).await;
+    let grouped = captured_grouped_stats(&outcome.stats);
+    assert_eq!(grouped.len(), 1);
+    assert_eq!(grouped[0].hits, 3);
+    assert_eq!(grouped[0].duration, 6_000_000);
+}
+
+/// AGG-4: spans with distinct resources stay in separate groups, each counted independently.
+#[tokio::test]
+async fn e2e_stats_groups_by_resource() {
+    let traces = vec![
+        stats_trace(1, "GET /a", 1_000_000, 0),
+        stats_trace(2, "GET /a", 1_000_000, 0),
+        stats_trace(3, "GET /b", 1_000_000, 0),
+    ];
+    let outcome = run_processor_pipeline_with_traces(true, false, traces).await;
+    let grouped = captured_grouped_stats(&outcome.stats);
+    assert_eq!(grouped.len(), 2, "distinct resources must not be merged");
+    let a = grouped
+        .iter()
+        .find(|g| g.resource == "GET /a")
+        .expect("GET /a group should be present");
+    let b = grouped
+        .iter()
+        .find(|g| g.resource == "GET /b")
+        .expect("GET /b group should be present");
+    assert_eq!(a.hits, 2);
+    assert_eq!(b.hits, 1);
 }

--- a/bottlecap/tests/apm_integration_test.rs
+++ b/bottlecap/tests/apm_integration_test.rs
@@ -629,3 +629,65 @@ async fn e2e_stats_groups_by_resource() {
     assert_eq!(a.hits, 2);
     assert_eq!(b.hits, 1);
 }
+
+/// Like `stats_trace` but stamps extra `meta` keys on the span (e.g. `span.kind`,
+/// `http.status_code`) that the concentrator folds into the aggregation key.
+fn stats_trace_with_meta(id: u64, resource: &str, meta: &[(&str, &str)]) -> Vec<pb::Span> {
+    let mut trace = stats_trace(id, resource, 1_000_000, 0);
+    for (key, value) in meta {
+        trace[0]
+            .meta
+            .insert((*key).to_string(), (*value).to_string());
+    }
+    trace
+}
+
+/// AGG-5: spans differing only in `span.kind` stay in separate groups.
+#[tokio::test]
+async fn e2e_stats_groups_by_span_kind() {
+    let traces = vec![
+        stats_trace_with_meta(1, "GET /fake", &[("span.kind", "server")]),
+        stats_trace_with_meta(2, "GET /fake", &[("span.kind", "server")]),
+        stats_trace_with_meta(3, "GET /fake", &[("span.kind", "internal")]),
+    ];
+    let outcome = run_processor_pipeline_with_traces(true, false, traces).await;
+    let grouped = captured_grouped_stats(&outcome.stats);
+    assert_eq!(grouped.len(), 2, "distinct span.kind must not be merged");
+    let server = grouped
+        .iter()
+        .find(|g| g.span_kind == "server")
+        .expect("server group should be present");
+    let internal = grouped
+        .iter()
+        .find(|g| g.span_kind == "internal")
+        .expect("internal group should be present");
+    assert_eq!(server.hits, 2);
+    assert_eq!(internal.hits, 1);
+}
+
+/// AGG-6: spans differing only in `http.status_code` stay in separate groups.
+#[tokio::test]
+async fn e2e_stats_groups_by_http_status_code() {
+    let traces = vec![
+        stats_trace_with_meta(1, "GET /fake", &[("http.status_code", "200")]),
+        stats_trace_with_meta(2, "GET /fake", &[("http.status_code", "200")]),
+        stats_trace_with_meta(3, "GET /fake", &[("http.status_code", "500")]),
+    ];
+    let outcome = run_processor_pipeline_with_traces(true, false, traces).await;
+    let grouped = captured_grouped_stats(&outcome.stats);
+    assert_eq!(
+        grouped.len(),
+        2,
+        "distinct http.status_code must not be merged"
+    );
+    let ok = grouped
+        .iter()
+        .find(|g| g.http_status_code == 200)
+        .expect("200 group should be present");
+    let err = grouped
+        .iter()
+        .find(|g| g.http_status_code == 500)
+        .expect("500 group should be present");
+    assert_eq!(ok.hits, 2);
+    assert_eq!(err.hits, 1);
+}

--- a/bottlecap/tests/apm_integration_test.rs
+++ b/bottlecap/tests/apm_integration_test.rs
@@ -206,7 +206,7 @@ async fn trace_payload_roundtrip_through_fake_intake() {
         trace_id: 0x1111_1111_1111_1111,
         span_id: 0x2222_2222_2222_2222,
         parent_id: 0,
-        start: 1_700_000_000_000_000_000,
+        start: STATS_SPAN_START_NS,
         duration: 5_000_000,
         error: 0,
         r#type: "web".to_string(),
@@ -400,6 +400,11 @@ async fn run_processor_pipeline_with_traces(
     }
 }
 
+/// Fixed span start well in the past relative to the concentrator's clock, so all spans
+/// fold into the single oldest bucket and a `force_flush` returns exactly one bucket.
+/// That keeps the aggregation assertions deterministic without controlling time.
+const STATS_SPAN_START_NS: i64 = 1_700_000_000_000_000_000;
+
 /// Single-root-span convenience wrapper used by the `_dd.compute_stats` tests below.
 async fn run_processor_pipeline(
     compute_on_extension: bool,
@@ -413,7 +418,7 @@ async fn run_processor_pipeline(
         trace_id: 0x1111_1111_1111_1111,
         span_id: 0x2222_2222_2222_2222,
         parent_id: 0,
-        start: 1_700_000_000_000_000_000,
+        start: STATS_SPAN_START_NS,
         duration: 5_000_000,
         error: 0,
         r#type: "web".to_string(),
@@ -518,9 +523,7 @@ async fn e2e_client_computed_stats_absent_meta_and_no_stats() {
 // SpanConcentrator and assert on the *computed* aggregate values (hits, errors,
 // duration, grouping) that reach the intake, not just on stats presence.
 //
-// All spans use a `start` well in the past relative to the concentrator's clock,
-// so they fold into the single oldest bucket and a `force_flush` returns exactly
-// one bucket. That keeps these assertions deterministic without controlling time.
+// Determinism comes from `STATS_SPAN_START_NS` (see its doc comment).
 // ---------------------------------------------------------------------------
 
 /// Builds a single-span trace the concentrator will count toward stats.
@@ -535,7 +538,7 @@ fn stats_trace(id: u64, resource: &str, duration: i64, error: i32) -> Vec<pb::Sp
         trace_id: id,
         span_id: id,
         parent_id: 0,
-        start: 1_700_000_000_000_000_000,
+        start: STATS_SPAN_START_NS,
         duration,
         error,
         r#type: "web".to_string(),


### PR DESCRIPTION
- [x] ~Note: stacked on #1255. Merge that PR first.~

## Overview

Extends the in-process fake-intake APM tests (added in #1194) with **value-level** coverage of trace stats aggregation. The existing stats tests assert serialization fidelity (a hand-built `ClientStatsPayload` survives the roundtrip) and stats presence/suppression (`_dd.compute_stats` truth table). None assert that the *computed* aggregates reaching the intake are correct.

This PR routes concrete spans through the real pipeline (`SendingTraceProcessor` → `StatsConcentratorService` → `StatsFlusher` → fake-intake) and asserts on the decoded `ClientGroupedStats`:

- `e2e_stats_count_aggregates_identical_spans` — 3 identical top-level spans collapse into one group with `hits == 3`, `top_level_hits == 3`.
- `e2e_stats_counts_errors_separately_from_hits` — `errors` counts only `error != 0`; `hits` counts all.
- `e2e_stats_sums_span_durations` — `duration` is the nanosecond sum of aggregated spans.
- `e2e_stats_groups_by_resource` — distinct resources stay in separate groups.
- `e2e_stats_groups_by_span_kind` — distinct `span.kind` stay in separate groups.
- `e2e_stats_groups_by_http_status_code` — distinct `http.status_code` stay in separate groups.

These verify bottlecap's wiring and serialization end-to-end (a span entering the trace path comes out the intake correctly aggregated), which libdatadog's concentrator unit tests cannot see. The aggregation *math* itself is owned and exhaustively tested upstream in `libdd-trace-stats`.

To support multiple spans, `run_processor_pipeline` was generalized into `run_processor_pipeline_with_traces(.., traces)`, with a thin single-span wrapper preserving the existing `_dd.compute_stats` tests unchanged.

### Out of scope: time-bucketing

Deliberately not added. Bucket assignment lives entirely inside `SpanConcentrator` and is thoroughly tested in `libdd-trace-stats` (`test_concentrator_stats_counts` over multiple buckets, `test_concentrator_oldest_timestamp_cold/hot`, `test_force_flush`). bottlecap's wiring does not touch bucketing, so a test here would duplicate upstream coverage and require a production clock seam (the concentrator seeds `oldest_timestamp` from wall-clock) for no unique coverage.

## Testing

This PR is only adding more tests. If they pass, we're good.

Ran locally:
- `cargo test --test apm_integration_test`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --features default`

> *"Six tests walk into a bucket. They all collapse into one group — turns out they were identical the whole time."* — Claude 🤖
