### PR TITLE
Add apm_integration_test.rs to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 * @DataDog/serverless-aws
 
 .github/chainguard/serverless-init-ci-publish.sts.yaml @DataDog/serverless
-.github/workflows/publish-serverless-init-to-ghcr.yml @DataDog/serverless
+.github/workflows/publish-serverless-init-to-ghcr.yml  @DataDog/serverless
 
-bottlecap/src/traces/ @DataDog/serverless-aws @DataDog/apm-serverless
+bottlecap/src/traces/                   @DataDog/serverless-aws @DataDog/apm-serverless
 bottlecap/tests/apm_integration_test.rs @DataDog/serverless-aws @DataDog/apm-serverless

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,4 @@
 .github/workflows/publish-serverless-init-to-ghcr.yml @DataDog/serverless
 
 bottlecap/src/traces/ @DataDog/serverless-aws @DataDog/apm-serverless
+bottlecap/tests/apm_integration_test.rs @DataDog/serverless-aws @DataDog/apm-serverless


### PR DESCRIPTION
Add GitHub team `apm-serverless` as co-owner of `apm_integration_test.rs` in `CODEOWNERS`.