### PR TITLE
SLES 2889 | Fixing payload size

### DIFF
--- a/.gitlab/datasources/test-suites.yaml
+++ b/.gitlab/datasources/test-suites.yaml
@@ -6,3 +6,4 @@ test_suites:
   - name: auth
   - name: oom
   - name: lmi-oom
+  - name: payload-size

--- a/bottlecap/src/traces/trace_aggregator.rs
+++ b/bottlecap/src/traces/trace_aggregator.rs
@@ -1,12 +1,11 @@
 use libdd_trace_utils::send_data::SendDataBuilder;
 use libdd_trace_utils::trace_utils::TracerHeaderTags;
 use std::collections::VecDeque;
+use tracing::debug;
 
-/// Maximum content size per payload uncompressed in bytes,
-/// that the Datadog Trace API accepts. The value is 3.2 MB.
-///
-/// <https://github.com/DataDog/datadog-agent/blob/9d57c10a9eeb3916e661d35dbd23c6e36395a99d/pkg/trace/writer/trace.go#L27-L31>
-pub const MAX_CONTENT_SIZE_BYTES: usize = 3_200_000;
+/// Maximum uncompressed bytes per outbound batch. Kept below the trace intake's
+/// ~15 MB limit so an enriched payload flushes in a single batch.
+pub const MAX_CONTENT_SIZE_BYTES: usize = 12_000_000;
 
 /// Owned version of `TracerHeaderTags<'a>` so it can be stored across async
 /// boundaries without lifetime issues.
@@ -130,6 +129,14 @@ impl TraceAggregator {
             } else {
                 break;
             }
+        }
+
+        if !self.buffer.is_empty() {
+            debug!(
+                "TRACES | batched {} payload(s) totaling {batch_size} bytes (cap {} bytes)",
+                self.buffer.len(),
+                self.max_content_size_bytes
+            );
         }
 
         std::mem::take(&mut self.buffer)

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -464,6 +464,8 @@ impl TraceProcessor for ServerlessTraceProcessor {
             _ => body_size,
         };
 
+        debug!("TRACES | trace payload size after enrichment: {body_size} bytes");
+
         let owned_header_tags = OwnedTracerHeaderTags::from(header_tags.clone());
 
         // Move original payload into builder (no clone needed)
