### PR TITLE
chore(deps): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -2981,9 +2981,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Overview

Fixes high-severity advisory [RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185): *Remote memory exhaustion in quinn-proto from unbounded out-of-order stream reassembly*. Solution per the advisory is to upgrade to `>= 0.11.15`.

`quinn-proto` is pulled in transitively via `reqwest -> quinn -> quinn-proto` across multiple workspace crates (`bottlecap`, `dogstatsd`, `datadog-fips`, `libddwaf`, `datadog-agent-config`).

This blocks the v98 release — `cargo audit` is failing CI on `main`.

`cargo audit` after the bump shows zero vulnerabilities; the remaining entries are pre-existing unmaintained-crate warnings (async-std, buf_redux, multipart, rustls-pemfile, safemem, twoway).

## Testing

- `cargo audit` no longer reports a vulnerability.