### PR TITLE
perf(tags): cache tag strings; hoist per-call regexes to LazyLock

### DIFF
--- a/bottlecap/src/proc/mod.rs
+++ b/bottlecap/src/proc/mod.rs
@@ -5,6 +5,7 @@ use std::{
     collections::HashMap,
     fs::{self, File},
     io::{self, BufRead},
+    sync::LazyLock,
 };
 
 use constants::{
@@ -13,6 +14,14 @@ use constants::{
 };
 use regex::Regex;
 use tracing::debug;
+
+// Compiled once on first use rather than on every call. Both patterns capture
+// the soft limit value (the first numeric value after the title) from a
+// process `limits` file.
+static MAX_OPEN_FILES_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^Max open files\s+(\d+)").expect("valid static regex"));
+static MAX_PROCESSES_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^Max processes\s+(\d+)").expect("valid static regex"));
 
 #[must_use]
 pub fn get_pid_list() -> Vec<i64> {
@@ -222,8 +231,7 @@ pub fn get_fd_max_data(pids: &[i64]) -> f64 {
 
 fn get_fd_max_data_from_path(path: &str, pids: &[i64]) -> f64 {
     let mut fd_max = constants::LAMBDA_FILE_DESCRIPTORS_DEFAULT_LIMIT;
-    // regex to capture the soft limit value (first numeric value after the title)
-    let re = Regex::new(r"^Max open files\s+(\d+)").expect("Failed to create regex");
+    let re = &*MAX_OPEN_FILES_RE;
 
     for &pid in pids {
         let limits_path = format!("{path}/{pid}/limits");
@@ -273,8 +281,7 @@ pub fn get_threads_max_data(pids: &[i64]) -> f64 {
 
 fn get_threads_max_data_from_path(path: &str, pids: &[i64]) -> f64 {
     let mut threads_max = constants::LAMBDA_EXECUTION_PROCESSES_DEFAULT_LIMIT;
-    // regex to capture the soft limit value (first numeric value after the title)
-    let re = Regex::new(r"^Max processes\s+(\d+)").expect("Failed to create regex");
+    let re = &*MAX_PROCESSES_RE;
 
     for &pid in pids {
         let limits_path = format!("{path}/{pid}/limits");

--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -65,6 +65,12 @@ const RESOURCE_KEY: &str = "resource";
 #[derive(Debug, Clone)]
 pub struct Lambda {
     tags_map: HashMap<String, String>,
+    // Cached representations computed once at construction so that the hot
+    // getters below are O(1) reads instead of re-iterating `tags_map` and
+    // re-running `format!("{k}:{v}")`/`join(",")` on every call.
+    tags_vec: Vec<String>,
+    tags_string: String,
+    function_tags_map: HashMap<String, String>,
 }
 
 fn arch_to_platform<'a>() -> &'a str {
@@ -227,17 +233,29 @@ impl Lambda {
         config: Arc<config::Config>,
         metadata: &HashMap<String, String>,
     ) -> Self {
+        let tags_map = tags_from_env(HashMap::new(), config, metadata);
+        // Compute the derived representations once. The tag set is immutable
+        // after construction, so callers can read these cached values cheaply.
+        let tags_vec: Vec<String> = tags_map.iter().map(|(k, v)| format!("{k}:{v}")).collect();
+        let tags_string = tags_vec.join(",");
+        let function_tags_map =
+            HashMap::from_iter([(FUNCTION_TAGS_KEY.to_string(), tags_string.clone())]);
         Lambda {
-            tags_map: tags_from_env(HashMap::new(), config, metadata),
+            tags_map,
+            tags_vec,
+            tags_string,
+            function_tags_map,
         }
     }
 
     #[must_use]
     pub fn get_tags_vec(&self) -> Vec<String> {
-        self.tags_map
-            .iter()
-            .map(|(k, v)| format!("{k}:{v}"))
-            .collect()
+        self.tags_vec.clone()
+    }
+
+    #[must_use]
+    pub fn get_tags_string(&self) -> &str {
+        &self.tags_string
     }
 
     #[must_use]
@@ -257,13 +275,7 @@ impl Lambda {
 
     #[must_use]
     pub fn get_function_tags_map(&self) -> HashMap<String, String> {
-        let tags = self
-            .tags_map
-            .iter()
-            .map(|(k, v)| format!("{k}:{v}"))
-            .collect::<Vec<String>>()
-            .join(",");
-        HashMap::from_iter([(FUNCTION_TAGS_KEY.to_string(), tags)])
+        self.function_tags_map.clone()
     }
 }
 

--- a/bottlecap/src/tags/provider.rs
+++ b/bottlecap/src/tags/provider.rs
@@ -39,7 +39,7 @@ impl Provider {
 
     #[must_use]
     pub fn get_tags_string(&self) -> String {
-        self.get_tags_vec().join(",")
+        self.tag_provider.get_tags_string().to_string()
     }
 
     #[must_use]
@@ -65,6 +65,7 @@ impl Provider {
 
 trait GetTags {
     fn get_tags_vec(&self) -> Vec<String>;
+    fn get_tags_string(&self) -> &str;
     fn get_canonical_id(&self) -> Option<String>;
     fn get_canonical_resource_name(&self) -> Option<String>;
     fn get_tags_map(&self) -> &hash_map::HashMap<String, String>;
@@ -75,6 +76,12 @@ impl GetTags for TagProvider {
     fn get_tags_vec(&self) -> Vec<String> {
         match self {
             TagProvider::Lambda(lambda_tags) => lambda_tags.get_tags_vec(),
+        }
+    }
+
+    fn get_tags_string(&self) -> &str {
+        match self {
+            TagProvider::Lambda(lambda_tags) => lambda_tags.get_tags_string(),
         }
     }
 


### PR DESCRIPTION
**Jira:** none yet — add before marking ready.

> **DRAFT** — stacked on #1271 (`jordan.gonzalez/cold-start-instrumentation/feature`). Review/merge the base PR first; this targets that branch, not `main`.

## Overview

Two small cold-start / hot-path cleanups. Behavior is unchanged — same tag set, order, format, and values; same metrics. Only redundant work is removed.

**1. Cache Lambda tag representations (`tags/lambda/tags.rs`, `tags/provider.rs`)**

`Lambda::get_tags_vec`, `get_tags_string`, and `get_function_tags_map` previously re-iterated the tag map and re-ran `format!("{k}:{v}")` (and `join(",")`) on every call. These are called repeatedly during init (`start_dogstatsd` builds the enrichment-tag string/vec) and per-trace (`trace_processor`, log processor), so the same string was rebuilt many times over.

The tag set is immutable after construction, so the `Vec<String>`, joined `String`, and `_dd.tags.function` map are now computed once in `Lambda::new_from_config` and stored. The getters return the cached values, making repeated reads O(1). A `get_tags_string()` returning `&str` was added so `Provider::get_tags_string()` clones the cached string instead of re-joining the vec.

**2. Hoist per-call regexes to `LazyLock` (`proc/mod.rs`)**

`get_fd_max_data_from_path` and `get_threads_max_data_from_path` called `Regex::new(...)` on every invocation (every fd/threads metrics sample). Both patterns are static literals, so they are now compiled once via `LazyLock<Regex>` (using `.expect("valid static regex")`).

**`trace_processor::span_matches_tag_regex` — left unchanged.** Its pattern comes from per-call user config (`apm_filter_tags_regex_reject`), not a static literal, so it cannot be hoisted to a `LazyLock` without changing behavior. Left as-is intentionally.

## Testing

- `cargo fmt` clean; `cargo clippy --bin bottlecap --no-deps` clean (only the pre-existing `buf_redux`/`multipart` future-incompat warning remains; pedantic/`unwrap_used` denied — satisfied, only `.expect()` used).
- `cargo test --lib` for `proc::tests`, `tags::lambda::tags::tests`, `tags::provider::tests` passes. (Two `test_get_function_tags_map*` cases are a pre-existing multi-threaded env-var-race flake — they also fail on the unmodified base branch and pass single-threaded / in isolation; not caused by this change.)
