### PR TITLE
chore: bump EXTENSION_VERSION to 98-next

### DIFF
--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -47,7 +47,7 @@ const FUNCTION_TAGS_KEY: &str = "_dd.tags.function";
 // TODO(astuyve) decide what to do with the version
 const EXTENSION_VERSION_KEY: &str = "dd_extension_version";
 // TODO(duncanista) figure out a better way to not hardcode this
-pub const EXTENSION_VERSION: &str = "97-next";
+pub const EXTENSION_VERSION: &str = "98-next";
 
 const REGION_KEY: &str = "region";
 const ACCOUNT_ID_KEY: &str = "account_id";


### PR DESCRIPTION
## Overview

Bump extension version to `98-next` in preparation for the v98 release.

## Testing

No functional change.