### PR TITLE
feat(config): add DD_SERVERLESS_APM_ONLY traces-only mode

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -1275,6 +1275,17 @@ fn start_metrics_flushers(
 ) -> Vec<MetricsFlusher> {
     let mut flushers = Vec::new();
 
+    // APM-only ("traces only") mode: do not create any metrics flushers, so that
+    // no metrics (custom DogStatsD, enhanced, or process) ever reach intake. The
+    // DogStatsD server still runs and the aggregator is still drained on flush, but
+    // the drained data is discarded because there is no flusher to send it. This is
+    // the authoritative guarantee that no infrastructure-monitoring charges are
+    // incurred (see DD_SERVERLESS_APM_ONLY).
+    if config.serverless_apm_only {
+        debug!("DD_SERVERLESS_APM_ONLY is enabled: not starting any metrics flushers");
+        return flushers;
+    }
+
     let metrics_intake_url = if !config.dd_url.is_empty() {
         let dd_dd_url = DdDdUrl::new(config.dd_url.clone()).expect("can't parse DD_DD_URL");
 

--- a/bottlecap/src/config/env.rs
+++ b/bottlecap/src/config/env.rs
@@ -401,6 +401,14 @@ pub struct EnvConfig {
     /// Enable logs for AWS Lambda. Alias for `DD_SERVERLESS_LOGS_ENABLED`. Default is `true`.
     #[serde(deserialize_with = "deserialize_optional_bool_from_anything")]
     pub logs_enabled: Option<bool>,
+    /// @env `DD_SERVERLESS_APM_ONLY`
+    ///
+    /// Run the extension in APM-only ("traces only") mode. When `true`, logs and
+    /// all metrics (enhanced, process, custom `DogStatsD`, and OTLP) are suppressed
+    /// at intake so no infrastructure-monitoring or log-ingestion charges are
+    /// incurred. Traces and APM trace stats are unaffected. Default is `false`.
+    #[serde(deserialize_with = "deserialize_optional_bool_from_anything")]
+    pub serverless_apm_only: Option<bool>,
     /// @env `DD_SERVERLESS_FLUSH_STRATEGY`
     ///
     /// The flush strategy to use for AWS Lambda.
@@ -677,6 +685,7 @@ fn merge_config(config: &mut Config, env_config: &EnvConfig) {
             || env_config.logs_enabled.unwrap_or(false);
     }
 
+    merge_option_to_value!(config, env_config, serverless_apm_only);
     merge_option_to_value!(config, env_config, serverless_flush_strategy);
     merge_option_to_value!(config, env_config, enhanced_metrics);
     merge_option_to_value!(config, env_config, lambda_proc_enhanced_metrics);
@@ -1037,6 +1046,7 @@ mod tests {
                 kms_api_key: "test-kms-key".to_string(),
                 api_key_ssm_arn: String::default(),
                 serverless_logs_enabled: false,
+                serverless_apm_only: false,
                 serverless_flush_strategy: FlushStrategy::Periodically(PeriodicStrategy {
                     interval: 60000,
                 }),

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -186,6 +186,31 @@ impl ConfigBuilder {
             self.config.site = "datadoghq.com".to_string();
         }
 
+        // APM-only ("traces only") mode: suppress every billable metrics and logs
+        // egress path so the customer incurs no infrastructure-monitoring or
+        // log-ingestion charges. This intentionally overrides any individually
+        // configured metrics/logs toggles, since the guarantee must hold even if a
+        // user also set, e.g., DD_ENHANCED_METRICS=true. Traces and APM trace stats
+        // are unaffected. The custom DogStatsD egress is additionally disabled in
+        // the metrics flusher wiring (see start_metrics_flushers in main.rs).
+        if self.config.serverless_apm_only {
+            if self.config.serverless_logs_enabled
+                || self.config.enhanced_metrics
+                || self.config.lambda_proc_enhanced_metrics
+                || self.config.otlp_config_metrics_enabled
+                || self.config.otlp_config_logs_enabled
+            {
+                debug!(
+                    "DD_SERVERLESS_APM_ONLY is enabled: forcing logs and all metrics off (traces-only mode)"
+                );
+            }
+            self.config.serverless_logs_enabled = false;
+            self.config.enhanced_metrics = false;
+            self.config.lambda_proc_enhanced_metrics = false;
+            self.config.otlp_config_metrics_enabled = false;
+            self.config.otlp_config_logs_enabled = false;
+        }
+
         // If `proxy_https` is not set, set it from `HTTPS_PROXY` environment variable
         // if it exists
         if let Ok(https_proxy) = std::env::var("HTTPS_PROXY")
@@ -355,6 +380,11 @@ pub struct Config {
     pub kms_api_key: String,
     pub api_key_ssm_arn: String,
     pub serverless_logs_enabled: bool,
+    /// When true, the extension operates in APM-only ("traces only") mode:
+    /// logs and all metrics (enhanced, process, custom `DogStatsD`, and OTLP) are
+    /// suppressed at intake so that no infrastructure-monitoring or log-ingestion
+    /// charges are incurred. Traces and APM trace stats are unaffected.
+    pub serverless_apm_only: bool,
     pub serverless_flush_strategy: FlushStrategy,
     pub enhanced_metrics: bool,
     pub lambda_proc_enhanced_metrics: bool,
@@ -472,6 +502,7 @@ impl Default for Config {
             kms_api_key: String::default(),
             api_key_ssm_arn: String::default(),
             serverless_logs_enabled: true,
+            serverless_apm_only: false,
             serverless_flush_strategy: FlushStrategy::Default,
             enhanced_metrics: true,
             lambda_proc_enhanced_metrics: true,
@@ -1450,6 +1481,45 @@ pub mod tests {
             assert!(config.enhanced_metrics);
             assert!(config.logs_config_use_compression);
             assert!(!config.capture_lambda_payload);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_serverless_apm_only_defaults_off() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+            let config = get_config(Path::new(""));
+            assert!(!config.serverless_apm_only);
+            // Defaults remain unchanged when APM-only is not set.
+            assert!(config.serverless_logs_enabled);
+            assert!(config.enhanced_metrics);
+            assert!(config.lambda_proc_enhanced_metrics);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_serverless_apm_only_forces_metrics_and_logs_off() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+            jail.set_env("DD_SERVERLESS_APM_ONLY", "true");
+            // Even when a user explicitly enables these, APM-only must override them
+            // so that no metrics or logs reach intake (billing guarantee).
+            jail.set_env("DD_SERVERLESS_LOGS_ENABLED", "true");
+            jail.set_env("DD_ENHANCED_METRICS", "true");
+            jail.set_env("DD_LAMBDA_PROC_ENHANCED_METRICS", "true");
+            jail.set_env("DD_OTLP_CONFIG_METRICS_ENABLED", "true");
+            jail.set_env("DD_OTLP_CONFIG_LOGS_ENABLED", "true");
+
+            let config = get_config(Path::new(""));
+
+            assert!(config.serverless_apm_only);
+            assert!(!config.serverless_logs_enabled);
+            assert!(!config.enhanced_metrics);
+            assert!(!config.lambda_proc_enhanced_metrics);
+            assert!(!config.otlp_config_metrics_enabled);
+            assert!(!config.otlp_config_logs_enabled);
             Ok(())
         });
     }

--- a/bottlecap/src/config/yaml.rs
+++ b/bottlecap/src/config/yaml.rs
@@ -117,6 +117,8 @@ pub struct YamlConfig {
     pub serverless_logs_enabled: Option<bool>,
     #[serde(deserialize_with = "deserialize_optional_bool_from_anything")]
     pub logs_enabled: Option<bool>,
+    #[serde(deserialize_with = "deserialize_optional_bool_from_anything")]
+    pub serverless_apm_only: Option<bool>,
     pub serverless_flush_strategy: Option<FlushStrategy>,
     #[serde(deserialize_with = "deserialize_optional_bool_from_anything")]
     pub enhanced_metrics: Option<bool>,
@@ -701,6 +703,7 @@ fn merge_config(config: &mut Config, yaml_config: &YamlConfig) {
             || yaml_config.logs_enabled.unwrap_or(false);
     }
 
+    merge_option_to_value!(config, yaml_config, serverless_apm_only);
     merge_option_to_value!(config, yaml_config, serverless_flush_strategy);
     merge_option_to_value!(config, yaml_config, enhanced_metrics);
     merge_option_to_value!(config, yaml_config, lambda_proc_enhanced_metrics);
@@ -1011,6 +1014,7 @@ api_security_sample_delay: 60 # Seconds
                 kms_api_key: "test-kms-key".to_string(),
                 api_key_ssm_arn: String::default(),
                 serverless_logs_enabled: false,
+                serverless_apm_only: false,
                 serverless_flush_strategy: FlushStrategy::Periodically(PeriodicStrategy {
                     interval: 60000,
                 }),

--- a/bottlecap/src/logs/flusher.rs
+++ b/bottlecap/src/logs/flusher.rs
@@ -259,6 +259,14 @@ impl LogsFlusher {
         &self,
         retry_request: Option<reqwest::RequestBuilder>,
     ) -> Vec<reqwest::RequestBuilder> {
+        // APM-only ("traces only") mode: never send logs to intake. Logs are also
+        // dropped upstream (serverless_logs_enabled is forced off, so the processor
+        // never queues them), but this guard guarantees no log egress regardless of
+        // aggregator or redrive state. See DD_SERVERLESS_APM_ONLY.
+        if self.config.serverless_apm_only {
+            return Vec::new();
+        }
+
         let mut failed_requests = Vec::new();
 
         // If retry_request is provided, only process that request


### PR DESCRIPTION
## Summary

Adds a single master switch — **`DD_SERVERLESS_APM_ONLY`** — that puts the extension in **APM-only ("traces only") mode**. When enabled, every billable metrics and logs egress path is suppressed so the customer incurs no infrastructure-monitoring or log-ingestion charges, while **traces and APM trace stats are unaffected**.

This closes the gap that made a true "traces only" configuration impossible before: there was no toggle to disable **custom DogStatsD metrics**, so even with logs and enhanced metrics turned off, custom metrics could still egress. A single, defensive flag now guarantees the behavior.

- Default is `false` — existing behavior is completely preserved.
- Readable from both environment (`DD_SERVERLESS_APM_ONLY`) and YAML.

## Behavior

| Signal | APM-only mode |
|---|---|
| Traces / APM trace stats | **sent** (unchanged) |
| Enhanced metrics | suppressed |
| Process (proc) enhanced metrics | suppressed |
| Custom DogStatsD metrics | suppressed |
| OTLP metrics | suppressed |
| Logs (incl. OTLP logs) | suppressed |

## Enforcement (defense in depth)

The flag is enforced at multiple layers so the guarantee holds regardless of other configuration (e.g. even if a user also sets `DD_ENHANCED_METRICS=true`):

1. **Config** (`config/mod.rs`) — forces `serverless_logs_enabled`, `enhanced_metrics`, `lambda_proc_enhanced_metrics`, `otlp_config_metrics_enabled`, and `otlp_config_logs_enabled` to `false`, overriding any individually set toggles.
2. **Metrics wiring** (`main.rs::start_metrics_flushers`) — returns no flushers, so anything drained from the DogStatsD aggregator (custom / enhanced / process) is discarded rather than sent.
3. **Logs flusher** (`logs/flusher.rs::flush`) — short-circuits to an empty request set, guaranteeing no log egress even if something is queued or redriven.

## Testing

- `cargo fmt --all -- --check` — passes.
- `cargo clippy --workspace --all-targets --features default` — passes (no new warnings).
- `cargo test` (config + logs modules) — 55 passed, including two new tests:
  - `test_serverless_apm_only_defaults_off` — flag defaults off; other toggles unchanged.
  - `test_serverless_apm_only_forces_metrics_and_logs_off` — flag overrides explicitly-enabled metrics/logs toggles.

### Live validation on AWS Lambda

Built the layer (arm64) and deployed two otherwise-identical Node.js 22 functions (Datadog Node layer + this extension), one with the flag off and one on, then invoked each and queried the Datadog API:

| Signal | flag OFF | flag ON (APM-only) |
|---|---|---|
| Spans / traces | present | **present** |
| Logs | present | **0** |
| Custom metric | present | **absent (never ingested)** |

The extension's Lambda Telemetry API subscription also drops from `[Platform, Extension, Function]` to `[Platform]` when the flag is on, confirming logs are cut off at the source.

## Risk / rollback

Low. Behavior is gated entirely behind a new flag that defaults to `false`; when unset the code paths are unchanged. Rollback is setting/leaving `DD_SERVERLESS_APM_ONLY` unset.

## Notes for reviewers

- The FIPS-feature clippy variant could not be run locally (macOS is missing the aws-lc FIPS crypto dylib); it exercises the same feature-agnostic config/logs code and runs on the Ubuntu CI runners.