@@ -1458,7 +1460,6 @@ mod tests {
     #[test]
     fn test_process_traces_body_size_reflects_enriched_payload() {
         use libdd_trace_obfuscation::obfuscation_config::ObfuscationConfig;
-        use prost::Message as _;
 
         let config = Arc::new(Config {
             apm_dd_url: "https://trace.agent.datadoghq.com".to_string(),
@@ -1519,7 +1520,7 @@ mod tests {
         let TracerPayloadCollection::V07(ref payloads) = processed_payloads else {
             panic!("expected V07");
         };
-        let enriched_size: usize = payloads.iter().map(|tp| tp.encoded_len()).sum();
+        let enriched_size: usize = payloads.iter().map(prost::Message::encoded_len).sum();
 
         assert_eq!(
             info.size, enriched_size,

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -442,7 +442,7 @@ impl TraceProcessor for ServerlessTraceProcessor {
         // stats are still counted. SamplerPriority::None (-128) means no explicit priority
         // was set and the trace is kept; drop priorities are SamplerPriority::AutoDrop (0)
         // and UserDrop (-1, not represented in SamplerPriority).
-        let body_size = if config.compute_trace_stats_on_extension
+        if config.compute_trace_stats_on_extension
             && let TracerPayloadCollection::V07(ref mut tracer_payloads) = payload
         {
             for tp in tracer_payloads.iter_mut() {
@@ -454,17 +454,14 @@ impl TraceProcessor for ServerlessTraceProcessor {
             if tracer_payloads.is_empty() {
                 return (None, payloads_for_stats);
             }
+        }
 
-            // Update body_size after dropping sampled-out traces.
-            // Use the protobuf-encoded size of the filtered payload so the
-            // TraceAggregator's 3.2 MB batch limit reflects only the data that
-            // will actually be sent to the backend.
-            tracer_payloads
+        let body_size = match &payload {
+            TracerPayloadCollection::V07(tracer_payloads) => tracer_payloads
                 .iter()
                 .map(prost::Message::encoded_len)
-                .sum()
-        } else {
-            body_size
+                .sum(),
+            _ => body_size,
         };
 
         let owned_header_tags = OwnedTracerHeaderTags::from(header_tags.clone());
@@ -1450,6 +1447,87 @@ mod tests {
         assert!(
             info.size < 999_999,
             "body_size must be smaller than the original unfiltered request size"
+        );
+    }
+
+    /// `process_traces` enriches every span (adding the tags-provider map), so the
+    /// payload it sends is larger than the raw msgpack the tracer posted. `body_size`
+    /// must reflect that enriched, protobuf-encoded size — not the smaller ingress
+    /// size — otherwise the aggregator/coalesce caps undercount and oversized payloads
+    /// reach the backend and get a 413. This is the default config (no local stats).
+    #[test]
+    fn test_process_traces_body_size_reflects_enriched_payload() {
+        use libdd_trace_obfuscation::obfuscation_config::ObfuscationConfig;
+        use prost::Message as _;
+
+        let config = Arc::new(Config {
+            apm_dd_url: "https://trace.agent.datadoghq.com".to_string(),
+            ..Config::default()
+        });
+        let tags_provider = Arc::new(Provider::new(
+            config.clone(),
+            "lambda".to_string(),
+            &std::collections::HashMap::from([(
+                "function_arn".to_string(),
+                "test-arn".to_string(),
+            )]),
+        ));
+        let processor = ServerlessTraceProcessor {
+            obfuscation_config: Arc::new(
+                ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
+            ),
+        };
+        let header_tags = tracer_header_tags::TracerHeaderTags {
+            lang: "rust",
+            lang_version: "1.0",
+            lang_interpreter: "",
+            lang_vendor: "",
+            tracer_version: "1.0",
+            container_id: "",
+            client_computed_top_level: false,
+            client_computed_stats: false,
+            dropped_p0_traces: 0,
+            dropped_p0_spans: 0,
+        };
+
+        let span = pb::Span {
+            trace_id: 1,
+            span_id: 1,
+            parent_id: 0,
+            service: "svc".to_string(),
+            name: "op".to_string(),
+            resource: "res".to_string(),
+            ..Default::default()
+        };
+        let traces = vec![vec![span]];
+
+        // Ingress size smaller than any real enriched payload, as it always is in
+        // production (raw msgpack < enriched protobuf).
+        let ingress_size = 1;
+        let (payload_info, processed_payloads) = processor.process_traces(
+            config,
+            tags_provider,
+            header_tags,
+            traces,
+            ingress_size,
+            None,
+        );
+
+        let info = payload_info.expect("expected Some payload");
+
+        // Nothing is filtered here, so the returned payloads are exactly what gets sent.
+        let TracerPayloadCollection::V07(ref payloads) = processed_payloads else {
+            panic!("expected V07");
+        };
+        let enriched_size: usize = payloads.iter().map(|tp| tp.encoded_len()).sum();
+
+        assert_eq!(
+            info.size, enriched_size,
+            "body_size must equal the protobuf encoded_len of the sent payload"
+        );
+        assert!(
+            info.size > ingress_size,
+            "enrichment inflates the payload, so body_size must exceed the ingress size"
         );
     }
 

--- a/integration-tests/bin/app.ts
+++ b/integration-tests/bin/app.ts
@@ -9,6 +9,7 @@ import {AuthStack} from '../lib/stacks/auth';
 import {Oom} from '../lib/stacks/oom';
 import {LmiOom} from '../lib/stacks/lmi-oom';
 import {CustomMetrics} from '../lib/stacks/custom-metrics';
+import {PayloadSize} from '../lib/stacks/payload-size';
 import {AuthRoleStack} from '../lib/auth-role';
 import {ACCOUNT, getIdentifier, REGION} from '../config';
 import {CapacityProviderStack} from "../lib/capacity-provider";
@@ -50,6 +51,9 @@ const stacks = [
         env,
     }),
     new CustomMetrics(app, `integ-${identifier}-custom-metrics`, {
+        env,
+    }),
+    new PayloadSize(app, `integ-${identifier}-payload-size`, {
         env,
     }),
 ]

--- a/integration-tests/lambda/large-trace-node/index.js
+++ b/integration-tests/lambda/large-trace-node/index.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const tracer = require('dd-trace');
+
+/**
+ * Models a service that processes a batch of records and captures the payload
+ * it handles on each span, producing one large single-invocation trace
+ * (~spanCount * payloadBytes) to exercise the extension's per-batch size cap.
+ * Configured entirely via the invocation event: `spanCount` (keep under 1000 so
+ * the tracer keeps all spans in one trace) and `payloadBytes` (capped at the
+ * tracer's 25,000-char tag-value limit).
+ */
+
+const MAX_TAG_VALUE_BYTES = 24000; // under the tracer's 25,000-char truncation limit
+
+/** Builds an order document of roughly `targetBytes`, sized via line items. */
+function buildOrderPayload(targetBytes, requestId, index) {
+  const order = {
+    orderId: `ord-${requestId}-${index}`,
+    placedAt: '2026-06-11T10:00:00.000Z',
+    channel: index % 2 === 0 ? 'web' : 'mobile',
+    customer: {
+      tier: index % 3 === 0 ? 'enterprise' : 'standard',
+      shippingAddress: '123 Example Street, Suite 400, Sydney NSW 2000, Australia',
+    },
+    lineItems: [],
+  };
+  const makeItem = (item) => ({
+    sku: `SKU-${(item * 7 + index) % 100000}`,
+    description: `Wholesale item ${item} — replenishment for warehouse wh-${item % 40}`,
+    quantity: (item % 12) + 1,
+    unitPriceCents: 1999 + (item % 500),
+  });
+  const baseLen = JSON.stringify(order).length;
+  const itemLen = JSON.stringify(makeItem(0)).length + 1; // + array comma
+  const itemCount = Math.max(0, Math.ceil((targetBytes - baseLen) / itemLen));
+  for (let item = 0; item < itemCount; item++) {
+    order.lineItems.push(makeItem(item));
+  }
+  return JSON.stringify(order).slice(0, targetBytes);
+}
+
+exports.handler = async (event, context) => {
+  const spanCount = Number(event?.spanCount ?? 400);
+  const payloadBytes = Math.min(Number(event?.payloadBytes ?? 24000), MAX_TAG_VALUE_BYTES);
+  console.log(`Processing batch of ${spanCount} records (~${payloadBytes} bytes captured per span)`);
+
+  for (let i = 0; i < spanCount; i++) {
+    const requestBody = buildOrderPayload(payloadBytes, context.awsRequestId, i);
+    await tracer.trace(
+      'order.process',
+      { resource: `POST /orders/batch[${i}]`, service: process.env.DD_SERVICE },
+      async (span) => {
+        // Captured payloads dominate the span's size.
+        span.addTags({
+          'http.method': 'POST',
+          'http.route': '/orders',
+          'http.status_code': i % 50 === 0 ? 500 : 200,
+          'order.id': `ord-${context.awsRequestId}-${i}`,
+          'order.request_body': requestBody,
+          'order.response_body': `{"orderId":"ord-${context.awsRequestId}-${i}","status":"accepted"}`,
+        });
+      },
+    );
+  }
+
+  console.log(`Finished processing ${spanCount} records`);
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      message: 'Success',
+      requestId: context.awsRequestId,
+      recordsProcessed: spanCount,
+    }),
+  };
+};

--- a/integration-tests/lib/stacks/payload-size.ts
+++ b/integration-tests/lib/stacks/payload-size.ts
@@ -1,0 +1,48 @@
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { Construct } from 'constructs';
+import {
+  createLogGroup,
+  defaultDatadogEnvVariables,
+  defaultDatadogSecretPolicy,
+  getExtensionLayer,
+  getDefaultNodeLayer,
+  defaultNodeRuntime,
+} from '../util';
+
+/**
+ * Functions that exercise the extension's trace payload-size handling. Add new
+ * scenarios as additional functions on this stack.
+ */
+export class PayloadSize extends cdk.Stack {
+  constructor(scope: Construct, id: string, props: cdk.StackProps) {
+    super(scope, id, props);
+
+    const extensionLayer = getExtensionLayer(this);
+    const nodeLayer = getDefaultNodeLayer(this);
+
+    const largeTraceFunctionName = `${id}-large-trace-lambda`;
+    const largeTraceFunction = new lambda.Function(this, largeTraceFunctionName, {
+      runtime: defaultNodeRuntime,
+      architecture: lambda.Architecture.ARM_64,
+      handler: '/opt/nodejs/node_modules/datadog-lambda-js/handler.handler',
+      code: lambda.Code.fromAsset('./lambda/large-trace-node'),
+      functionName: largeTraceFunctionName,
+      // Headroom for building and flushing a large trace.
+      timeout: cdk.Duration.seconds(120),
+      memorySize: 1024,
+      environment: {
+        ...defaultDatadogEnvVariables,
+        DD_SERVICE: largeTraceFunctionName,
+        DD_TRACE_ENABLED: 'true',
+        DD_LAMBDA_HANDLER: 'index.handler',
+        // Debug level surfaces the extension's payload-size logs the test reads.
+        DD_LOG_LEVEL: 'debug',
+      },
+      logGroup: createLogGroup(this, largeTraceFunctionName),
+    });
+    largeTraceFunction.addToRolePolicy(defaultDatadogSecretPolicy);
+    largeTraceFunction.addLayers(extensionLayer);
+    largeTraceFunction.addLayers(nodeLayer);
+  }
+}

--- a/integration-tests/tests/payload-size.test.ts
+++ b/integration-tests/tests/payload-size.test.ts
@@ -1,0 +1,145 @@
+import { invokeAndCollectTelemetry, FunctionConfig } from './utils/default';
+import { DatadogTelemetry } from './utils/datadog';
+import { forceColdStart } from './utils/lambda';
+import { filterLogMessages } from './utils/cloudwatch';
+import { getIdentifier } from '../config';
+
+// The enriched payload must be large enough to need a high batch cap, yet stay
+// under the 12 MB cap so it flushes in a single batch without a 413.
+const MIN_ENRICHED_BYTES = 10_000_000;
+
+// Trace config, sent in the invocation payload. 400 x 24 KB enriches to ~10 MB.
+const SPAN_COUNT = 400;
+const PAYLOAD_BYTES = 24_000;
+
+const identifier = getIdentifier();
+const stackName = `integ-${identifier}-payload-size`;
+
+describe('Payload Size Integration Tests', () => {
+
+  describe('large single-invocation trace', () => {
+    let telemetry: Record<string, DatadogTelemetry>;
+    let enrichedPayloadBytes: number | undefined;
+    let batchedPayloadBytes: number | undefined;
+    let sendErrorMessages: string[] = [];
+
+    const functionName = `${stackName}-large-trace-lambda`;
+
+    beforeAll(async () => {
+      const functions: FunctionConfig[] = [
+        { functionName, runtime: 'node' },
+      ];
+
+      await Promise.all(functions.map(fn => forceColdStart(fn.functionName)));
+
+      const startTime = Date.now() - 60_000;
+
+      // Invoke a few times. A cold invocation delivers its large (~10 MB) trace
+      // to the extension too late to make that invocation's end-of-invocation
+      // flush, so it flushes on a following invocation. The extra invocations
+      // give the first request's trace a flush to ride out on.
+      telemetry = await invokeAndCollectTelemetry(
+        functions, 3, 1, 2000, { spanCount: SPAN_COUNT, payloadBytes: PAYLOAD_BYTES });
+
+      const enrichedMessages = await filterLogMessages(
+        functionName,
+        '"payload size after enrichment"',
+        startTime,
+        Date.now(),
+      );
+      enrichedPayloadBytes = getMaxLoggedBytes(enrichedMessages, /payload size after enrichment: (\d+) bytes/);
+      console.log(`Extension reported enriched payload size: ${enrichedPayloadBytes} bytes`);
+
+      const batchedMessages = await filterLogMessages(
+        functionName,
+        '"totaling"',
+        startTime,
+        Date.now(),
+      );
+      batchedPayloadBytes = getMaxLoggedBytes(batchedMessages, /totaling (\d+) bytes/);
+      console.log(`Extension reported batched payload size: ${batchedPayloadBytes} bytes`);
+
+      // A payload over the intake limit logs "Max retries exceeded, returning
+      // HTTP error" with status=413. Capture any such lines so we can assert the
+      // extension flushed without a 413.
+      sendErrorMessages = await filterLogMessages(
+        functionName,
+        '?"Max retries exceeded" ?"status=413" ?"Payload Too Large"',
+        startTime,
+        Date.now(),
+      );
+      console.log(`Extension send-error log lines: ${sendErrorMessages.length}`);
+
+      console.log('Invocation and telemetry collection complete');
+    }, 900000);
+
+    // Assert on the FIRST request's trace. Its flush is deferred to a later
+    // invocation (cold-start race), which is why we invoke a few times — but the
+    // trace is tagged with the first request's id, so it's found here.
+    const getInvocation = () => telemetry.node?.threads[0]?.[0];
+
+    it('should invoke Lambda successfully', () => {
+      const result = getInvocation();
+      expect(result).toBeDefined();
+      expect(result.statusCode).toBe(200);
+    });
+
+    // Guards that the trace is actually large enough to exercise the high cap.
+    it('should have a large enriched payload', () => {
+      expect(enrichedPayloadBytes).toBeDefined();
+      expect(enrichedPayloadBytes!).toBeGreaterThan(MIN_ENRICHED_BYTES);
+    });
+
+    it('should have a large batched payload', () => {
+      expect(batchedPayloadBytes).toBeDefined();
+      expect(batchedPayloadBytes!).toBeGreaterThan(MIN_ENRICHED_BYTES);
+    });
+
+    it('should flush without a 413 Payload Too Large error', () => {
+      expect(sendErrorMessages).toEqual([]);
+    });
+
+    it('should deliver exactly one trace to Datadog', () => {
+      const result = getInvocation();
+      expect(result).toBeDefined();
+      expect(result.traces?.length).toBe(1);
+    });
+
+    it('should have the aws.lambda root span', () => {
+      const result = getInvocation();
+      expect(result).toBeDefined();
+
+      const allSpans = result.traces!.flatMap(t => t.spans);
+      const awsLambdaSpan = allSpans.find(
+        (span: any) => span.attributes.operation_name === 'aws.lambda'
+      );
+      expect(awsLambdaSpan).toBeDefined();
+    });
+
+    it('should contain all the payload-carrying spans from the large trace', () => {
+      // Exactly the SPAN_COUNT order.process spans we emitted should come back
+      // (SPAN_COUNT < the 1000-span API page limit, so none are truncated).
+      const result = getInvocation();
+      expect(result).toBeDefined();
+
+      const orderSpans = result
+        .traces!.flatMap(t => t.spans)
+        .filter((span: any) => span.attributes.operation_name === 'order.process');
+      expect(orderSpans.length).toBe(SPAN_COUNT);
+    });
+  });
+});
+
+function getMaxLoggedBytes(messages: string[], pattern: RegExp): number | undefined {
+  let max: number | undefined;
+  for (const message of messages) {
+    const match = message.match(pattern);
+    if (match) {
+      const bytes = Number(match[1]);
+      if (max === undefined || bytes > max) {
+        max = bytes;
+      }
+    }
+  }
+  return max;
+}

--- a/integration-tests/tests/utils/cloudwatch.ts
+++ b/integration-tests/tests/utils/cloudwatch.ts
@@ -1,0 +1,43 @@
+import {
+  CloudWatchLogsClient,
+  FilterLogEventsCommand,
+} from '@aws-sdk/client-cloudwatch-logs';
+
+const logsClient = new CloudWatchLogsClient({ region: 'us-east-1' });
+
+/**
+ * Returns the messages of all log events in a Lambda's CloudWatch log group
+ * matching `filterPattern` within [startTime, endTime] (epoch ms). The Datadog
+ * extension's logs land here too, so use a quoted literal
+ * (e.g. '"payload size after enrichment"') to read extension-emitted lines.
+ */
+export async function filterLogMessages(
+  functionName: string,
+  filterPattern: string,
+  startTime: number,
+  endTime: number,
+): Promise<string[]> {
+  const logGroupName = `/aws/lambda/${functionName}`;
+  const messages: string[] = [];
+  let nextToken: string | undefined;
+
+  do {
+    const response = await logsClient.send(
+      new FilterLogEventsCommand({
+        logGroupName,
+        filterPattern,
+        startTime,
+        endTime,
+        nextToken,
+      }),
+    );
+    for (const event of response.events ?? []) {
+      if (event.message) {
+        messages.push(event.message);
+      }
+    }
+    nextToken = response.nextToken;
+  } while (nextToken);
+
+  return messages;
+}


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/SLES-2889

## Overview

Large single-invocation traces could be rejected by the trace intake with a 413, because the extension undercounted how big a payload would be once it left the extension.

 The extension enriches every span after the tracer posts it (adding the tags-provider map), so the protobuf payload it sends is larger than the raw msgpack it received. The trace aggregator's batch cap therefore undercounted the true outbound bytes and packed too much into a single request, whose combined size exceeded the intake limit → 413.

The batch cap was below realistic enriched payload sizes. The cap was set to the old 3.2 MB documented limit. However, from [trace intake config](https://github.com/DataDog/logs-backend/blob/6b17c3834760efe43f0fc2ae09f8c03f893f32fb/domains/intake/apps/intake/src/main/resources/track-types.conf#L269), the limit is actually 15. 

This PR:

- Computes `body_size` from the enriched, protobuf-encoded payload **unconditionally** (not only when on-extension stats are enabled), so the aggregator's batch cap reflects exactly what will be sent.
- Raises the batch cap from 3.2 MB to 12 MB — kept below the trace intake's ~15 MB limit so a large enriched payload flushes in a single batch without a 413.
- Adds debug logs for the post-enrichment payload size and per-batch coalesced size.

## Testing

- **Unit:** new test asserting `body_size` equals the protobuf `encoded_len` of the payload actually sent, and exceeds the (smaller) ingress size — on the default config (no on-extension stats).
- **Integration:** new `payload-size` suite deploys a Node Lambda that emits a ~10 MB single-invocation trace (400 spans carrying large captured payloads) and verifies it: enriches to >10 MB, flushes in a single batch >10 MB, arrives with no 413, and is delivered intact (one trace, root span present, all 400 spans). Run against a locally published extension layer in the serverless sandbox.
