### PR TITLE
fix(traces): avoid panic on empty `/v0.6/stats` payload

### DIFF
--- a/bottlecap/src/traces/stats_processor.rs
+++ b/bottlecap/src/traces/stats_processor.rs
@@ -78,12 +78,20 @@ impl StatsProcessor for ServerlessStatsProcessor {
                 }
             };
 
+        // An empty stats payload (e.g. an empty msgpack map) has nothing to buffer, so
+        // treat it as a harmless no-op instead of indexing into an empty vec (which panics).
+        let Some(first_bucket) = stats.stats.first_mut() else {
+            debug!("Received empty trace stats payload; nothing to aggregate.");
+            return Ok((StatusCode::ACCEPTED, "Empty stats payload; nothing to aggregate.")
+                .into_response());
+        };
+
         let start = SystemTime::now();
         let timestamp = start
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_nanos();
-        stats.stats[0].start = if let Ok(result) = u64::try_from(timestamp) {
+        first_bucket.start = if let Ok(result) = u64::try_from(timestamp) {
             result
         } else {
             let error_msg = "Error converting timestamp to u64";
@@ -107,5 +115,34 @@ impl StatsProcessor for ServerlessStatsProcessor {
                 Ok((StatusCode::INTERNAL_SERVER_ERROR, error_msg).into_response())
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use tokio::sync::mpsc;
+
+    #[tokio::test]
+    async fn empty_stats_payload_does_not_panic() {
+        // An empty msgpack map (0x80) deserializes to a ClientStatsPayload with an empty
+        // `stats` vec. Indexing `stats.stats[0]` used to panic here; assert we return 202
+        // Accepted instead and buffer nothing.
+        let req = Request::builder()
+            .body(Body::from(vec![0x80u8]))
+            .expect("failed to build request");
+
+        let (tx, mut rx) = mpsc::channel(1);
+        let response = ServerlessStatsProcessor {}
+            .process_stats(req, tx)
+            .await
+            .expect("process_stats returned an error");
+
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        assert!(
+            rx.try_recv().is_err(),
+            "no stats payload should be buffered for an empty request"
+        );
     }
 }

--- a/bottlecap/src/traces/stats_processor.rs
+++ b/bottlecap/src/traces/stats_processor.rs
@@ -82,7 +82,10 @@ impl StatsProcessor for ServerlessStatsProcessor {
         // treat it as a harmless no-op instead of indexing into an empty vec (which panics).
         let Some(first_bucket) = stats.stats.first_mut() else {
             debug!("Received empty trace stats payload; nothing to aggregate.");
-            return Ok((StatusCode::ACCEPTED, "Empty stats payload; nothing to aggregate.")
+            return Ok((
+                StatusCode::ACCEPTED,
+                "Empty stats payload; nothing to aggregate.",
+            )
                 .into_response());
         };
 


### PR DESCRIPTION
## Overview

The `/v0.6/stats` handler unconditionally indexed `stats.stats[0]` to stamp the payload start time. When the request body is an empty msgpack map (`0x80`), `stats_utils::get_stats_from_request_body` returns a `ClientStatsPayload` with an empty `stats` vec, so `stats.stats[0]` panicked:

```
index out of bounds: the len is 0 but the index is 0
```

This is a pre-existing bug reproducible in the Lambda binary; it surfaced while smoke-testing the test-mode binary.

The fix guards the empty case before indexing: an empty payload has nothing to buffer, so we return `202 Accepted` as a harmless no-op. When at least one bucket exists, we set `.start` via `stats.first_mut()`.

## Testing

Added a regression test (`empty_stats_payload_does_not_panic`) that feeds an empty msgpack map body and asserts the handler returns `202 Accepted` without panicking and buffers nothing to the aggregator.

🤖