### PR TITLE
perf(init): issue telemetry subscribe earlier, overlapping service construction

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -373,70 +373,23 @@ async fn extension_loop_active(
     log_init_checkpoint(start_time, "dogstatsd_started");
 
     let propagator = Arc::new(DatadogCompositePropagator::new(Arc::clone(config)));
-    // Lifecycle Invocation Processor
-    let (invocation_processor_handle, invocation_processor_service) =
-        InvocationProcessorService::new(
-            Arc::clone(&tags_provider),
-            Arc::clone(config),
-            Arc::clone(&aws_config),
-            metrics_aggregator_handle.clone(),
-            Arc::clone(&propagator),
-            durable_context_tx,
-        );
-    tokio::spawn(async move {
-        invocation_processor_service.run().await;
-    });
 
-    // AppSec processor (if enabled)
-    let appsec_processor = match AppSecProcessor::new(config) {
-        Ok(p) => Some(Arc::new(TokioMutex::new(p))),
-        Err(AppSecFeatureDisabled) => None,
-        Err(e) => {
-            error!(
-                "AAP | error creating App & API Protection processor, the feature will be disabled: {e}"
-            );
-            None
-        }
-    };
-
-    let (
-        trace_agent_channel,
-        trace_flusher,
-        trace_processor,
-        stats_flusher,
-        proxy_flusher,
-        trace_agent_shutdown_token,
-        stats_concentrator,
-        trace_aggregator_handle,
-    ) = start_trace_agent(
-        config,
-        &api_key_factory,
-        &tags_provider,
-        invocation_processor_handle.clone(),
-        appsec_processor.clone(),
-        &shared_client,
-    );
-    log_init_checkpoint(start_time, "trace_agent_started");
-
-    let api_runtime_proxy_shutdown_signal = start_api_runtime_proxy(
-        config,
-        Arc::clone(&aws_config),
-        &invocation_processor_handle,
-        appsec_processor.as_ref(),
-        Arc::clone(&propagator),
-    );
-
-    let lifecycle_listener =
-        LifecycleListener::new(invocation_processor_handle.clone(), Arc::clone(&propagator));
-    let lifecycle_listener_shutdown_token = lifecycle_listener.get_shutdown_token();
-    // TODO(astuyve): deprioritize this task after the first request
-    tokio::spawn(async move {
-        if let Err(e) = lifecycle_listener.start().await {
-            error!("Error starting lifecycle listener: {e:?}");
-        }
-    });
-
-    let telemetry_listener_cancel_token = setup_telemetry_client(
+    // The Lambda Extensions API ends the INIT phase at the first `/next` call, so the
+    // serialized critical path before that call directly inflates cold-start time. The
+    // telemetry subscription only depends on `logs_agent_channel` (already available),
+    // and its `subscribe` HTTP round-trip is independent of constructing the trace agent,
+    // AppSec, API-runtime proxy, and lifecycle listener below. We therefore issue the
+    // subscribe and run that remaining (synchronous) service construction concurrently
+    // via `tokio::join!`: the subscribe future is polled first so its network round-trip
+    // is in flight while construction proceeds, instead of being serialized behind it.
+    //
+    // Correctness: `setup_telemetry_client` binds the telemetry listener socket
+    // (synchronously, before `subscribe` returns — see `TelemetryListener::start`) prior
+    // to subscribing, so the listener is already accepting connections when the Telemetry
+    // API begins delivering events. No early `platform.initStart`/`initReport` or logs are
+    // dropped. The construction branch only spawns background tasks and returns handles;
+    // it performs no I/O that the subscribe depends on, so the two are order-independent.
+    let telemetry_setup = setup_telemetry_client(
         client,
         &r.extension_id,
         &aws_config.runtime_api,
@@ -444,8 +397,92 @@ async fn extension_loop_active(
         event_bus_tx.clone(),
         config.ext.serverless_logs_enabled,
         aws_config.is_managed_instance_mode(),
-    )
-    .await?;
+    );
+
+    let build_services = async {
+        // Lifecycle Invocation Processor
+        let (invocation_processor_handle, invocation_processor_service) =
+            InvocationProcessorService::new(
+                Arc::clone(&tags_provider),
+                Arc::clone(config),
+                Arc::clone(&aws_config),
+                metrics_aggregator_handle.clone(),
+                Arc::clone(&propagator),
+                durable_context_tx,
+            );
+        tokio::spawn(async move {
+            invocation_processor_service.run().await;
+        });
+
+        // AppSec processor (if enabled)
+        let appsec_processor = match AppSecProcessor::new(config) {
+            Ok(p) => Some(Arc::new(TokioMutex::new(p))),
+            Err(AppSecFeatureDisabled) => None,
+            Err(e) => {
+                error!(
+                    "AAP | error creating App & API Protection processor, the feature will be disabled: {e}"
+                );
+                None
+            }
+        };
+
+        let trace_agent_bundle = start_trace_agent(
+            config,
+            &api_key_factory,
+            &tags_provider,
+            invocation_processor_handle.clone(),
+            appsec_processor.clone(),
+            &shared_client,
+        );
+        log_init_checkpoint(start_time, "trace_agent_started");
+
+        let api_runtime_proxy_shutdown_signal = start_api_runtime_proxy(
+            config,
+            Arc::clone(&aws_config),
+            &invocation_processor_handle,
+            appsec_processor.as_ref(),
+            Arc::clone(&propagator),
+        );
+
+        let lifecycle_listener =
+            LifecycleListener::new(invocation_processor_handle.clone(), Arc::clone(&propagator));
+        let lifecycle_listener_shutdown_token = lifecycle_listener.get_shutdown_token();
+        // TODO(astuyve): deprioritize this task after the first request
+        tokio::spawn(async move {
+            if let Err(e) = lifecycle_listener.start().await {
+                error!("Error starting lifecycle listener: {e:?}");
+            }
+        });
+
+        (
+            invocation_processor_handle,
+            appsec_processor,
+            trace_agent_bundle,
+            api_runtime_proxy_shutdown_signal,
+            lifecycle_listener_shutdown_token,
+        )
+    };
+
+    let (
+        telemetry_listener_cancel_token,
+        (
+            invocation_processor_handle,
+            appsec_processor,
+            (
+                trace_agent_channel,
+                trace_flusher,
+                trace_processor,
+                stats_flusher,
+                proxy_flusher,
+                trace_agent_shutdown_token,
+                stats_concentrator,
+                trace_aggregator_handle,
+            ),
+            api_runtime_proxy_shutdown_signal,
+            lifecycle_listener_shutdown_token,
+        ),
+    ) = tokio::join!(telemetry_setup, build_services);
+    let telemetry_listener_cancel_token = telemetry_listener_cancel_token?;
     log_init_checkpoint(start_time, "telemetry_subscribed");
 
     let otlp_cancel_token = start_otlp_agent(
@@ -1417,7 +1454,7 @@ async fn setup_telemetry_client(
     let listener = TelemetryListener::new(EXTENSION_HOST_IP, TELEMETRY_PORT, logs_tx, event_bus_tx);
 
     let cancel_token = listener.cancel_token();
-    match listener.start() {
+    match listener.start().await {
         Ok(()) => {
             // Drop the listener, so event_bus_tx is closed
             drop(listener);

--- a/bottlecap/src/extension/telemetry/listener.rs
+++ b/bottlecap/src/extension/telemetry/listener.rs
@@ -49,17 +49,27 @@ impl TelemetryListener {
         self.cancel_token.clone()
     }
 
-    pub fn start(&self) -> Result<(), Box<dyn std::error::Error>> {
+    /// Binds the telemetry listener socket and starts serving in a background task.
+    ///
+    /// The bind happens synchronously (before this method returns) so the socket is
+    /// already accepting connections by the time the caller subscribes to the Lambda
+    /// Telemetry API. This makes listener readiness deterministic and avoids dropping
+    /// early `platform.initStart`/`initReport` events delivered immediately after
+    /// subscription.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the listener socket cannot be bound.
+    pub async fn start(&self) -> Result<(), Box<dyn std::error::Error>> {
         let socket = SocketAddr::from((self.host, self.port));
         let router = self.make_router();
+
+        let listener = TcpListener::bind(&socket).await?;
+        debug!("TELEMETRY API | Starting listener on {}", socket);
 
         let cancel_token_clone = self.cancel_token();
         let event_bus_tx = self.event_bus_tx.clone();
         tokio::spawn(async move {
-            let listener = TcpListener::bind(&socket)
-                .await
-                .expect("Failed to bind socket");
-            debug!("TELEMETRY API | Starting listener on {}", socket);
             axum::serve(listener, router)
                 .with_graceful_shutdown(Self::graceful_shutdown(cancel_token_clone, event_bus_tx))
                 .await


### PR DESCRIPTION
**Jira:** none yet — add before marking ready.

> **Draft, stacked on #1271** (`jordan.gonzalez/cold-start-instrumentation/feature`). This PR targets that branch, not `main`. Review/merge #1271 first. Depends on the H0 init-timing instrumentation in #1271 to validate the cold-start win.

## Overview

Cold-start optimization (Confluence H2: reorder init to call `/next` sooner).

The Lambda Extensions API ends the INIT phase at the first `extension::next_event` (`/next`) call, so any work serialized before that call inflates measured cold-start time. In `extension_loop_active`, the telemetry subscription (`setup_telemetry_client` → `telemetry::subscribe`) previously ran **last**, serialized behind `InvocationProcessorService::new`, `AppSecProcessor::new`, `start_trace_agent`, `start_api_runtime_proxy`, and the lifecycle listener — even though the subscribe only depends on `logs_agent_channel` (available right after `start_dogstatsd`).

**What this PR does (the safe subset):**

1. **Hoist + overlap the telemetry subscribe.** The `setup_telemetry_client` future is now created as soon as `logs_agent_channel` is available and run concurrently with the remaining service construction via `tokio::join!`. The subscribe future is the first `join!` argument, so it is polled first: it binds the listener socket and issues the `subscribe` HTTP PUT, then yields on the network round-trip while the construction branch (invocation processor, AppSec, trace agent, API-runtime proxy, lifecycle listener) runs. The subscribe round-trip is therefore in flight *during* construction instead of being serialized after it. The construction branch is otherwise synchronous (it only spawns background tasks and returns handles), so behavior is unchanged — only the timing of the subscribe moves earlier.

2. **Make telemetry-listener readiness deterministic.** `TelemetryListener::start` now binds its TCP socket synchronously (with `.await?`, before returning) instead of binding inside a spawned task. The serve loop still runs in a background task. This matches the pattern already used by the lifecycle, trace, and OTLP listeners.

**What was deferred (intentionally not done):** the fuller refactor that would call `/next` *before* constructing the trace agent / OTLP / AppSec. That reordering is more invasive and risks dropping or mis-ordering early invocation lifecycle handling, so it is out of scope here. This PR keeps every service started and the entire subsequent event loop (both On-Demand and Managed Instance paths) byte-for-byte intact — it changes only *when* the subscribe is issued, not *what* gets built.

## Correctness argument

- **No telemetry dropped.** Hoisting the subscribe earlier shrinks the window between binding the listener and the Telemetry API beginning to POST events, which would *increase* the risk of dropping early `platform.initStart` / `initReport` / logs if the bind were still racy. To remove that race entirely, `TelemetryListener::start` now binds the socket **synchronously before `subscribe` is called**, so the listener is guaranteed to be accepting connections by the time the Telemetry API is told to deliver to `http://sandbox:8999/`. No early platform events or logs can be dropped.
- **Order-independence.** The `build_services` branch performs no I/O that the subscribe depends on, and the subscribe performs no work the construction depends on — the two are independent, so running them under `tokio::join!` cannot reorder any observable side effect. All produced handles (`invocation_processor_handle`, trace bundle, `appsec_processor`, proxy/lifecycle shutdown tokens, etc.) are returned from the join and consumed exactly as before.
- **Cancellation / shutdown unchanged.** `telemetry_listener_cancel_token`, `lifecycle_listener_shutdown_token`, `trace_agent_shutdown_token`, etc. are all still wired into `cancel_background_services` and the tombstone path identically.
- **H0 instrumentation preserved.** All `log_init_checkpoint(...)` calls from #1271 are retained (`dogstatsd_started`, `trace_agent_started`, `telemetry_subscribed`, `ready`, …); `trace_agent_started` now fires inside the join branch but still records.

## Testing

- `cargo fmt` clean.
- `cargo clippy --bin bottlecap --no-deps` clean under `clippy::all` + `pedantic` + `unwrap_used` denied (only the pre-existing `buf_redux`/`multipart` future-incompat warning remains).
- **Not yet validated at runtime.** This needs the H0 init-timing instrumentation (from #1271) plus integration testing on a real Lambda to confirm the cold-start reduction and verify no early telemetry events are dropped. Recommended: compare the `INIT | phase=telemetry_subscribed cumulative=…` and `phase=ready` checkpoints before/after, and confirm `platform.initReport` is still received.
