### PR TITLE
perf(build): eager symbol binding (-z,now,-z,relro) for faster init

### DIFF
--- a/images/Dockerfile.bottlecap.alpine.compile
+++ b/images/Dockerfile.bottlecap.alpine.compile
@@ -41,7 +41,7 @@ RUN --mount=type=cache,target=/root/.cargo/git \
     if [ "${PLATFORM}" = "x86_64" ]; then \
         # The `libddwaf` crate links against static objects that require `libclang_rt.builtins`, but
         # this is not presented to the linker by default on this platform, so we force it in.
-        export RUSTFLAGS="${RUSTFLAGS:-} -Clinker=clang -L$(dirname $(clang --print-file-name="libclang_rt.builtins-$(uname -m).a")) -lclang_rt.builtins-$(uname -m)"; \
+        export RUSTFLAGS="${RUSTFLAGS:-} -Clinker=clang -L$(dirname $(clang --print-file-name="libclang_rt.builtins-$(uname -m).a")) -lclang_rt.builtins-$(uname -m) -Clink-arg=-Wl,-z,now -Clink-arg=-Wl,-z,relro"; \
     fi; \
     # We use a wrapper to allow `libddwaf-sys`' build.rs to be compiled with
     # -Ctarget-feature=-crt-static so that it is capable of dynamically loading

--- a/images/Dockerfile.bottlecap.compile
+++ b/images/Dockerfile.bottlecap.compile
@@ -45,7 +45,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/git \
     fi; \
     # The `libddwaf` crate links against static objects that require `libclang_rt.builtins`, but
     # this is not presented to the linker by default on this platform, so we force it in.
-    export RUSTFLAGS="${RUSTFLAGS:-} -Clinker=clang -L$(dirname $(clang --print-file-name="libclang_rt.builtins-$(uname -m).a")) -lclang_rt.builtins-$(uname -m)"; \
+    export RUSTFLAGS="${RUSTFLAGS:-} -Clinker=clang -L$(dirname $(clang --print-file-name="libclang_rt.builtins-$(uname -m).a")) -lclang_rt.builtins-$(uname -m) -Clink-arg=-Wl,-z,now -Clink-arg=-Wl,-z,relro"; \
     cargo +stable build --verbose --locked --no-default-features --features="${FEATURES}" ${BUILD_FLAG} && \
     mkdir -p /tmp/out && cp "/tmp/dd/bottlecap/target/${BUILD_MODE}/bottlecap" /tmp/out/bottlecap
 


### PR DESCRIPTION
**Jira:** none yet — add before marking ready.

> :warning: **DRAFT** — stacked on #1271 (`jordan.gonzalez/cold-start-instrumentation/feature`). Review/merge that first; this PR's base will retarget once #1271 lands.

## Overview

Appends two link args to the clang-linker `RUSTFLAGS` in both compile Dockerfiles (`images/Dockerfile.bottlecap.compile` and `images/Dockerfile.bottlecap.alpine.compile`):

```
-Clink-arg=-Wl,-z,now -Clink-arg=-Wl,-z,relro
```

**Mechanism.** The published layers are dynamically-linked glibc binaries. By default the dynamic linker resolves imported symbols lazily, on first call, via the PLT/GOT — so the first invocation of each external function pays a one-time resolution stall, and many of those stalls land on the cold-start INIT path. `-z now` forces *eager* binding: every dynamic symbol is resolved at load time, moving that resolution work off the INIT path. `-z relro` then marks the GOT read-only after relocation, which is a standard hardening that pairs with full eager binding (full RELRO).

**Scope.** This is a no-op for the static musl build: that binary statically links its dependencies, so there is no lazy PLT resolution of dynamic symbols to eliminate. In the alpine Dockerfile the edited `export RUSTFLAGS=...` already lives inside the existing `if [ "${PLATFORM}" = "x86_64" ]` clang-linker branch, so behavior there is unchanged beyond the added (inert) flags. The flags only have a runtime effect on the dynamically-linked glibc layers.

Dockerfile-only change — no Rust source changes.

## Testing

- Inspected the resulting `RUSTFLAGS` string in both Dockerfiles to confirm the two args are appended cleanly after the existing `-lclang_rt.builtins-$(uname -m)` flag, preserving the surrounding shell quoting and command substitution.
- **NOT** docker-built locally — CI will validate the image build. Functional/cold-start impact to be confirmed via layer build + INIT-duration measurement once CI produces an artifact.
