### PR TITLE
chore(deps): unify duplicate crate versions

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -389,7 +389,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools 0.11.0",
@@ -432,12 +432,6 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -519,13 +513,13 @@ dependencies = [
  "mime",
  "mock_instant",
  "multipart",
- "nix 0.26.4",
+ "nix",
  "opentelemetry-proto",
- "opentelemetry-semantic-conventions 0.30.0",
+ "opentelemetry-semantic-conventions",
  "ordered_hash_map",
  "proptest",
  "prost 0.14.3",
- "rand 0.8.6",
+ "rand 0.9.4",
  "regex",
  "reqwest",
  "rmp-serde",
@@ -541,7 +535,7 @@ dependencies = [
  "serial_test",
  "sha2",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tikv-jemallocator",
  "time",
  "tokio",
@@ -828,7 +822,7 @@ dependencies = [
  "libdd-trace-utils 2.0.2",
  "lru",
  "opentelemetry",
- "opentelemetry-semantic-conventions 0.31.0",
+ "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "rand 0.8.6",
  "rustc_version_runtime",
@@ -1923,7 +1917,7 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "libc",
- "nix 0.29.0",
+ "nix",
  "pin-project",
  "regex",
  "serde",
@@ -1954,7 +1948,7 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "libc",
- "nix 0.29.0",
+ "nix",
  "pin-project",
  "regex",
  "rustls",
@@ -2282,7 +2276,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "libc",
  "plain",
  "redox_syscall 0.7.3",
@@ -2441,22 +2435,11 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
-]
-
-[[package]]
-name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2529,12 +2512,6 @@ dependencies = [
  "tonic 0.14.5",
  "tonic-prost",
 ]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d059a296a47436748557a353c5e6c5705b9470ef6c95cfc52c21a8814ddac2"
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
@@ -2806,7 +2783,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
- "bitflags 2.11.0",
+ "bitflags",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -3109,7 +3086,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -3118,7 +3095,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -3296,7 +3273,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3309,7 +3286,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -3449,7 +3426,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4151,7 +4128,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -4500,7 +4477,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4891,7 +4868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags",
  "indexmap",
  "log",
  "serde",

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -22,13 +22,13 @@ lazy_static = { version = "1.5", default-features = false }
 log = { version = "0.4", default-features = false }
 mime = { version = "0.3", default-features = false }
 multipart = { version = "0.18", default-features = false, features = ["server"] }
-nix = { version = "0.26", default-features = false, features = ["feature", "fs"] }
+nix = { version = "0.29", default-features = false, features = ["feature", "fs"] }
 ordered_hash_map = { version = "0.4", default-features = false }
 regex = { version = "1.10", default-features = false }
 reqwest = { version = "0.12.11", features = ["json", "http2"], default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
-thiserror = { version = "1.0", default-features = false }
+thiserror = { version = "2.0", default-features = false }
 # Transitive dependency (pulled in via cookie). Pinned to >=0.3.47 so cargo audit / CI passes (RUSTSEC-2026-0009).
 time = { version = "0.3.47", default-features = false }
 tokio = { version = "1.47", default-features = false, features = ["macros", "rt-multi-thread", "time"] }
@@ -46,7 +46,7 @@ rustls-webpki = { version = "0.103.13", default-features = false }
 rustls-pemfile = { version = "2.0", default-features = false, features = ["std"] }
 rustls-pki-types = { version = "1.0", default-features = false }
 hyper-rustls = { version = "0.27.7", default-features = false }
-rand = { version = "0.8", default-features = false }
+rand = { version = "0.9", default-features = false }
 prost = { version = "0.14", default-features = false }
 tonic = { version = "0.14", features = ["transport", "codegen", "server", "channel", "router"], default-features = false }
 tonic-types = { version = "0.14", default-features = false }
@@ -55,7 +55,7 @@ futures = { version = "0.3.31", default-features = false }
 serde-aux = { version = "4.7", default-features = false }
 serde_html_form = { version = "0.2", default-features = false }
 opentelemetry-proto = { version = "0.31.0", features = ["trace", "with-serde", "gen-tonic"] }
-opentelemetry-semantic-conventions = { version = "0.30", features = ["semconv_experimental"] }
+opentelemetry-semantic-conventions = { version = "0.31", features = ["semconv_experimental"] }
 # Pinned to <0.8.3: version 0.8.3 upgraded to openssl-probe 0.2.x which scans all cert
 # directories and parses ~200 individual cert files on Lambda instead of loading a single
 # bundle file, adding ~45ms to each reqwest::Client::build() call.

--- a/bottlecap/src/lifecycle/invocation/mod.rs
+++ b/bottlecap/src/lifecycle/invocation/mod.rs
@@ -1,6 +1,7 @@
 use base64::{DecodeError, Engine, engine::general_purpose};
 use libdd_trace_protobuf::pb::Span;
-use rand::{Rng, RngCore, rngs::OsRng};
+use rand::rngs::OsRng;
+use rand::{Rng, TryRngCore};
 use std::collections::HashMap;
 
 use crate::tags::lambda::tags::{INIT_TYPE, SNAP_START_VALUE};
@@ -51,11 +52,16 @@ fn create_empty_span(name: String, resource: &str, service: &str) -> Span {
 #[must_use]
 pub fn generate_span_id() -> u64 {
     if std::env::var(INIT_TYPE).is_ok_and(|it| it == SNAP_START_VALUE) {
-        return OsRng.next_u64();
+        // SnapStart restores from a snapshot, so seed directly from OS entropy to
+        // avoid reusing the snapshotted RNG state. Fall back to the thread RNG on
+        // the (effectively impossible) OS RNG failure rather than panicking.
+        if let Ok(id) = OsRng.try_next_u64() {
+            return id;
+        }
     }
 
-    let mut rng = rand::thread_rng();
-    rng.r#gen()
+    let mut rng = rand::rng();
+    rng.random()
 }
 
 fn redact_value(key: &str, value: String) -> String {


### PR DESCRIPTION
> **DRAFT — stacked on #1271** (`jordan.gonzalez/cold-start-instrumentation/feature`). Review/merge #1271 first; this PR targets that branch as its base, not `main`.

**Jira:** none yet — add before marking ready.

## Overview

Dependency-hygiene change (Confluence H12): bump our direct dependencies in `bottlecap/Cargo.toml` to match the versions the transitive graph already pulls in, collapsing duplicate compiled crate versions. Fewer duplicate crates means a smaller dependency graph and faster, lighter builds.

Bumps landed:

| Crate | Before | After | Source changes |
|-------|--------|-------|----------------|
| `nix` | 0.26 | **0.29** | none — `sysconf`/`SysconfVar`/`statfs` paths & signatures unchanged. Also eliminates the duplicate `bitflags 1.x` (nix 0.26 pulled bitflags 1; nix 0.29 uses bitflags 2). |
| `thiserror` | 1.0 | **2.0** | none — drop-in. |
| `opentelemetry-semantic-conventions` | 0.30 | **0.31** | none — all constants used in `src/otlp/transform.rs` are unchanged. |
| `rand` | 0.8 | **0.9** | `src/lifecycle/invocation/mod.rs`: `thread_rng()`->`rng()`, `Rng::gen()`->`Rng::random()`, and `OsRng` now implements `TryRngCore` instead of `RngCore` (use `try_next_u64()` with a thread-RNG fallback instead of `next_u64()`). |

No bumps were skipped — all four landed cleanly.

### Files / call-sites changed
- `bottlecap/Cargo.toml` — four version bumps (nix, thiserror, rand, opentelemetry-semantic-conventions).
- `bottlecap/Cargo.lock` — regenerated by `cargo build`.
- `bottlecap/src/lifecycle/invocation/mod.rs` — `generate_span_id()` updated for the rand 0.9 API (only source file needing changes).

### Note on remaining `rand`/`thiserror` duplicates
`cargo tree -d` still lists `rand 0.8` and `thiserror 1.x` after this change. Those copies are **not** reachable from our direct deps anymore — they are pulled exclusively by upstream Datadog git crates (`dd-trace-rs` / `datadog-opentelemetry`, `serverless-components` / `dogstatsd` + `datadog-agent-config`, and the `libdatadog` `libdd-*` crates), plus `multipart` for `rand`. They can only be collapsed by bumping those upstream crates, which is out of scope here. The duplicates this PR's direct deps fully control — `nix` (+ `bitflags 1.x`) and `opentelemetry-semantic-conventions` — are eliminated.

## Testing

- `cargo fmt --manifest-path bottlecap/Cargo.toml` — clean.
- `cargo clippy --manifest-path bottlecap/Cargo.toml --bin bottlecap --no-deps` — **clean** (crate denies `clippy::all` + `pedantic` + `unwrap_used`). Also ran `--all-targets` (lib + tests) clean. Only output is the pre-existing `buf_redux`/`multipart` future-incompat warning.
- `cargo build --bin bottlecap` — succeeds.

### `cargo tree -d` evidence (targeted crates)

Before:
```
bitflags v1.3.2
bitflags v2.11.0
nix v0.26.4
nix v0.29.0
opentelemetry-semantic-conventions v0.30.0
opentelemetry-semantic-conventions v0.31.0
rand v0.8.6
rand v0.9.4
thiserror v1.0.69
thiserror v2.0.18
```

After:
```
rand v0.8.6        (transitive-only: dd-trace-rs / serverless-components / libdatadog / multipart)
rand v0.9.4
thiserror v1.0.69  (transitive-only: dd-trace-rs / serverless-components / libdatadog)
thiserror v2.0.18
```

`bitflags 1.3.2`, `nix 0.26.4`, and `opentelemetry-semantic-conventions 0.30.0` are gone (3 duplicate compiled crates eliminated). The `Cargo.lock` now lists a single version each of `nix` (0.29.0), `opentelemetry-semantic-conventions` (0.31.0), and `bitflags` (2.11.0).
