### PR TITLE
perf(init): parallelize init HTTP client construction

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -136,25 +136,43 @@ async fn main() -> anyhow::Result<()> {
     // Separate checkpoint so the next difference isolates the TLS client build from
     // crypto-provider setup (the latter is non-trivial in FIPS builds).
     log_init_checkpoint(start_time, "crypto_provider_ready");
-    let client = create_reqwest_client_builder()
-        .map_err(|e| anyhow::anyhow!("Failed to create client builder: {e:?}"))?
-        .no_proxy()
-        .build()
-        .map_err(|e| anyhow::anyhow!("Failed to create client: {e:?}"))?;
-    log_init_checkpoint(start_time, "tls_client_build");
 
-    let cloned_client = client.clone();
+    // Build the register/`/next` reqwest client and register the extension on a
+    // background task. Both the TLS client build (which loads native root certs)
+    // and the register network round-trip then overlap with config parsing and
+    // the shared client build on the main task below, instead of running
+    // serially. The task hands back the client because the `/next` long-poll
+    // reuses it for the lifetime of the extension.
+    //
+    // This client is kept separate from the shared flushing client on purpose:
+    // the Extension API register + `/next` long-poll must NOT route through
+    // `DD_PROXY_HTTPS` (hence `.no_proxy()`) and must NOT carry the shared
+    // client's `flush_timeout` (which would abort the long-poll that blocks
+    // until the next invocation). Those needs conflict, so the two clients
+    // cannot be collapsed into one — we overlap their construction instead.
     let runtime_api = aws_config.runtime_api.clone();
     let managed_instance_mode = aws_config.is_managed_instance_mode();
-    let response = tokio::task::spawn(async move {
-        extension::register(
-            &cloned_client,
+    let register_handle = tokio::task::spawn(async move {
+        let client = tokio::task::spawn_blocking(|| {
+            create_reqwest_client_builder()
+                .map_err(|e| anyhow::anyhow!("Failed to create client builder: {e:?}"))?
+                .no_proxy()
+                .build()
+                .map_err(|e| anyhow::anyhow!("Failed to create client: {e:?}"))
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to join client build task: {e:?}"))??;
+        let response = extension::register(
+            &client,
             &runtime_api,
             extension::EXTENSION_NAME,
             managed_instance_mode,
         )
         .await
+        .map_err(|e| anyhow::anyhow!("Failed to register extension: {e:?}"))?;
+        Ok::<_, anyhow::Error>((client, response))
     });
+
     // First load the AWS configuration
     let lambda_directory: String =
         env::var("LAMBDA_TASK_ROOT").unwrap_or_else(|_| "/var/task".to_string());
@@ -164,15 +182,15 @@ async fn main() -> anyhow::Result<()> {
     let aws_config = Arc::new(aws_config);
     // Build one shared reqwest::Client for metrics, logs, trace proxy flushing, and calls to
     // Datadog APIs (e.g. delegated auth). reqwest::Client is Arc-based internally, so cloning
-    // just increments a refcount and shares the connection pool.
+    // just increments a refcount and shares the connection pool. Its TLS build overlaps with
+    // the register client build kicked off above.
     let shared_client = bottlecap::http::get_client(&config);
     let api_key_factory = create_api_key_factory(&config, &aws_config, &shared_client);
     log_init_checkpoint(start_time, "shared_client_ready");
 
-    let r = response
+    let (client, r) = register_handle
         .await
-        .map_err(|e| anyhow::anyhow!("Failed to join task: {e:?}"))?
-        .map_err(|e| anyhow::anyhow!("Failed to register extension: {e:?}"))?;
+        .map_err(|e| anyhow::anyhow!("Failed to join task: {e:?}"))??;
     log_init_checkpoint(start_time, "register_ready");
 
     match extension_loop_active(


### PR DESCRIPTION
## Overview

Cold-start optimization (Confluence **H4**). During init, `main.rs` builds two reqwest clients whose TLS construction loads native root certificates:

- the **register / `/next`** client (built via `create_reqwest_client_builder()…no_proxy().build()`), and
- the **shared flushing** client (`bottlecap::http::get_client`, used for metrics / logs / trace-proxy / Datadog API calls).

Previously these two builds ran **serially**. This PR overlaps them: the register/`/next` client is now built on a blocking thread (`spawn_blocking`) inside a spawned task, and the extension `register` network round-trip runs there too — so both the second cert load and the register call overlap with config parsing and the shared client build on the main task.

### Approach: parallelize, not merge

I deliberately did **not** collapse the two clients into one. Their requirements genuinely conflict:

| Setting | register / `/next` client | shared flushing client |
|---|---|---|
| Proxy (`DD_PROXY_HTTPS`) | **must not** use it (`.no_proxy()`) — Runtime API is local | proxy-aware |
| `flush_timeout` | **none** — `/next` is a long-poll that blocks until the next invocation; a timeout would abort it | `timeout(flush_timeout)` |
| `pool_max_idle_per_host(0)` (issue #1092 stale-conn fix) | n/a | required |
| http2/http1 + custom cert | n/a | required |

Because a flush timeout and the proxy would both break the `/next` long-poll, merging is not behavior-safe. So I took the **fallback: build the two clients concurrently** instead.

### Preserved settings / behavior

- Shared client still built via `bottlecap::http::get_client(&config)` → keeps `flush_timeout`, `pool_max_idle_per_host(0)`, proxy, http2/http1 selection, and custom-cert unchanged.
- Register/`/next` client still built via `create_reqwest_client_builder()…no_proxy().build()` (no proxy, no timeout); it is handed back from the task and reused for the `/next` long-poll for the extension's lifetime — same as before.
- `clippy.toml` `disallowed-methods` respected — no direct `reqwest::Client::builder`; still uses the FIPS adapter / `get_client`.
- H0 cold-start init instrumentation is preserved. The `tls_client_build` checkpoint is folded into the parallel build phase (it is no longer a distinct serial step); `crypto_provider_ready` → `config_parse` → `shared_client_ready` → `register_ready` remain sequential and meaningful.

**Files changed:** `bottlecap/src/bin/bottlecap/main.rs` (init section only).

> **Draft, stacked on #1271** (`jordan.gonzalez/cold-start-instrumentation/feature`), which provides the H0 init instrumentation this builds on. Review/merge #1271 first.
>
> Overlaps with **H1 (#1276, shared TLS `ClientConfig`)**: H1 reduces the per-client cert-loading cost; this PR overlaps the two builds. They are complementary and will need a trivial reconcile when both land.

## Testing

- `cargo fmt` clean.
- `cargo clippy --bin bottlecap --no-deps` clean (clippy::all + pedantic + `unwrap_used` denied); only the pre-existing `buf_redux`/`multipart` future-incompat warning remains.
- Behavior-preserving refactor: client settings and downstream usage (`extension_loop_active` / `extension_loop_idle`) are unchanged; the register/`/next` client is the same one, just built concurrently and returned from the task.

**Jira:** none yet — add before marking ready.
