### PR TITLE
ci: unique identifier per integration-suite attempt; configurable stack prefix

### DIFF
--- a/.gitlab/templates/pipeline.yaml.tpl
+++ b/.gitlab/templates/pipeline.yaml.tpl
@@ -626,7 +626,7 @@ integration-suite:
     - build ruby lambdas
     - build go lambdas
   variables:
-    IDENTIFIER: ${CI_COMMIT_SHORT_SHA}
+    IDENTIFIER: it-${CI_COMMIT_SHORT_SHA}-${CI_JOB_ID}
     AWS_DEFAULT_REGION: us-east-1
     DD_SITE: datadoghq.com
   {{ with $environment := (ds "environments").environments.sandbox }}
@@ -649,7 +649,7 @@ integration-suite:
     - export CDK_DEFAULT_ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
     - export CDK_DEFAULT_REGION=us-east-1
     - npm run build
-    - npx cdk deploy "integ-${IDENTIFIER}-${TEST_SUITE}" --require-approval never --import-existing-resources
+    - npx cdk deploy "${IDENTIFIER}-${TEST_SUITE}" --require-approval never --import-existing-resources
     - echo "Running ${TEST_SUITE} integration tests with identifier ${IDENTIFIER}..."
     - export TEST_SUITE=${TEST_SUITE}
     - npx jest tests/${TEST_SUITE}.test.ts
@@ -658,7 +658,7 @@ integration-suite:
     - EXTERNAL_ID_NAME={{ $environment.external_id }} ROLE_TO_ASSUME={{ $environment.role_to_assume }} AWS_ACCOUNT={{ $environment.account }} source .gitlab/scripts/get_secrets.sh
     - echo "Destroying ${TEST_SUITE} CDK stack with identifier ${IDENTIFIER}..."
     - |
