### PR TITLE
perf(runtime): size Tokio worker pool from Lambda memory tier

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -106,8 +106,22 @@ use tracing::{debug, error, warn};
 use tracing_subscriber::EnvFilter;
 use ustr::Ustr;
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
+    // Right-size the Tokio worker pool to the Lambda memory tier instead of letting
+    // `#[tokio::main]` default to `available_parallelism()`. AWS scales a function's
+    // vCPU allotment linearly with memory, granting one full vCPU at 1769 MB, so we
+    // map memory -> workers with integer math (no float casts that would trip
+    // clippy::pedantic) and clamp to a sane 1..=4 range. Pairs with the H0
+    // `available_parallelism` log so the chosen worker count can be benchmarked.
+    let worker_threads = tokio_worker_threads();
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(worker_threads)
+        .enable_all()
+        .build()?
+        .block_on(run())
+}
+
+async fn run() -> anyhow::Result<()> {
     let start_time = Instant::now();
     init_ustr();
     enable_logging_subsystem();
@@ -194,6 +208,30 @@ async fn main() -> anyhow::Result<()> {
             error!("Extension loop failed: {e:?}, Calling /next without Datadog instrumentation");
             extension_loop_idle(&client, &r, &aws_config).await
         }
+    }
+}
+
+/// Derives the Tokio worker-thread count from the Lambda memory tier exposed via
+/// `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` (megabytes). AWS allocates ~1 vCPU per
+/// 1769 MB, so `workers = round(mem_mb / 1769)` approximates the vCPUs the
+/// sandbox actually grants; the result is clamped to `1..=4`. Uses integer math
+/// — `(mem_mb + 884) / 1769` is `round(mem_mb / 1769)` — to avoid float casts.
+/// Falls back to 2 workers when the variable is absent or unparseable.
+fn tokio_worker_threads() -> usize {
+    const MB_PER_VCPU: u32 = 1769;
+    const DEFAULT_WORKERS: usize = 2;
+    const MAX_WORKERS: usize = 4;
+
+    match env::var("AWS_LAMBDA_FUNCTION_MEMORY_SIZE")
+        .ok()
+        .and_then(|mem| mem.trim().parse::<u32>().ok())
+    {
+        Some(mem_mb) => {
+            // round(mem_mb / 1769) via integer arithmetic, then clamp to 1..=4.
+            let workers = (mem_mb + MB_PER_VCPU / 2) / MB_PER_VCPU;
+            (workers as usize).clamp(1, MAX_WORKERS)
+        }
+        None => DEFAULT_WORKERS,
     }
 }
 


### PR DESCRIPTION
> **DRAFT — stacked on #1271** (`jordan.gonzalez/cold-start-instrumentation/feature`). Review/merge #1271 first; this PR's diff is against that branch, not `main`.

**Jira:** none yet — add before marking ready.

## Overview

Cold-start hypothesis **H15: right-size the Tokio runtime.**

Today the extension uses `#[tokio::main]`, which sizes the worker pool from `std::thread::available_parallelism()`. In a Lambda sandbox that reflects the host's core count, not the fraction of vCPU the function is actually granted, so low-memory functions can spin up more worker threads than they have CPU for (extra thread stacks + scheduler overhead during init).

This PR replaces `#[tokio::main]` with an explicit multi-thread runtime whose worker count is derived from the Lambda **memory tier**:

- AWS allocates roughly **1 vCPU per 1769 MB** of configured memory.
- `workers = round(mem_mb / 1769)`, computed with **integer math** (`(mem_mb + 884) / 1769`, since `884 = 1769 / 2`) to avoid `clippy::pedantic` float-cast lints, then **clamped to `1..=4`**.
- The memory value is read from `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` and parsed as `u32`; if the variable is **missing or unparseable**, we fall back to **2 workers** (no `.unwrap()`).

Resulting mapping (a few points):

| Memory | vCPU (approx) | Workers |
|-------:|--------------:|--------:|
| ≤ 1769 MB | ≤ 1.0 | 1 |
| ~2654–3538 MB | ~1.5–2.0 | 2 |
| ~5307 MB | ~3.0 | 3 |
| ≥ 7076 MB (incl. 10240 max) | ≥ 4.0 | 4 (clamped) |

`.enable_all()` is preserved and the `rt-multi-thread` Tokio feature is unchanged. The init body is moved verbatim from `async fn main` into a new `async fn run()` that the runtime drives via `block_on(run())`; **no other behavior changes**, and all H0 cold-start instrumentation (the `available_parallelism` debug log, `log_init_checkpoint` helper and its calls) is preserved.

This pairs with the H0 `available_parallelism` log added in #1271: that log makes the value the runtime *would* have used observable per tier, and this change makes the value it *does* use deliberate. **Net cold-start and steady-state effect of the chosen worker count still needs benchmarking** across memory tiers before this is considered a confirmed win.

## Testing

- `cargo fmt` and `cargo clippy --bin bottlecap --no-deps` are clean (only the pre-existing `buf_redux`/`multipart` future-incompatibility note remains; pedantic + `unwrap_used` are denied crate-wide and pass).
- The heuristic was unit-checked against representative inputs — `128 / 512 / 884 / 1769 → 1`, `2654 / 3008 / 3538 → 2`, `5307 → 3`, `7076 / 10240 → 4`, `0 → 1`, and missing/empty/non-numeric/whitespace-padded inputs → fallback/trimmed as expected.
- Worker-count performance impact across memory tiers to be measured (see note above).
