### PR TITLE
perf(build): set -Ctarget-cpu for Graviton2 / x86-64-v2

### DIFF
--- a/images/Dockerfile.bottlecap.alpine.compile
+++ b/images/Dockerfile.bottlecap.alpine.compile
@@ -38,10 +38,15 @@ RUN --mount=type=cache,target=/root/.cargo/git \
     else \
         export FEATURES=default; \
     fi; \
+    # Tune codegen for the known Lambda CPUs: arm64 is Graviton2 (neoverse-n1),
+    # x86_64 uses the universally-safe x86-64-v2 baseline (NOT v3, which risks SIGILL).
+    if [ "${PLATFORM}" = "aarch64" ]; then TARGET_CPU="neoverse-n1"; else TARGET_CPU="x86-64-v2"; fi; \
     if [ "${PLATFORM}" = "x86_64" ]; then \
         # The `libddwaf` crate links against static objects that require `libclang_rt.builtins`, but
         # this is not presented to the linker by default on this platform, so we force it in.
-        export RUSTFLAGS="${RUSTFLAGS:-} -Clinker=clang -L$(dirname $(clang --print-file-name="libclang_rt.builtins-$(uname -m).a")) -lclang_rt.builtins-$(uname -m)"; \
+        export RUSTFLAGS="${RUSTFLAGS:-} -Clinker=clang -L$(dirname $(clang --print-file-name="libclang_rt.builtins-$(uname -m).a")) -lclang_rt.builtins-$(uname -m) -Ctarget-cpu=${TARGET_CPU}"; \
+    else \
+        export RUSTFLAGS="${RUSTFLAGS:-} -Ctarget-cpu=${TARGET_CPU}"; \
     fi; \
     # We use a wrapper to allow `libddwaf-sys`' build.rs to be compiled with
     # -Ctarget-feature=-crt-static so that it is capable of dynamically loading

--- a/images/Dockerfile.bottlecap.compile
+++ b/images/Dockerfile.bottlecap.compile
@@ -43,9 +43,12 @@ RUN --mount=type=cache,target=/usr/local/cargo/git \
         export BUILD_MODE=debug; \
         export BUILD_FLAG=""; \
     fi; \
+    # Tune codegen for the known Lambda CPUs: arm64 is Graviton2 (neoverse-n1),
+    # x86_64 uses the universally-safe x86-64-v2 baseline (NOT v3, which risks SIGILL).
+    if [ "${PLATFORM}" = "aarch64" ]; then TARGET_CPU="neoverse-n1"; else TARGET_CPU="x86-64-v2"; fi; \
     # The `libddwaf` crate links against static objects that require `libclang_rt.builtins`, but
     # this is not presented to the linker by default on this platform, so we force it in.
-    export RUSTFLAGS="${RUSTFLAGS:-} -Clinker=clang -L$(dirname $(clang --print-file-name="libclang_rt.builtins-$(uname -m).a")) -lclang_rt.builtins-$(uname -m)"; \
+    export RUSTFLAGS="${RUSTFLAGS:-} -Clinker=clang -L$(dirname $(clang --print-file-name="libclang_rt.builtins-$(uname -m).a")) -lclang_rt.builtins-$(uname -m) -Ctarget-cpu=${TARGET_CPU}"; \
     cargo +stable build --verbose --locked --no-default-features --features="${FEATURES}" ${BUILD_FLAG} && \
     mkdir -p /tmp/out && cp "/tmp/dd/bottlecap/target/${BUILD_MODE}/bottlecap" /tmp/out/bottlecap
 


### PR DESCRIPTION
**Please include Jira ticket in title.**

**Jira:** none yet — add before marking ready.

> :construction: **DRAFT** — stacked on #1271 (`jordan.gonzalez/cold-start-instrumentation/feature`). Review/merge that first; this PR's base will retarget to `main` once #1271 lands.

## Overview

Pin `-Ctarget-cpu` per build platform in both compile Dockerfiles
(`images/Dockerfile.bottlecap.compile` and
`images/Dockerfile.bottlecap.alpine.compile`).

The Lambda CPU is known at build time:

- **arm64** → Graviton2 → `-Ctarget-cpu=neoverse-n1`
- **x86_64** → `-Ctarget-cpu=x86-64-v2` (the universally-safe baseline)

**Mechanism / why:** by default rustc generates code for a generic CPU of
the target arch. Telling the compiler the exact microarchitecture lets
codegen use the ISA extensions actually present on Lambda hosts. This
mostly benefits hot, vectorizable paths exercised during init —
TLS/crypto handshakes and (de)compression — so it targets the cold-start
work this stack is about.

**Why x86-64-v2 and not v3 (important):** `x86-64-v3` (AVX2/BMI2/FMA) is
**not** guaranteed across every x86 host Lambda may schedule us onto. If
the binary is built for an ISA the host lacks, it does not degrade
gracefully — it crashes with **SIGILL** (illegal instruction) the first
time such an instruction executes. `x86-64-v2` (SSE4.2 era) is supported
on all current Lambda x86 hardware, so it is the safe choice. arm64 has a
single known CPU (Graviton2), so `neoverse-n1` is exact.

Implementation detail: a small shell conditional sets `TARGET_CPU` from
`${PLATFORM}` and the value is appended to the already-exported
`RUSTFLAGS`. In the alpine Dockerfile the linker-flags export is x86_64-only,
so the aarch64 path now also exports `RUSTFLAGS` (preserving the base
`-Cpanic=abort`) to carry `-Ctarget-cpu`. All existing flags are preserved.

Dockerfile-only change; no Rust source changes.

## Testing

- Verified the shell conditional resolves correctly for both `aarch64`
  (`neoverse-n1`) and `x86_64` (`x86-64-v2`), and that `sh -n` parses both
  build branches.
- **Not** docker-built locally. CI is the source of truth for the actual
  cross-compiles. A wrong/over-aggressive ISA would surface as a **SIGILL**
  at runtime, so the conservative `x86-64-v2` baseline is intentional.