-      STACK_NAME="integ-${IDENTIFIER}-${TEST_SUITE}"
+      STACK_NAME="${IDENTIFIER}-${TEST_SUITE}"
 
       # Check if stack exists
       STACK_STATUS=$(aws cloudformation describe-stacks \

--- a/integration-tests/bin/app.ts
+++ b/integration-tests/bin/app.ts
@@ -11,7 +11,7 @@ import {LmiOom} from '../lib/stacks/lmi-oom';
 import {CustomMetrics} from '../lib/stacks/custom-metrics';
 import {PayloadSize} from '../lib/stacks/payload-size';
 import {AuthRoleStack} from '../lib/auth-role';
-import {ACCOUNT, getIdentifier, REGION} from '../config';
+import {ACCOUNT, IDENTIFIER, REGION} from '../config';
 import {CapacityProviderStack} from "../lib/capacity-provider";
 
 const app = new cdk.App();
@@ -21,39 +21,37 @@ const env = {
     region: REGION,
 };
 
-const identifier = getIdentifier();
-
 // Use the same Lambda Managed Instance Capacity Provider for all LMI functions.
 // It is slow to create/destroy the related resources.
 new CapacityProviderStack(app, `integ-default-capacity-provider`, {env});
 new AuthRoleStack(app, `integ-auth-role`, {env});
 
 const stacks = [
-    new OnDemand(app, `integ-${identifier}-on-demand`, {
+    new OnDemand(app, `${IDENTIFIER}-on-demand`, {
         env,
     }),
-    new Otlp(app, `integ-${identifier}-otlp`, {
+    new Otlp(app, `${IDENTIFIER}-otlp`, {
         env,
     }),
-    new Snapstart(app, `integ-${identifier}-snapstart`, {
+    new Snapstart(app, `${IDENTIFIER}-snapstart`, {
         env,
     }),
-    new LambdaManagedInstancesStack(app, `integ-${identifier}-lmi`, {
+    new LambdaManagedInstancesStack(app, `${IDENTIFIER}-lmi`, {
         env,
     }),
-    new AuthStack(app, `integ-${identifier}-auth`, {
+    new AuthStack(app, `${IDENTIFIER}-auth`, {
         env,
     }),
-    new Oom(app, `integ-${identifier}-oom`, {
+    new Oom(app, `${IDENTIFIER}-oom`, {
         env,
     }),
-    new LmiOom(app, `integ-${identifier}-lmi-oom`, {
+    new LmiOom(app, `${IDENTIFIER}-lmi-oom`, {
         env,
     }),
-    new CustomMetrics(app, `integ-${identifier}-custom-metrics`, {
+    new CustomMetrics(app, `${IDENTIFIER}-custom-metrics`, {
         env,
     }),
-    new PayloadSize(app, `integ-${identifier}-payload-size`, {
+    new PayloadSize(app, `${IDENTIFIER}-payload-size`, {
         env,
     }),
 ]

--- a/integration-tests/config.ts
+++ b/integration-tests/config.ts
@@ -22,11 +22,13 @@ export function getIdentifier(): string {
     const username = os.userInfo().username;
     const firstName = username.split('.')[0];
     if (firstName && firstName.length > 0) {
-      return firstName;
+      return `it-${firstName}`;
     }
   } catch (error) {
     console.error('Error getting identifier:', error);
   }
 
-  return 'integration';
+  return 'it-integration';
 }
+
+export const IDENTIFIER = getIdentifier();

--- a/integration-tests/tests/auth.test.ts
+++ b/integration-tests/tests/auth.test.ts
@@ -1,10 +1,9 @@
 import { invokeAndCollectTelemetry, FunctionConfig } from './utils/default';
 import { DatadogTelemetry } from './utils/datadog';
 import { forceColdStart, publishVersion, waitForSnapStartReady } from './utils/lambda';
-import { getIdentifier } from '../config';
+import { IDENTIFIER } from '../config';
 
-const identifier = getIdentifier();
-const stackName = `integ-${identifier}-auth`;
+const stackName = `${IDENTIFIER}-auth`;
 
 describe('Auth Integration Tests', () => {
   let telemetry: Record<string, DatadogTelemetry>;

--- a/integration-tests/tests/custom-metrics.test.ts
+++ b/integration-tests/tests/custom-metrics.test.ts
@@ -1,9 +1,8 @@
 import { hasMetricWithTag } from "./utils/datadog";
 import { forceColdStart, invokeLambda } from "./utils/lambda";
-import { getIdentifier, DEFAULT_DATADOG_INDEXING_WAIT_MS } from "../config";
+import { IDENTIFIER, DEFAULT_DATADOG_INDEXING_WAIT_MS } from "../config";
 
-const identifier = getIdentifier();
-const stackName = `integ-${identifier}-custom-metrics`;
+const stackName = `${IDENTIFIER}-custom-metrics`;
 
 const CUSTOM_METRIC_NAME = "custom.exclude_tags_test";
 const EXCLUDED_TAGS = ["function_arn", "region"];

--- a/integration-tests/tests/lmi-oom.test.ts
+++ b/integration-tests/tests/lmi-oom.test.ts
@@ -1,6 +1,6 @@
 import { invokeLambda } from './utils/lambda';
 import { getMetricCount, OUT_OF_MEMORY_METRIC } from './utils/datadog';
-import { getIdentifier } from '../config';
+import { IDENTIFIER } from '../config';
 
 /**
  * LMI OOM test.
@@ -15,8 +15,7 @@ import { getIdentifier } from '../config';
  * (e.g. a future change where `handle_managed_instance_report` surfaces
  * `Runtime.OutOfMemory` in the synthesized runtime-done).
  */
-const identifier = getIdentifier();
-const stackName = `integ-${identifier}-lmi-oom`;
+const stackName = `${IDENTIFIER}-lmi-oom`;
 const functionName = `${stackName}-python-lambda`;
 
 const INITIAL_WAIT_MS = 90 * 1000;

--- a/integration-tests/tests/lmi.test.ts
+++ b/integration-tests/tests/lmi.test.ts
@@ -1,12 +1,11 @@
 import { invokeAndCollectTelemetry, FunctionConfig } from './utils/default';
 import { DatadogTelemetry } from './utils/datadog';
-import { getIdentifier } from '../config';
+import { IDENTIFIER } from '../config';
 
 const runtimes = ['node', 'python', 'java', 'dotnet'] as const;
 type Runtime = typeof runtimes[number];
 
-const identifier = getIdentifier();
-const stackName = `integ-${identifier}-lmi`;
+const stackName = `${IDENTIFIER}-lmi`;
 
 describe('LMI Integration Tests', () => {
   let telemetry: Record<string, DatadogTelemetry>;

--- a/integration-tests/tests/on-demand.test.ts
+++ b/integration-tests/tests/on-demand.test.ts
@@ -1,13 +1,12 @@
 import { invokeAndCollectTelemetry, FunctionConfig } from './utils/default';
 import { DatadogTelemetry, DURATION_METRICS } from './utils/datadog';
 import { forceColdStart } from './utils/lambda';
-import { getIdentifier } from '../config';
+import { IDENTIFIER } from '../config';
 
 const runtimes = ['node', 'python', 'java', 'dotnet'] as const;
 type Runtime = typeof runtimes[number];
 
-const identifier = getIdentifier();
-const stackName = `integ-${identifier}-on-demand`;
+const stackName = `${IDENTIFIER}-on-demand`;
 
 describe('On-Demand Integration Tests', () => {
   let telemetry: Record<string, DatadogTelemetry>;

--- a/integration-tests/tests/oom.test.ts
+++ b/integration-tests/tests/oom.test.ts
@@ -1,6 +1,6 @@
 import { invokeLambda } from './utils/lambda';
 import { getMetricCount, OUT_OF_MEMORY_METRIC } from './utils/datadog';
-import { getIdentifier } from '../config';
+import { IDENTIFIER } from '../config';
 
 /**
  * Cross-runtime OOM test.
@@ -25,8 +25,7 @@ import { getIdentifier } from '../config';
  * after an initial wait we re-query every 30s until every runtime reports
  * count>=1 or the overall budget is exhausted.
  */
-const identifier = getIdentifier();
-const stackName = `integ-${identifier}-oom`;
+const stackName = `${IDENTIFIER}-oom`;
 
 interface OomCase {
   runtime: string;

--- a/integration-tests/tests/otlp.test.ts
+++ b/integration-tests/tests/otlp.test.ts
@@ -1,12 +1,11 @@
 import { invokeAndCollectTelemetry, FunctionConfig } from './utils/default';
 import { DatadogTelemetry } from './utils/datadog';
-import { getIdentifier, DATADOG_INDEXING_WAIT_5_MIN_MS } from '../config';
+import { IDENTIFIER, DATADOG_INDEXING_WAIT_5_MIN_MS } from '../config';
 
 const runtimes = ['node', 'python', 'java', 'dotnet'] as const;
 type Runtime = typeof runtimes[number];
 
-const identifier = getIdentifier();
-const stackName = `integ-${identifier}-otlp`;
+const stackName = `${IDENTIFIER}-otlp`;
 
 describe('OTLP Integration Tests', () => {
   let telemetry: Record<string, DatadogTelemetry>;

--- a/integration-tests/tests/payload-size.test.ts
+++ b/integration-tests/tests/payload-size.test.ts
@@ -2,7 +2,7 @@ import { invokeAndCollectTelemetry, FunctionConfig } from './utils/default';
 import { DatadogTelemetry } from './utils/datadog';
 import { forceColdStart } from './utils/lambda';
 import { filterLogMessages } from './utils/cloudwatch';
-import { getIdentifier } from '../config';
+import { IDENTIFIER } from '../config';
 
 // The enriched payload must be large enough to need a high batch cap, yet stay
 // under the 12 MB cap so it flushes in a single batch without a 413.
@@ -12,8 +12,7 @@ const MIN_ENRICHED_BYTES = 10_000_000;
 const SPAN_COUNT = 400;
 const PAYLOAD_BYTES = 24_000;
 
-const identifier = getIdentifier();
-const stackName = `integ-${identifier}-payload-size`;
+const stackName = `${IDENTIFIER}-payload-size`;
 
 describe('Payload Size Integration Tests', () => {
 

--- a/integration-tests/tests/snapstart.test.ts
+++ b/integration-tests/tests/snapstart.test.ts
@@ -1,13 +1,12 @@
 import { invokeAndCollectTelemetry, FunctionConfig } from './utils/default';
 import { DatadogTelemetry } from './utils/datadog';
 import { publishVersion, waitForSnapStartReady } from './utils/lambda';
-import { getIdentifier } from '../config';
+import { IDENTIFIER } from '../config';
 
 const runtimes = ['java', 'dotnet'] as const;
 type Runtime = typeof runtimes[number];
 
-const identifier = getIdentifier();
-const stackName = `integ-${identifier}-snapstart`;
+const stackName = `${IDENTIFIER}-snapstart`;
 
 describe('Snapstart Integration Tests', () => {
   let telemetry: Record<string, DatadogTelemetry>;


### PR DESCRIPTION
## Overview

Integration-suite deploys intermittently fail at `cdk deploy` (before any test runs) because of resource conflict. On some retries, the previous run resources were not cleaned up correctly.

## Fix

* Include `CI_JOB_ID` in the identifier so every attempt gets unique names and there won't be resource conflict.
* Also shorted 'integ' to 'it' so we are less likely to hit the 64 character limit on cdk resources names. 

Note - The integration tests are failing due to 429 error, too many requests. Will address this in follow up PR.

