### PR TITLE
feat(config): add DD_SERVERLESS_APM_ONLY traces-only mode

### DIFF
--- a/.gitlab/datasources/test-suites.yaml
+++ b/.gitlab/datasources/test-suites.yaml
@@ -8,3 +8,4 @@ test_suites:
   - name: lmi-oom
   - name: payload-size
   - name: durable-cold-start
+  - name: apm-standalone

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -1300,14 +1300,14 @@ fn start_metrics_flushers(
 ) -> Vec<MetricsFlusher> {
     let mut flushers = Vec::new();
 
-    // APM-only ("traces only") mode: do not create any metrics flushers, so that
-    // no metrics (custom DogStatsD, enhanced, or process) ever reach intake. The
-    // DogStatsD server still runs and the aggregator is still drained on flush, but
-    // the drained data is discarded because there is no flusher to send it. This is
-    // the authoritative guarantee that no infrastructure-monitoring charges are
-    // incurred (see DD_SERVERLESS_APM_ONLY).
-    if config.ext.serverless_apm_only {
-        debug!("DD_SERVERLESS_APM_ONLY is enabled: not starting any metrics flushers");
+    // APM standalone ("traces only") mode: skip wiring up metrics flushers
+    // entirely, so no metrics (custom DogStatsD, enhanced, or process) reach
+    // intake. The DogStatsD server still runs and its aggregator is still drained
+    // on flush, but the drained data is discarded since there is no flusher to
+    // send it. Logs and OTLP signals are suppressed separately (see
+    // `apply_apm_standalone` and the logs flusher guard). See
+    // DD_APM_STANDALONE_ENABLED.
+    if config.ext.apm_standalone_enabled {
         return flushers;
     }
 

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -1300,6 +1300,17 @@ fn start_metrics_flushers(
 ) -> Vec<MetricsFlusher> {
     let mut flushers = Vec::new();
 
+    // APM-only ("traces only") mode: do not create any metrics flushers, so that
+    // no metrics (custom DogStatsD, enhanced, or process) ever reach intake. The
+    // DogStatsD server still runs and the aggregator is still drained on flush, but
+    // the drained data is discarded because there is no flusher to send it. This is
+    // the authoritative guarantee that no infrastructure-monitoring charges are
+    // incurred (see DD_SERVERLESS_APM_ONLY).
+    if config.ext.serverless_apm_only {
+        debug!("DD_SERVERLESS_APM_ONLY is enabled: not starting any metrics flushers");
+        return flushers;
+    }
+
     let metrics_intake_url = if !config.dd_url.is_empty() {
         let dd_dd_url = DdDdUrl::new(config.dd_url.clone()).expect("can't parse DD_DD_URL");
 

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -28,33 +28,26 @@ pub type Config = datadog_agent_config::Config<LambdaConfig>;
 #[must_use]
 pub fn get_config(config_directory: &Path) -> Config {
     let mut config = get_config_with_extension::<LambdaConfig>(config_directory);
-    apply_serverless_apm_only(&mut config);
+    apply_apm_standalone(&mut config);
     config
 }
 
-/// APM-only ("traces only") mode: suppress every billable metrics and logs
-/// egress path so the customer incurs no infrastructure-monitoring or
+/// APM standalone ("traces only") mode: suppress every billable metrics and
+/// logs egress path so the customer incurs no infrastructure-monitoring or
 /// log-ingestion charges. This intentionally overrides any individually
 /// configured metrics/logs toggles, since the guarantee must hold even if a
 /// user also set, e.g., `DD_ENHANCED_METRICS=true`. Traces and APM trace stats
 /// are unaffected. The custom `DogStatsD` egress is additionally disabled in
 /// the metrics flusher wiring (see `start_metrics_flushers` in `main.rs`), and
 /// log egress is guarded in the logs flusher.
-fn apply_serverless_apm_only(config: &mut Config) {
-    if !config.ext.serverless_apm_only {
+fn apply_apm_standalone(config: &mut Config) {
+    if !config.ext.apm_standalone_enabled {
         return;
     }
 
-    if config.ext.serverless_logs_enabled
-        || config.ext.enhanced_metrics
-        || config.ext.lambda_proc_enhanced_metrics
-        || config.otlp_config_metrics_enabled
-        || config.otlp_config_logs_enabled
-    {
-        tracing::debug!(
-            "DD_SERVERLESS_APM_ONLY is enabled: forcing logs and all metrics off (traces-only mode)"
-        );
-    }
+    tracing::debug!(
+        "DD_APM_STANDALONE_ENABLED is set: forcing logs and all metrics off (traces-only mode)"
+    );
 
     config.ext.serverless_logs_enabled = false;
     config.ext.enhanced_metrics = false;
@@ -92,12 +85,12 @@ pub struct LambdaConfig {
     pub kms_api_key: String,
     pub api_key_ssm_arn: String,
     pub serverless_logs_enabled: bool,
-    /// When true, the extension operates in APM-only ("traces only") mode:
-    /// logs and all metrics (enhanced, process, custom `DogStatsD`, and OTLP)
-    /// are suppressed at intake so that no infrastructure-monitoring or
+    /// When true, the extension operates in APM standalone ("traces only")
+    /// mode: logs and all metrics (enhanced, process, custom `DogStatsD`, and
+    /// OTLP) are suppressed at intake so that no infrastructure-monitoring or
     /// log-ingestion charges are incurred. Traces and APM trace stats are
     /// unaffected. Defaults to `false`.
-    pub serverless_apm_only: bool,
+    pub apm_standalone_enabled: bool,
     pub serverless_flush_strategy: UpstreamFlushStrategy,
     pub enhanced_metrics: bool,
     pub lambda_proc_enhanced_metrics: bool,
@@ -127,7 +120,7 @@ impl Default for LambdaConfig {
             kms_api_key: String::new(),
             api_key_ssm_arn: String::new(),
             serverless_logs_enabled: true,
-            serverless_apm_only: false,
+            apm_standalone_enabled: false,
             serverless_flush_strategy: UpstreamFlushStrategy::Default,
             enhanced_metrics: true,
             lambda_proc_enhanced_metrics: true,
@@ -177,12 +170,12 @@ pub struct LambdaConfigSource {
     #[serde(deserialize_with = "deser_opt_bool")]
     pub logs_enabled: Option<bool>,
 
-    /// `DD_SERVERLESS_APM_ONLY` — run the extension in APM-only ("traces only")
-    /// mode. When `true`, logs and all metrics (enhanced, process, custom
-    /// `DogStatsD`, and OTLP) are suppressed at intake. Traces and APM trace
-    /// stats are unaffected. Defaults to `false`.
+    /// `DD_APM_STANDALONE_ENABLED` — run the extension in APM standalone
+    /// ("traces only") mode. When `true`, logs and all metrics (enhanced,
+    /// process, custom `DogStatsD`, and OTLP) are suppressed at intake. Traces
+    /// and APM trace stats are unaffected. Defaults to `false`.
     #[serde(deserialize_with = "deser_opt_bool")]
-    pub serverless_apm_only: Option<bool>,
+    pub apm_standalone_enabled: Option<bool>,
 
     pub serverless_flush_strategy: Option<UpstreamFlushStrategy>,
 
@@ -239,7 +232,7 @@ impl DatadogConfigExtension for LambdaConfig {
         datadog_agent_config::merge_fields!(self, source,
             string: [api_key_secret_arn, kms_api_key, api_key_ssm_arn],
             value:  [
-                serverless_apm_only,
+                apm_standalone_enabled,
                 serverless_flush_strategy,
                 enhanced_metrics,
                 lambda_proc_enhanced_metrics,
@@ -308,36 +301,37 @@ mod lambda_config_tests {
     }
 
     #[test]
-    fn serverless_apm_only_defaults_off() {
+    fn apm_standalone_defaults_off() {
         let config = load(|_| Ok(()));
-        assert!(!config.ext.serverless_apm_only);
-        // Defaults remain unchanged when APM-only is not set.
+        assert!(!config.ext.apm_standalone_enabled);
+        // Defaults remain unchanged when APM standalone is not set.
         assert!(config.ext.serverless_logs_enabled);
         assert!(config.ext.enhanced_metrics);
         assert!(config.ext.lambda_proc_enhanced_metrics);
     }
 
     #[test]
-    fn serverless_apm_only_from_yaml() {
-        // Guards the YAML key mapping (`serverless_apm_only:`) independently of the
-        // env-var path. The override application is covered by
-        // `serverless_apm_only_forces_metrics_and_logs_off` via `get_config`.
+    fn apm_standalone_from_yaml() {
+        // Guards the YAML key mapping (`apm_standalone_enabled:`) independently of
+        // the env-var path. The override application is covered by
+        // `apm_standalone_forces_metrics_and_logs_off` via `get_config`.
         let config = load(|jail| {
-            jail.create_file("datadog.yaml", "serverless_apm_only: true\n")?;
+            jail.create_file("datadog.yaml", "apm_standalone_enabled: true\n")?;
             Ok(())
         });
-        assert!(config.ext.serverless_apm_only);
+        assert!(config.ext.apm_standalone_enabled);
     }
 
     #[test]
-    fn serverless_apm_only_forces_metrics_and_logs_off() {
+    fn apm_standalone_forces_metrics_and_logs_off() {
         // Exercised through `get_config` (not `load`) because the override is
         // applied there, after the shared env/yaml merge.
         Jail::expect_with(|jail| {
             jail.clear_env();
-            jail.set_env("DD_SERVERLESS_APM_ONLY", "true");
-            // Even when a user explicitly enables these, APM-only must override
-            // them so that no metrics or logs reach intake (billing guarantee).
+            jail.set_env("DD_APM_STANDALONE_ENABLED", "true");
+            // Even when a user explicitly enables these, APM standalone must
+            // override them so that no metrics or logs reach intake (billing
+            // guarantee).
             jail.set_env("DD_SERVERLESS_LOGS_ENABLED", "true");
             jail.set_env("DD_ENHANCED_METRICS", "true");
             jail.set_env("DD_LAMBDA_PROC_ENHANCED_METRICS", "true");
@@ -346,7 +340,7 @@ mod lambda_config_tests {
 
             let config = get_config(Path::new(""));
 
-            assert!(config.ext.serverless_apm_only);
+            assert!(config.ext.apm_standalone_enabled);
             assert!(!config.ext.serverless_logs_enabled);
             assert!(!config.ext.enhanced_metrics);
             assert!(!config.ext.lambda_proc_enhanced_metrics);

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -318,6 +318,18 @@ mod lambda_config_tests {
     }
 
     #[test]
+    fn serverless_apm_only_from_yaml() {
+        // Guards the YAML key mapping (`serverless_apm_only:`) independently of the
+        // env-var path. The override application is covered by
+        // `serverless_apm_only_forces_metrics_and_logs_off` via `get_config`.
+        let config = load(|jail| {
+            jail.create_file("datadog.yaml", "serverless_apm_only: true\n")?;
+            Ok(())
+        });
+        assert!(config.ext.serverless_apm_only);
+    }
+
+    #[test]
     fn serverless_apm_only_forces_metrics_and_logs_off() {
         // Exercised through `get_config` (not `load`) because the override is
         // applied there, after the shared env/yaml merge.

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -25,10 +25,42 @@ use serde::Deserialize;
 pub type Config = datadog_agent_config::Config<LambdaConfig>;
 
 #[allow(clippy::module_name_repetitions)]
-#[inline]
 #[must_use]
 pub fn get_config(config_directory: &Path) -> Config {
-    get_config_with_extension::<LambdaConfig>(config_directory)
+    let mut config = get_config_with_extension::<LambdaConfig>(config_directory);
+    apply_serverless_apm_only(&mut config);
+    config
+}
+
+/// APM-only ("traces only") mode: suppress every billable metrics and logs
+/// egress path so the customer incurs no infrastructure-monitoring or
+/// log-ingestion charges. This intentionally overrides any individually
+/// configured metrics/logs toggles, since the guarantee must hold even if a
+/// user also set, e.g., `DD_ENHANCED_METRICS=true`. Traces and APM trace stats
+/// are unaffected. The custom `DogStatsD` egress is additionally disabled in
+/// the metrics flusher wiring (see `start_metrics_flushers` in `main.rs`), and
+/// log egress is guarded in the logs flusher.
+fn apply_serverless_apm_only(config: &mut Config) {
+    if !config.ext.serverless_apm_only {
+        return;
+    }
+
+    if config.ext.serverless_logs_enabled
+        || config.ext.enhanced_metrics
+        || config.ext.lambda_proc_enhanced_metrics
+        || config.otlp_config_metrics_enabled
+        || config.otlp_config_logs_enabled
+    {
+        tracing::debug!(
+            "DD_SERVERLESS_APM_ONLY is enabled: forcing logs and all metrics off (traces-only mode)"
+        );
+    }
+
+    config.ext.serverless_logs_enabled = false;
+    config.ext.enhanced_metrics = false;
+    config.ext.lambda_proc_enhanced_metrics = false;
+    config.otlp_config_metrics_enabled = false;
+    config.otlp_config_logs_enabled = false;
 }
 // ---------------------------------------------------------------------------
 // LambdaConfig — bottlecap's `ConfigExtension` for the shared
@@ -60,6 +92,12 @@ pub struct LambdaConfig {
     pub kms_api_key: String,
     pub api_key_ssm_arn: String,
     pub serverless_logs_enabled: bool,
+    /// When true, the extension operates in APM-only ("traces only") mode:
+    /// logs and all metrics (enhanced, process, custom `DogStatsD`, and OTLP)
+    /// are suppressed at intake so that no infrastructure-monitoring or
+    /// log-ingestion charges are incurred. Traces and APM trace stats are
+    /// unaffected. Defaults to `false`.
+    pub serverless_apm_only: bool,
     pub serverless_flush_strategy: UpstreamFlushStrategy,
     pub enhanced_metrics: bool,
     pub lambda_proc_enhanced_metrics: bool,
@@ -89,6 +127,7 @@ impl Default for LambdaConfig {
             kms_api_key: String::new(),
             api_key_ssm_arn: String::new(),
             serverless_logs_enabled: true,
+            serverless_apm_only: false,
             serverless_flush_strategy: UpstreamFlushStrategy::Default,
             enhanced_metrics: true,
             lambda_proc_enhanced_metrics: true,
@@ -137,6 +176,13 @@ pub struct LambdaConfigSource {
     /// `serverless_logs_enabled` — that is the field lambda call sites read.
     #[serde(deserialize_with = "deser_opt_bool")]
     pub logs_enabled: Option<bool>,
+
+    /// `DD_SERVERLESS_APM_ONLY` — run the extension in APM-only ("traces only")
+    /// mode. When `true`, logs and all metrics (enhanced, process, custom
+    /// `DogStatsD`, and OTLP) are suppressed at intake. Traces and APM trace
+    /// stats are unaffected. Defaults to `false`.
+    #[serde(deserialize_with = "deser_opt_bool")]
+    pub serverless_apm_only: Option<bool>,
 
     pub serverless_flush_strategy: Option<UpstreamFlushStrategy>,
 
@@ -193,6 +239,7 @@ impl DatadogConfigExtension for LambdaConfig {
         datadog_agent_config::merge_fields!(self, source,
             string: [api_key_secret_arn, kms_api_key, api_key_ssm_arn],
             value:  [
+                serverless_apm_only,
                 serverless_flush_strategy,
                 enhanced_metrics,
                 lambda_proc_enhanced_metrics,
@@ -258,6 +305,43 @@ mod lambda_config_tests {
     fn defaults_match_lambda_config_default() {
         let config = load(|_| Ok(()));
         assert_eq!(config.ext, LambdaConfig::default());
+    }
+
+    #[test]
+    fn serverless_apm_only_defaults_off() {
+        let config = load(|_| Ok(()));
+        assert!(!config.ext.serverless_apm_only);
+        // Defaults remain unchanged when APM-only is not set.
+        assert!(config.ext.serverless_logs_enabled);
+        assert!(config.ext.enhanced_metrics);
+        assert!(config.ext.lambda_proc_enhanced_metrics);
+    }
+
+    #[test]
+    fn serverless_apm_only_forces_metrics_and_logs_off() {
+        // Exercised through `get_config` (not `load`) because the override is
+        // applied there, after the shared env/yaml merge.
+        Jail::expect_with(|jail| {
+            jail.clear_env();
+            jail.set_env("DD_SERVERLESS_APM_ONLY", "true");
+            // Even when a user explicitly enables these, APM-only must override
+            // them so that no metrics or logs reach intake (billing guarantee).
+            jail.set_env("DD_SERVERLESS_LOGS_ENABLED", "true");
+            jail.set_env("DD_ENHANCED_METRICS", "true");
+            jail.set_env("DD_LAMBDA_PROC_ENHANCED_METRICS", "true");
+            jail.set_env("DD_OTLP_CONFIG_METRICS_ENABLED", "true");
+            jail.set_env("DD_OTLP_CONFIG_LOGS_ENABLED", "true");
+
+            let config = get_config(Path::new(""));
+
+            assert!(config.ext.serverless_apm_only);
+            assert!(!config.ext.serverless_logs_enabled);
+            assert!(!config.ext.enhanced_metrics);
+            assert!(!config.ext.lambda_proc_enhanced_metrics);
+            assert!(!config.otlp_config_metrics_enabled);
+            assert!(!config.otlp_config_logs_enabled);
+            Ok(())
+        });
     }
 
     // ---- string fields from env / yaml ----

--- a/bottlecap/src/logs/flusher.rs
+++ b/bottlecap/src/logs/flusher.rs
@@ -259,6 +259,14 @@ impl LogsFlusher {
         &self,
         retry_request: Option<reqwest::RequestBuilder>,
     ) -> Vec<reqwest::RequestBuilder> {
+        // APM-only ("traces only") mode: never send logs to intake. Logs are also
+        // dropped upstream (serverless_logs_enabled is forced off, so the processor
+        // never queues them), but this guard guarantees no log egress regardless of
+        // aggregator or redrive state. See DD_SERVERLESS_APM_ONLY.
+        if self.config.ext.serverless_apm_only {
+            return Vec::new();
+        }
+
         let mut failed_requests = Vec::new();
 
         // If retry_request is provided, only process that request

--- a/bottlecap/src/logs/flusher.rs
+++ b/bottlecap/src/logs/flusher.rs
@@ -264,6 +264,11 @@ impl LogsFlusher {
         // never queues them), but this guard guarantees no log egress regardless of
         // aggregator or redrive state. See DD_SERVERLESS_APM_ONLY.
         if self.config.ext.serverless_apm_only {
+            // Drain and discard any queued batches so the aggregator stays bounded,
+            // mirroring the metrics path (which drains its aggregator and discards
+            // the data because no flusher is wired up). No requests are ever
+            // produced here, so nothing reaches intake.
+            let _ = self.aggregator_handle.get_batches().await;
             return Vec::new();
         }
 

--- a/bottlecap/src/logs/flusher.rs
+++ b/bottlecap/src/logs/flusher.rs
@@ -259,11 +259,11 @@ impl LogsFlusher {
         &self,
         retry_request: Option<reqwest::RequestBuilder>,
     ) -> Vec<reqwest::RequestBuilder> {
-        // APM-only ("traces only") mode: never send logs to intake. Logs are also
-        // dropped upstream (serverless_logs_enabled is forced off, so the processor
-        // never queues them), but this guard guarantees no log egress regardless of
-        // aggregator or redrive state. See DD_SERVERLESS_APM_ONLY.
-        if self.config.ext.serverless_apm_only {
+        // APM standalone ("traces only") mode: never send logs to intake. Logs are
+        // also dropped upstream (serverless_logs_enabled is forced off, so the
+        // processor never queues them), but this guard guarantees no log egress
+        // regardless of aggregator or redrive state. See DD_APM_STANDALONE_ENABLED.
+        if self.config.ext.apm_standalone_enabled {
             // Drain and discard any queued batches so the aggregator stays bounded,
             // mirroring the metrics path (which drains its aggregator and discards
             // the data because no flusher is wired up). No requests are ever

--- a/integration-tests/bin/app.ts
+++ b/integration-tests/bin/app.ts
@@ -11,6 +11,7 @@ import {LmiOom} from '../lib/stacks/lmi-oom';
 import {CustomMetrics} from '../lib/stacks/custom-metrics';
 import {PayloadSize} from '../lib/stacks/payload-size';
 import {DurableColdStart} from '../lib/stacks/durable-cold-start';
+import {ApmStandalone} from '../lib/stacks/apm-standalone';
 import {AuthRoleStack} from '../lib/auth-role';
 import {ACCOUNT, IDENTIFIER, REGION} from '../config';
 import {CapacityProviderStack} from "../lib/capacity-provider";
@@ -56,6 +57,9 @@ const stacks = [
         env,
     }),
     new DurableColdStart(app, `${IDENTIFIER}-durable-cold-start`, {
+        env,
+    }),
+    new ApmStandalone(app, `${IDENTIFIER}-apm-standalone`, {
         env,
     }),
 ]

--- a/integration-tests/lib/stacks/apm-standalone.ts
+++ b/integration-tests/lib/stacks/apm-standalone.ts
@@ -1,0 +1,57 @@
+import * as cdk from "aws-cdk-lib";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import { Construct } from "constructs";
+import {
+  createLogGroup,
+  defaultDatadogEnvVariables,
+  defaultDatadogSecretPolicy,
+  getExtensionLayer,
+  getDefaultNodeLayer,
+  defaultNodeRuntime,
+} from "../util";
+
+/**
+ * Two functions that emit the same telemetry (a trace, a custom DogStatsD
+ * metric, and logs). The baseline runs with the default config; the standalone
+ * function additionally sets DD_APM_STANDALONE_ENABLED=true. The test asserts
+ * that traces survive for both, while metrics and logs are suppressed for the
+ * standalone function — even though DD_SERVERLESS_LOGS_ENABLED=true is inherited
+ * from the default env, which APM standalone mode must override.
+ */
+export class ApmStandalone extends cdk.Stack {
+  constructor(scope: Construct, id: string, props: cdk.StackProps) {
+    super(scope, id, props);
+
+    const extensionLayer = getExtensionLayer(this);
+    const nodeLayer = getDefaultNodeLayer(this);
+
+    const makeFunction = (name: string, extraEnv: Record<string, string>) => {
+      const fn = new lambda.Function(this, name, {
+        runtime: defaultNodeRuntime,
+        architecture: lambda.Architecture.ARM_64,
+        handler: "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
+        code: lambda.Code.fromAsset("./lambda/custom-metrics-node"),
+        functionName: name,
+        timeout: cdk.Duration.seconds(30),
+        memorySize: 256,
+        environment: {
+          ...defaultDatadogEnvVariables,
+          DD_SERVICE: name,
+          DD_TRACE_ENABLED: "true",
+          DD_LAMBDA_HANDLER: "index.handler",
+          ...extraEnv,
+        },
+        logGroup: createLogGroup(this, name),
+      });
+      fn.addToRolePolicy(defaultDatadogSecretPolicy);
+      fn.addLayers(extensionLayer);
+      fn.addLayers(nodeLayer);
+      return fn;
+    };
+
+    makeFunction(`${id}-baseline-lambda`, {});
+    makeFunction(`${id}-standalone-lambda`, {
+      DD_APM_STANDALONE_ENABLED: "true",
+    });
+  }
+}

--- a/integration-tests/tests/apm-standalone.test.ts
+++ b/integration-tests/tests/apm-standalone.test.ts
@@ -1,0 +1,131 @@
+import {
+  getInvocationTracesLogsByRequestId,
+  getMetricCount,
+  DatadogSpan,
+  DatadogTrace,
+} from './utils/datadog';
+import { forceColdStart, invokeLambda } from './utils/lambda';
+import { IDENTIFIER, DEFAULT_DATADOG_INDEXING_WAIT_MS } from '../config';
+
+const stackName = `${IDENTIFIER}-apm-standalone`;
+
+// Enhanced (billable) metric the extension emits per invocation in normal mode.
+const ENHANCED_INVOCATIONS_METRIC = 'aws.lambda.enhanced.invocations';
+// Custom DogStatsD metric emitted by the custom-metrics-node handler.
+const CUSTOM_METRIC = 'custom.exclude_tags_test';
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function hasAwsLambdaSpan(traces: DatadogTrace[] | undefined): boolean {
+  return (traces ?? [])
+    .flatMap((t: DatadogTrace) => t.spans)
+    .some((s: DatadogSpan) => s.attributes?.operation_name === 'aws.lambda');
+}
+
+describe('APM Standalone Integration Tests', () => {
+  const baselineFunctionName = `${stackName}-baseline-lambda`;
+  const standaloneFunctionName = `${stackName}-standalone-lambda`;
+
+  let invocationStartTime: number;
+  let metricsEndTime: number;
+  let baseline: Awaited<ReturnType<typeof getInvocationTracesLogsByRequestId>>;
+  let standalone: Awaited<ReturnType<typeof getInvocationTracesLogsByRequestId>>;
+
+  beforeAll(async () => {
+    const functionNames = [baselineFunctionName, standaloneFunctionName];
+
+    await Promise.all(functionNames.map(fn => forceColdStart(fn)));
+
+    // Back up the metric query window so the rollup bucket (aligned to the
+    // interval boundary, often just before the invocation) falls in range.
+    invocationStartTime = Date.now() - 60_000;
+
+    const [baselineInv, standaloneInv] = await Promise.all(
+      functionNames.map(fn => invokeLambda(fn)),
+    );
+
+    await sleep(DEFAULT_DATADOG_INDEXING_WAIT_MS);
+    metricsEndTime = Date.now();
+
+    baseline = await getInvocationTracesLogsByRequestId(
+      baselineFunctionName,
+      baselineInv.requestId,
+    );
+    standalone = await getInvocationTracesLogsByRequestId(
+      standaloneFunctionName,
+      standaloneInv.requestId,
+    );
+
+    console.log('Invocation and telemetry collection complete');
+  }, 1800000);
+
+  // Traces are unaffected by APM standalone mode — both functions should
+  // produce a full trace with the inferred aws.lambda root span.
+  describe('traces (preserved in both modes)', () => {
+    it('baseline should have the aws.lambda root span', () => {
+      expect(hasAwsLambdaSpan(baseline.traces)).toBe(true);
+    });
+
+    it('standalone should still have the aws.lambda root span', () => {
+      expect(hasAwsLambdaSpan(standalone.traces)).toBe(true);
+    });
+  });
+
+  describe('enhanced metrics', () => {
+    it('baseline should emit aws.lambda.enhanced.invocations', async () => {
+      const count = await getMetricCount(
+        ENHANCED_INVOCATIONS_METRIC,
+        baselineFunctionName,
+        invocationStartTime,
+        metricsEndTime,
+      );
+      expect(count).toBeGreaterThan(0);
+    });
+
+    it('standalone should NOT emit aws.lambda.enhanced.invocations', async () => {
+      const count = await getMetricCount(
+        ENHANCED_INVOCATIONS_METRIC,
+        standaloneFunctionName,
+        invocationStartTime,
+        metricsEndTime,
+      );
+      expect(count).toBe(0);
+    });
+  });
+
+  describe('custom DogStatsD metrics', () => {
+    it('baseline should emit the custom metric', async () => {
+      const count = await getMetricCount(
+        CUSTOM_METRIC,
+        baselineFunctionName,
+        invocationStartTime,
+        metricsEndTime,
+      );
+      expect(count).toBeGreaterThan(0);
+    });
+
+    it('standalone should NOT emit the custom metric', async () => {
+      const count = await getMetricCount(
+        CUSTOM_METRIC,
+        standaloneFunctionName,
+        invocationStartTime,
+        metricsEndTime,
+      );
+      expect(count).toBe(0);
+    });
+  });
+
+  // Logs must be suppressed even though DD_SERVERLESS_LOGS_ENABLED=true is
+  // inherited from the default env — APM standalone mode forces it off.
+  describe('logs', () => {
+    it('baseline should forward logs to Datadog', () => {
+      expect(baseline.logs?.length ?? 0).toBeGreaterThan(0);
+    });
+
+    it('standalone should NOT forward any logs to Datadog', () => {
+      expect(standalone.logs?.length ?? 0).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a single master switch — **`DD_SERVERLESS_APM_ONLY`** — that puts the extension in **APM-only ("traces only") mode**. When enabled, every billable metrics and logs egress path is suppressed so the customer incurs no infrastructure-monitoring or log-ingestion charges, while **traces and APM trace stats are unaffected**.

This closes the gap that made a true "traces only" configuration impossible before: there was no toggle to disable **custom DogStatsD metrics**, so even with logs and enhanced metrics turned off, custom metrics could still egress. A single, defensive flag now guarantees the behavior.

- Default is `false` — existing behavior is completely preserved.
- Readable from both environment (`DD_SERVERLESS_APM_ONLY`) and YAML.

## Behavior

| Signal | APM-only mode |
|---|---|
| Traces / APM trace stats | **sent** (unchanged) |
| Enhanced metrics | suppressed |
| Process (proc) enhanced metrics | suppressed |
| Custom DogStatsD metrics | suppressed |
| OTLP metrics | suppressed |
| Logs (incl. OTLP logs) | suppressed |

## Implementation (on the Config<LambdaConfig> model)

- `LambdaConfig` / `LambdaConfigSource` gain a `serverless_apm_only` field, merged from both env (`DD_SERVERLESS_APM_ONLY`) and YAML via `merge_fields!`. Defaults to `false`.
- `get_config()` applies a post-merge override (`apply_serverless_apm_only`) that forces `serverless_logs_enabled`, `enhanced_metrics`, `lambda_proc_enhanced_metrics` (on `.ext`) and the core `otlp_config_metrics_enabled` / `otlp_config_logs_enabled` toggles off — overriding any individually set values so the guarantee holds regardless of other configuration.

## Enforcement (defense in depth)

1. **Config** (`config/mod.rs::apply_serverless_apm_only`) — forces the logs/metrics/OTLP toggles off after the shared env/yaml merge.
2. **Metrics wiring** (`main.rs::start_metrics_flushers`) — returns no flushers, so anything drained from the DogStatsD aggregator (custom / enhanced / process) is discarded rather than sent.
3. **Logs flusher** (`logs/flusher.rs::flush`) — short-circuits to an empty request set, guaranteeing no log egress even if something is queued or redriven.

## Testing

- `cargo fmt --all -- --check` — passes.
- `cargo clippy --workspace --all-targets --features default` — passes (no new warnings).
- `cargo test` — passes, including two new tests:
  - `serverless_apm_only_defaults_off` — flag defaults off; other toggles unchanged.
  - `serverless_apm_only_forces_metrics_and_logs_off` — flag overrides explicitly-enabled metrics/logs/OTLP toggles.

### Live validation on AWS Lambda

Built the layer (arm64) and deployed two fully-distinct Node.js 22 functions (Datadog Node layer + this extension), one with the flag off and one on, then invoked each and queried the Datadog API:

| Signal | flag OFF (`serverless-apm-full`) | flag ON (`serverless-apm-standalone`) |
|---|---|---|
| Spans / traces | present | **present** |
| Logs | present | **0** |
| Custom metric | present | **absent (never ingested)** |

The extension's Lambda Telemetry API subscription also drops from `[Platform, Extension, Function]` to `[Platform]` when the flag is on, confirming logs are cut off at the source.

## Risk / rollback

Low. Behavior is gated entirely behind a new flag that defaults to `false`; when unset the code paths are unchanged. Rollback is leaving `DD_SERVERLESS_APM_ONLY` unset.

## Notes for reviewers

- The FIPS-feature clippy variant could not be run locally (macOS is missing the aws-lc FIPS crypto dylib); it exercises the same feature-agnostic config/logs code and runs on the Ubuntu CI runners.