### PR TITLE
refactor(config): rename compute_trace_stats_on_extension -> lambda_extension_compute_stats

### DIFF
--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -65,7 +65,7 @@ pub struct LambdaConfig {
     pub lambda_proc_enhanced_metrics: bool,
     pub capture_lambda_payload: bool,
     pub capture_lambda_payload_max_depth: u32,
-    pub compute_trace_stats_on_extension: bool,
+    pub lambda_extension_compute_stats: bool,
     pub span_dedup_timeout: Option<Duration>,
     pub api_key_secret_reload_interval: Option<Duration>,
     pub dd_org_uuid: String,
@@ -95,7 +95,7 @@ impl Default for LambdaConfig {
             lambda_proc_enhanced_metrics: true,
             capture_lambda_payload: false,
             capture_lambda_payload_max_depth: 10,
-            compute_trace_stats_on_extension: false,
+            lambda_extension_compute_stats: false,
             span_dedup_timeout: None,
             api_key_secret_reload_interval: None,
             dd_org_uuid: String::new(),
@@ -144,8 +144,10 @@ pub struct LambdaConfigSource {
     pub capture_lambda_payload: Option<bool>,
     #[serde(deserialize_with = "deser_opt_lossless")]
     pub capture_lambda_payload_max_depth: Option<u32>,
+    /// `DD_LAMBDA_EXTENSION_COMPUTE_STATS` — when true, the extension computes
+    /// APM trace stats locally instead of letting the backend do it.
     #[serde(deserialize_with = "deser_opt_bool")]
-    pub compute_trace_stats_on_extension: Option<bool>,
+    pub lambda_extension_compute_stats: Option<bool>,
 
     #[serde(deserialize_with = "deser_dur_secs_ignore_zero")]
     pub span_dedup_timeout: Option<Duration>,
@@ -198,7 +200,7 @@ impl DatadogConfigExtension for LambdaConfig {
                 lambda_proc_enhanced_metrics,
                 capture_lambda_payload,
                 capture_lambda_payload_max_depth,
-                compute_trace_stats_on_extension,
+                lambda_extension_compute_stats,
                 serverless_appsec_enabled,
                 appsec_waf_timeout,
                 api_security_enabled,
@@ -487,12 +489,18 @@ mod lambda_config_tests {
     }
 
     #[test]
-    fn compute_trace_stats_on_extension_from_env() {
+    fn lambda_extension_compute_stats_from_env() {
         let config = load(|jail| {
-            jail.set_env("DD_COMPUTE_TRACE_STATS_ON_EXTENSION", "true");
+            jail.set_env("DD_LAMBDA_EXTENSION_COMPUTE_STATS", "true");
             Ok(())
         });
-        assert!(config.ext.compute_trace_stats_on_extension);
+        assert!(config.ext.lambda_extension_compute_stats);
+    }
+
+    #[test]
+    fn lambda_extension_compute_stats_defaults_false() {
+        let config = load(|_| Ok(()));
+        assert!(!config.ext.lambda_extension_compute_stats);
     }
 
     // ---- Duration fields ----

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -2958,7 +2958,7 @@ mod tests {
     }
 
     /// Build a [`Processor`] with a caller-supplied config (for toggling
-    /// `compute_trace_stats_on_extension`).
+    /// `lambda_extension_compute_stats`).
     fn setup_with_config(config: Arc<config::Config>) -> Processor {
         let aws_config = Arc::new(AwsConfig {
             region: "us-east-1".into(),
@@ -3042,7 +3042,7 @@ mod tests {
                 apm_dd_url: "https://trace.agent.datadoghq.com".to_string(),
                 service: Some("test-service".to_string()),
                 ext: config::LambdaConfig {
-                    compute_trace_stats_on_extension: compute_on_extension,
+                    lambda_extension_compute_stats: compute_on_extension,
                     ..Default::default()
                 },
                 ..config::Config::default()

--- a/bottlecap/src/otlp/agent.rs
+++ b/bottlecap/src/otlp/agent.rs
@@ -58,7 +58,7 @@ impl TracePipeline {
             return Err("Not sending traces, processor returned empty data".to_string());
         }
 
-        let compute_trace_stats_on_extension = self.config.ext.compute_trace_stats_on_extension;
+        let lambda_extension_compute_stats = self.config.ext.lambda_extension_compute_stats;
         // Capture before `tracer_header_tags` is moved into process_traces below.
         let client_computed_stats = tracer_header_tags.client_computed_stats;
         let (send_data_builder, processed_traces) = self.trace_processor.process_traces(
@@ -83,7 +83,7 @@ impl TracePipeline {
         // performs obfuscation, and we need to compute stats on the obfuscated traces.
         // Skip extension-side stats generation when the tracer already computed stats
         // client-side (Datadog-Client-Computed-Stats), to avoid double-counting.
-        if StatsComputedBy::resolve(compute_trace_stats_on_extension, client_computed_stats)
+        if StatsComputedBy::resolve(lambda_extension_compute_stats, client_computed_stats)
             == StatsComputedBy::Extension
             && let Err(err) = self.stats_generator.send(&processed_traces)
         {

--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -139,7 +139,7 @@ fn tags_from_env(
 
     // NOTE: `_dd.compute_stats` is intentionally NOT set here. It is a per-span backend
     // directive (whether the backend should compute trace stats) that depends on both
-    // `compute_trace_stats_on_extension` AND the tracer's `Datadog-Client-Computed-Stats`
+    // `lambda_extension_compute_stats` AND the tracer's `Datadog-Client-Computed-Stats`
     // header. The trace processor stamps it on each span's meta at processing time; baking
     // it into the function tags would leak it into `_dd.tags.function` and ignore the header.
 

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -38,7 +38,7 @@ use crate::traces::trace_aggregator::{OwnedTracerHeaderTags, SendDataBuilderInfo
 use libdd_trace_normalization::normalizer::SamplerPriority;
 
 /// Which party is responsible for computing trace stats for a trace, derived from
-/// `compute_trace_stats_on_extension` and the tracer's `Datadog-Client-Computed-Stats`
+/// `lambda_extension_compute_stats` and the tracer's `Datadog-Client-Computed-Stats`
 /// signal. Exactly one party computes, so the per-span `_dd.compute_stats` stamp and the
 /// extension-side stats-generation guards cannot disagree.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -90,7 +90,7 @@ impl TraceChunkProcessor for ChunkProcessor {
         // The stats-routing decision depends only on config and the per-request
         // client_computed_stats flag, so resolve it once instead of per span.
         let stamp_compute_stats = StatsComputedBy::resolve(
-            self.config.ext.compute_trace_stats_on_extension,
+            self.config.ext.lambda_extension_compute_stats,
             self.client_computed_stats,
         ) == StatsComputedBy::Backend;
 
@@ -128,7 +128,7 @@ impl TraceChunkProcessor for ChunkProcessor {
             });
 
             // Stamp `_dd.compute_stats="1"` to tell the backend to compute trace stats ONLY
-            // when nobody else did: neither the extension (compute_trace_stats_on_extension)
+            // when nobody else did: neither the extension (lambda_extension_compute_stats)
             // nor the tracer (client_computed_stats). Otherwise leave the key absent, which the
             // backend treats as "do not compute" (matching the Go agent's
             // pkg/serverless/tags/tags.go semantics, which only ever set "1" and never "0").
@@ -442,7 +442,7 @@ impl TraceProcessor for ServerlessTraceProcessor {
         // stats are still counted. SamplerPriority::None (-128) means no explicit priority
         // was set and the trace is kept; drop priorities are SamplerPriority::AutoDrop (0)
         // and UserDrop (-1, not represented in SamplerPriority).
-        if config.ext.compute_trace_stats_on_extension
+        if config.ext.lambda_extension_compute_stats
             && let TracerPayloadCollection::V07(ref mut tracer_payloads) = payload
         {
             for tp in tracer_payloads.iter_mut() {
@@ -581,7 +581,7 @@ impl SendingTraceProcessor {
         // Skip extension-side stats generation when the tracer already computed stats
         // client-side (Datadog-Client-Computed-Stats), to avoid double-counting.
         if StatsComputedBy::resolve(
-            config.ext.compute_trace_stats_on_extension,
+            config.ext.lambda_extension_compute_stats,
             client_computed_stats,
         ) == StatsComputedBy::Extension
             && let Err(err) = self.stats_generator.send(&processed_traces)
@@ -1172,7 +1172,7 @@ mod tests {
         );
     }
 
-    /// Verifies that when `compute_trace_stats_on_extension` is true, `process_traces`
+    /// Verifies that when `lambda_extension_compute_stats` is true, `process_traces`
     /// filters sampled-out chunks from the backend payload while preserving them in the
     /// stats collection.
     #[test]
@@ -1183,7 +1183,7 @@ mod tests {
         let config = Arc::new(Config {
             apm_dd_url: "https://trace.agent.datadoghq.com".to_string(),
             ext: crate::config::LambdaConfig {
-                compute_trace_stats_on_extension: true,
+                lambda_extension_compute_stats: true,
                 ..Default::default()
             },
             ..Config::default()
@@ -1272,7 +1272,7 @@ mod tests {
     }
 
     /// Verifies that `process_traces` returns `None` for the backend payload when all
-    /// traces are sampled out and `compute_trace_stats_on_extension` is true.
+    /// traces are sampled out and `lambda_extension_compute_stats` is true.
     #[test]
     fn test_process_traces_returns_none_when_all_sampled_out() {
         use libdd_trace_obfuscation::obfuscation_config::ObfuscationConfig;
@@ -1280,7 +1280,7 @@ mod tests {
         let config = Arc::new(Config {
             apm_dd_url: "https://trace.agent.datadoghq.com".to_string(),
             ext: crate::config::LambdaConfig {
-                compute_trace_stats_on_extension: true,
+                lambda_extension_compute_stats: true,
                 ..Default::default()
             },
             ..Config::default()
@@ -1361,7 +1361,7 @@ mod tests {
         let config = Arc::new(Config {
             apm_dd_url: "https://trace.agent.datadoghq.com".to_string(),
             ext: crate::config::LambdaConfig {
-                compute_trace_stats_on_extension: true,
+                lambda_extension_compute_stats: true,
                 ..Default::default()
             },
             ..Config::default()
@@ -1754,7 +1754,7 @@ mod tests {
     /// is absent. Assert directly on `Span.meta` (NOT `TracerPayload.tags`) — guards #1118.
     #[test]
     fn test_compute_stats_truth_table() {
-        // (compute_trace_stats_on_extension, client_computed_stats) -> expected meta value
+        // (lambda_extension_compute_stats, client_computed_stats) -> expected meta value
         let cases = [
             (false, false, Some("1")), // nobody computed -> tell backend to compute
             (false, true, None),       // tracer computed -> absent
@@ -1765,7 +1765,7 @@ mod tests {
         for (compute_on_extension, client_computed_stats, expected) in cases {
             let config = Arc::new(Config {
                 ext: crate::config::LambdaConfig {
-                    compute_trace_stats_on_extension: compute_on_extension,
+                    lambda_extension_compute_stats: compute_on_extension,
                     ..Default::default()
                 },
                 ..Config::default()
@@ -1811,7 +1811,7 @@ mod tests {
     }
 
     /// APMSVLS-487 Tier 1: `send_processed_traces` only generates extension-side stats when
-    /// `compute_trace_stats_on_extension == true AND client_computed_stats == false`. Drive the
+    /// `lambda_extension_compute_stats == true AND client_computed_stats == false`. Drive the
     /// real concentrator and assert a flushed payload is present/absent accordingly.
     #[tokio::test]
     #[allow(clippy::unwrap_used)]
@@ -1837,7 +1837,7 @@ mod tests {
                 apm_dd_url: "https://trace.agent.datadoghq.com".to_string(),
                 service: Some("test-service".to_string()),
                 ext: crate::config::LambdaConfig {
-                    compute_trace_stats_on_extension: compute_on_extension,
+                    lambda_extension_compute_stats: compute_on_extension,
                     ..Default::default()
                 },
                 ..Config::default()

--- a/bottlecap/tests/apm_integration_test.rs
+++ b/bottlecap/tests/apm_integration_test.rs
@@ -299,7 +299,7 @@ struct PipelineOutcome {
 }
 
 /// Drives `traces` through `SendingTraceProcessor::send_processed_traces` with the given
-/// `compute_trace_stats_on_extension` / `client_computed_stats`, then flushes both the trace
+/// `lambda_extension_compute_stats` / `client_computed_stats`, then flushes both the trace
 /// and stats pipelines into a fresh fake-intake and returns what it captured.
 async fn run_processor_pipeline_with_traces(
     compute_on_extension: bool,
@@ -315,7 +315,7 @@ async fn run_processor_pipeline_with_traces(
         apm_dd_url: fake_intake.traces_url(),
         service: Some("fake-intake-trace-service".to_string()),
         ext: bottlecap::config::LambdaConfig {
-            compute_trace_stats_on_extension: compute_on_extension,
+            lambda_extension_compute_stats: compute_on_extension,
             ..Default::default()
         },
         ..Config::default()


### PR DESCRIPTION
## Summary

Renames the public env var \`DD_COMPUTE_TRACE_STATS_ON_EXTENSION\` to \`DD_LAMBDA_EXTENSION_COMPUTE_STATS\`, plus the matching Rust field, so the name reflects the actual scope: this toggle only governs the Lambda extension's APM trace-stats pipeline and is not a generic Datadog Agent concept.

## Why

Auditing the \`LambdaConfig\` extension fields surfaced this one as the one with an ambiguous env var name. \"Compute trace stats on extension\" reads as if there's a generic \"extension\" concept; in practice it's specifically the Lambda extension. Making that explicit avoids confusion if/when the same idea surfaces in other embedders (which would then need a differently-named knob).

## Changes

- \`LambdaConfigSource\` field renamed: \`compute_trace_stats_on_extension\` → \`lambda_extension_compute_stats\`. Figment's \`DD_\` prefix maps to the new env var automatically.
- \`LambdaConfig\` field renamed in lockstep. All call sites in \`trace_processor.rs\`, \`otlp/agent.rs\`, \`lifecycle/invocation/processor.rs\`, \`tags/lambda/tags.rs\`, and the integration test now read \`config.ext.lambda_extension_compute_stats\`.
- \`merge_from\` keeps the field in the existing \`value:\` group of \`merge_fields!\` — no source-to-config rename needed since field names match.
- **No back-compat alias** for the old env var. The \`.ext\` migration this depends on has not shipped, so the legacy name was never released externally.
- Test renamed; default-false test added.

## Test plan

- [x] \`cargo test\` — \`config::lambda_config_tests::lambda_extension_compute_stats_from_env\` and \`lambda_extension_compute_stats_defaults_false\` pass; 38/38 in the module.
- [x] \`cargo clippy --workspace --all-targets --features default\` — clean.
- [x] \`cargo fmt -- --check\` — clean.

## Notes for review

Stacked on top of \`feat/migrate-bottlecap-to-upstream-config\` (the .ext migration PR). Merges into that branch.