### PR TITLE
[APMSVLS-469] chore(deps): bump `libdatadog` to `a820699` (align `bottlecap` with `serverless-components`)

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -512,8 +512,8 @@ dependencies = [
  "libdd-trace-normalization 2.0.0",
  "libdd-trace-obfuscation",
  "libdd-trace-protobuf 3.0.2",
- "libdd-trace-stats 4.0.0",
- "libdd-trace-utils 6.0.1",
+ "libdd-trace-stats 5.0.0",
+ "libdd-trace-utils 8.0.0",
  "libddwaf",
  "log",
  "mime",
@@ -783,13 +783,13 @@ dependencies = [
 [[package]]
 name = "datadog-agent-config"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=8ce37eb029410b7cf30847376772e3af6baa5f5c#8ce37eb029410b7cf30847376772e3af6baa5f5c"
+source = "git+https://github.com/DataDog/serverless-components?rev=d05932a53a9b80489d1db3a4dd390c18e2da1055#d05932a53a9b80489d1db3a4dd390c18e2da1055"
 dependencies = [
  "datadog-opentelemetry",
  "dogstatsd",
  "figment",
  "libdd-trace-obfuscation",
- "libdd-trace-utils 6.0.1",
+ "libdd-trace-utils 8.0.0",
  "log",
  "serde",
  "serde-aux",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "datadog-fips"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=8ce37eb029410b7cf30847376772e3af6baa5f5c#8ce37eb029410b7cf30847376772e3af6baa5f5c"
+source = "git+https://github.com/DataDog/serverless-components?rev=d05932a53a9b80489d1db3a4dd390c18e2da1055#d05932a53a9b80489d1db3a4dd390c18e2da1055"
 dependencies = [
  "reqwest",
  "rustls",
@@ -943,7 +943,7 @@ dependencies = [
 [[package]]
 name = "dogstatsd"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=8ce37eb029410b7cf30847376772e3af6baa5f5c#8ce37eb029410b7cf30847376772e3af6baa5f5c"
+source = "git+https://github.com/DataDog/serverless-components?rev=d05932a53a9b80489d1db3a4dd390c18e2da1055#d05932a53a9b80489d1db3a4dd390c18e2da1055"
 dependencies = [
  "datadog-protos",
  "ddsketch-agent",
@@ -1883,7 +1883,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 [[package]]
 name = "libdd-capabilities"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1894,7 +1894,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities-impl"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -1938,7 +1938,7 @@ dependencies = [
 [[package]]
 name = "libdd-common"
 version = "4.2.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2011,7 +2011,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "prost 0.14.3",
 ]
@@ -2033,7 +2033,7 @@ dependencies = [
 [[package]]
 name = "libdd-shared-runtime"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "async-trait",
  "futures",
@@ -2084,7 +2084,7 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "serde",
 ]
@@ -2102,7 +2102,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf 3.0.2",
@@ -2110,14 +2110,14 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-obfuscation"
-version = "3.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+version = "4.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "anyhow",
  "fluent-uri",
  "libdd-common 4.2.0",
  "libdd-trace-protobuf 3.0.2",
- "libdd-trace-utils 6.0.1",
+ "libdd-trace-utils 8.0.0",
  "log",
  "percent-encoding",
  "serde",
@@ -2138,7 +2138,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-protobuf"
 version = "3.0.2"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -2159,8 +2159,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-stats"
-version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+version = "5.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2170,11 +2170,11 @@ dependencies = [
  "libdd-capabilities",
  "libdd-capabilities-impl",
  "libdd-common 4.2.0",
- "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03)",
+ "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c)",
  "libdd-shared-runtime",
  "libdd-trace-obfuscation",
  "libdd-trace-protobuf 3.0.2",
- "libdd-trace-utils 6.0.1",
+ "libdd-trace-utils 8.0.0",
  "rmp-serde",
  "serde",
  "tokio",
@@ -2212,8 +2212,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-utils"
-version = "6.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+version = "8.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -74,17 +74,17 @@ indexmap = {version = "2.11.0", default-features = false}
 # be found in the clippy.toml file adjacent to this Cargo.toml.
 datadog-protos = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "f863626dbfe3c59bb390985fa6530b0621c2a0a2"}
 ddsketch-agent = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "f863626dbfe3c59bb390985fa6530b0621c2a0a2"}
-libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03", default-features = false }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03", default-features = false, features = ["mini_agent"] }
-libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03", default-features = false }
-libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03", default-features = false }
+libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", default-features = false }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", default-features = false, features = ["mini_agent"] }
+libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", default-features = false }
+libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", default-features = false }
 datadog-opentelemetry = { git = "https://github.com/DataDog/dd-trace-rs", rev = "f51cefc4ad24bec81b38fb2f36b1ed93f21ae913", default-features = false }
-dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "8ce37eb029410b7cf30847376772e3af6baa5f5c", default-features = false }
-datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "8ce37eb029410b7cf30847376772e3af6baa5f5c", default-features = false }
-datadog-agent-config = { git = "https://github.com/DataDog/serverless-components", rev = "8ce37eb029410b7cf30847376772e3af6baa5f5c", default-features = false }
+dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "d05932a53a9b80489d1db3a4dd390c18e2da1055", default-features = false }
+datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "d05932a53a9b80489d1db3a4dd390c18e2da1055", default-features = false }
+datadog-agent-config = { git = "https://github.com/DataDog/serverless-components", rev = "d05932a53a9b80489d1db3a4dd390c18e2da1055", default-features = false }
 libddwaf = { version = "1.28.1", git = "https://github.com/DataDog/libddwaf-rust", rev = "d1534a158d976bd4f747bf9fcc58e0712d2d17fc", default-features = false, features = ["serde"] }
 
 [dev-dependencies]


### PR DESCRIPTION
## Overview

Aligns bottlecap's `libdatadog` revision with serverless-components / the Serverless Compat Layer, as a precursor to the APMSVLS-469 error sampler.

- Bumps all `libdd-*` pins from `48da0d82` to `a820699` (e.g. `libdd-trace-utils` v6 -> v8, `libdd-trace-obfuscation` v3 -> v4).
- Bumps the serverless-components deps (`dogstatsd`, `datadog-fips`, `datadog-agent-config`) from `8ce37eb0` to `d05932a5` (current serverless-components `main`), which pins the same `a820699` libdatadog.

**Why the two bumps are coupled:** `datadog-agent-config`'s public API exposes `libdd_trace_obfuscation::ReplaceRule` (e.g. `Config.apm_replace_tags`), which bottlecap consumes. bottlecap and the config crate must therefore resolve to a single libdatadog revision. Mixing revisions puts two incompatible `ReplaceRule` types in the dependency graph and fails to compile (`E0308`).

**No production source changes.** Only `bottlecap/Cargo.toml` (10 rev bumps) and `bottlecap/Cargo.lock`.

**Why now:** the APMSVLS-469 error sampler consumes the new `datadog-agent-trace-sampler` crate from serverless-components, which lives on a base that pins `a820699`. Landing this bump first keeps that change focused on the sampler wiring and removes the long-standing bottlecap <-> serverless-components libdatadog drift.

## Testing

Verified on a clean worktree off `main` (only the Cargo bump applied):

- `cargo test --tests`: all pass (lib + `apm`/`appsec`/`logs`/`metrics` integration tests, including the fake-intake trace/stats protobuf roundtrips, so the `libdd-trace-protobuf` v3.0.2 wire format is compatible).
- `cargo clippy --workspace --all-targets --features default`: clean.
- FIPS build (`--no-default-features --features fips`) not run locally; relies on CI.

🤖