### PR TITLE
chore(build): honor pinned toolchain, drop dead UPX install

### DIFF
--- a/images/Dockerfile.bottlecap.alpine.compile
+++ b/images/Dockerfile.bottlecap.alpine.compile
@@ -18,7 +18,6 @@ RUN set -euo pipefail && \
         sh -s -- --profile minimal \
                  --default-host "${PLATFORM}-unknown-linux-musl" \
                  --default-toolchain none \
-                 --component rust-src \
                  -y
 ENV PATH="${PATH}:/root/.cargo/bin"
 

--- a/images/Dockerfile.bottlecap.alpine.compile
+++ b/images/Dockerfile.bottlecap.alpine.compile
@@ -17,7 +17,7 @@ RUN set -euo pipefail && \
     curl https://sh.rustup.rs -sSf | \
         sh -s -- --profile minimal \
                  --default-host "${PLATFORM}-unknown-linux-musl" \
-                 --default-toolchain "stable-${PLATFORM}-unknown-linux-musl" \
+                 --default-toolchain none \
                  --component rust-src \
                  -y
 ENV PATH="${PATH}:/root/.cargo/bin"
@@ -47,7 +47,7 @@ RUN --mount=type=cache,target=/root/.cargo/git \
     # -Ctarget-feature=-crt-static so that it is capable of dynamically loading
     # libclang; while still building bottlecap with a static CRT.
     RUSTC_WRAPPER=/tmp/dd/.cargo/musl.rustc-wrapper \
-    cargo +stable build --verbose --locked --no-default-features \
+    cargo build --verbose --locked --no-default-features \
         --features="${FEATURES}" \
         --profile="${PROFILE:-release}" && \
     mkdir -p /tmp/out && \

--- a/images/Dockerfile.bottlecap.compile
+++ b/images/Dockerfile.bottlecap.compile
@@ -17,7 +17,6 @@ RUN curl https://sh.rustup.rs -sSf | \
     sh -s -- --profile minimal \
              --default-host "${PLATFORM}-unknown-linux-gnu" \
              --default-toolchain none \
-             --component rust-src \
              -y
 ENV PATH="${PATH}:/root/.cargo/bin"
 

--- a/images/Dockerfile.bottlecap.compile
+++ b/images/Dockerfile.bottlecap.compile
@@ -16,7 +16,7 @@ RUN chmod +x /install-protoc.sh && /install-protoc.sh
 RUN curl https://sh.rustup.rs -sSf | \
     sh -s -- --profile minimal \
              --default-host "${PLATFORM}-unknown-linux-gnu" \
-             --default-toolchain "stable-${PLATFORM}-unknown-linux-gnu" \
+             --default-toolchain none \
              --component rust-src \
              -y
 ENV PATH="${PATH}:/root/.cargo/bin"
@@ -46,7 +46,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/git \
     # The `libddwaf` crate links against static objects that require `libclang_rt.builtins`, but
     # this is not presented to the linker by default on this platform, so we force it in.
     export RUSTFLAGS="${RUSTFLAGS:-} -Clinker=clang -L$(dirname $(clang --print-file-name="libclang_rt.builtins-$(uname -m).a")) -lclang_rt.builtins-$(uname -m)"; \
-    cargo +stable build --verbose --locked --no-default-features --features="${FEATURES}" ${BUILD_FLAG} && \
+    cargo build --verbose --locked --no-default-features --features="${FEATURES}" ${BUILD_FLAG} && \
     mkdir -p /tmp/out && cp "/tmp/dd/bottlecap/target/${BUILD_MODE}/bottlecap" /tmp/out/bottlecap
 
 # Use smallest image possible

--- a/images/Dockerfile.build_layer
+++ b/images/Dockerfile.build_layer
@@ -5,19 +5,6 @@ ARG FILE_SUFFIX
 # Install dependencies
 RUN apt-get update && apt-get install -y zip binutils wget tar xz-utils
 
-# UPX installation directly from GitHub
-ENV UPX_VERSION=5.0.0
-RUN ARCH=$(uname -m) && \
-    if [ "$ARCH" = "x86_64" ]; then \
-        ARCH_NAME="amd64"; \
-    elif [ "$ARCH" = "aarch64" ]; then \
-        ARCH_NAME="arm64"; \
-    fi && \
-    wget https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-${ARCH_NAME}_linux.tar.xz && \
-    tar -xf upx-${UPX_VERSION}-${ARCH_NAME}_linux.tar.xz && \
-    mv upx-${UPX_VERSION}-${ARCH_NAME}_linux/upx /usr/local/bin/ && \
-    rm -rf upx-${UPX_VERSION}-${ARCH_NAME}_linux upx-${UPX_VERSION}-${ARCH_NAME}_linux.tar.xz
-
 RUN mkdir /extensions
 WORKDIR /extensions
 


### PR DESCRIPTION
> **DRAFT** — stacked on #1271 (`jordan.gonzalez/cold-start-instrumentation/feature`). Base it against `main` once #1271 merges.

**Jira:** none yet — add before marking ready.

## Overview

Build-hygiene cleanup (Confluence H10). Dockerfile-only; no Rust source changes.

**1. Honor the pinned toolchain.** `rust-toolchain.toml` pins `channel = "1.93.1"`, but the compile Dockerfiles built with `cargo +stable`, which overrides the pin and silently builds with whatever `stable` currently resolves to. This change makes `rust-toolchain.toml` the single source of truth:

- Drop the `+stable` override: `cargo +stable build ...` → `cargo build ...` in both `images/Dockerfile.bottlecap.compile` and `images/Dockerfile.bottlecap.alpine.compile`.
- Change the rustup install from `--default-toolchain "stable-${PLATFORM}-unknown-linux-{gnu,musl}"` to `--default-toolchain none`. With no default installed, the first `cargo` invocation inside the bind-mounted source tree reads `rust-toolchain.toml` and auto-installs the pinned `1.93.1` (plus its declared `minimal` profile / `rustfmt` / `clippy`). The `--component rust-src` flag is retained.

Net effect: builds are reproducible against the pinned 1.93.1 instead of a moving `stable`.

Why `--default-toolchain none` over pinning the install to `1.93.1-${PLATFORM}-...`: it is the smaller, lower-maintenance change. The version lives in exactly one place (`rust-toolchain.toml`); bumping the pin later requires no Dockerfile edits, and there is no risk of the Dockerfile and the toml drifting apart.

**2. Remove dead UPX install.** `images/Dockerfile.build_layer` installed UPX (`ENV UPX_VERSION` + the download/extract `RUN`), but nothing compresses the binary anymore — it ships uncompressed and no step invokes `upx`. Only the install block is removed; everything else (deps install, zip packaging, layout) is untouched.

Note on intent: UPX compression is deliberately *not* reintroduced — decompressing a UPX-packed binary at process start would add cold-start latency, so shipping uncompressed is the correct behavior. This PR only removes the leftover dead install.

## Testing

- `git diff` reviewed: the change is exactly the four toolchain lines (two per compile Dockerfile) plus removal of the 13-line UPX block. No other lines touched; no Rust/Cargo files changed.
- Grep confirms no remaining references to `+stable` / `--default-toolchain "stable-..."` in `images/` or `scripts/`, and no remaining `upx` references in any Dockerfile, shell script, workflow, or Makefile.
- **Not** built via Docker locally (no local Docker build of these images was run). The Docker image builds in CI should be checked before this is marked ready for review.
