### PR TITLE
perf(build): set jemalloc narenas:1 to trim init metadata + RSS

### DIFF
--- a/images/Dockerfile.bottlecap.alpine.compile
+++ b/images/Dockerfile.bottlecap.alpine.compile
@@ -24,6 +24,11 @@ ENV PATH="${PATH}:/root/.cargo/bin"
 
 # Build the binary
 ENV RUSTFLAGS="-Cpanic=abort"
+# tikv-jemallocator uses the `_rjem_` symbol prefix, so the runtime MALLOC_CONF
+# env var is ignored. Tune jemalloc at compile time instead: a single arena
+# reduces metadata mapped at init and lowers RSS (the extension is not
+# allocation-throughput-bound, so arena contention is a non-issue here).
+ENV JEMALLOC_SYS_WITH_MALLOC_CONF="narenas:1"
 
 WORKDIR /tmp/dd/bottlecap
 RUN --mount=type=cache,target=/root/.cargo/git \

--- a/images/Dockerfile.bottlecap.compile
+++ b/images/Dockerfile.bottlecap.compile
@@ -23,6 +23,11 @@ ENV PATH="${PATH}:/root/.cargo/bin"
 
 # Build the binary
 ENV RUSTFLAGS="-Cpanic=abort"
+# tikv-jemallocator uses the `_rjem_` symbol prefix, so the runtime MALLOC_CONF
+# env var is ignored. Tune jemalloc at compile time instead: a single arena
+# reduces metadata mapped at init and lowers RSS (the extension is not
+# allocation-throughput-bound, so arena contention is a non-issue here).
+ENV JEMALLOC_SYS_WITH_MALLOC_CONF="narenas:1"
 ENV AWS_LC_FIPS_SYS_CC=clang
 ENV AWS_LC_FIPS_SYS_CXX=clang++
 


### PR DESCRIPTION
**Jira:** none yet — add before marking ready.

> :warning: **DRAFT** — stacked on top of #1271 (`jordan.gonzalez/cold-start-instrumentation/feature`). Base will be retargeted to `main` once #1271 merges. Needs benchmarking and was **NOT** docker-built locally.

## Overview

Tune jemalloc at **compile time** to a single arena (`narenas:1`) in both compile Dockerfiles:

- `images/Dockerfile.bottlecap.compile` (GNU / AL2)
- `images/Dockerfile.bottlecap.alpine.compile` (musl / Alpine)

```dockerfile
ENV JEMALLOC_SYS_WITH_MALLOC_CONF="narenas:1"
```

### Why compile-time, and not a `MALLOC_CONF` env var

The binary allocates through `tikv-jemallocator`, which links jemalloc with the **`_rjem_` symbol prefix**. With that prefix, jemalloc does **not** read the standard runtime `MALLOC_CONF` environment variable (nor the `malloc_conf` weak symbol under the unprefixed name), so setting `MALLOC_CONF` at runtime is silently ignored — a footgun. The robust way to configure a prefixed build is the compile-time env `JEMALLOC_SYS_WITH_MALLOC_CONF`, which `jemalloc-sys` bakes into the build. Hence the change lives in the Dockerfiles rather than in the Lambda runtime environment.

### Mechanism / expected effect

- jemalloc pre-maps per-arena metadata at init; the default arena count scales with CPU count. Forcing `narenas:1` cuts that to a single arena, **reducing the metadata mapped at initialization and lowering steady-state RSS**.
- The extension is **not allocation-throughput-bound** — it is an async I/O-bound telemetry forwarder — so the usual reason for many arenas (reducing cross-thread allocator contention) does not apply here. Arena contention is a non-issue for this workload.

## Testing

- [ ] Benchmark cold-start init time and RSS before/after (primary validation — not yet done).
- [ ] Confirm both images build (GNU + Alpine). **Not docker-built locally.**

Dockerfile-only change — no Rust source touched, no `cargo` run required.
