### PR TITLE
[SVLS-9373] fix(config): trim trailing slashes from DD URL env vars

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -783,7 +783,7 @@ dependencies = [
 [[package]]
 name = "datadog-agent-config"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=65eb3d052223b54620578673633e9a390ceb2c1c#65eb3d052223b54620578673633e9a390ceb2c1c"
+source = "git+https://github.com/DataDog/serverless-components?rev=ddb4378017a50761a89e3b9e9de3411b0d79211d#ddb4378017a50761a89e3b9e9de3411b0d79211d"
 dependencies = [
  "datadog-opentelemetry",
  "dogstatsd",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "datadog-fips"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=65eb3d052223b54620578673633e9a390ceb2c1c#65eb3d052223b54620578673633e9a390ceb2c1c"
+source = "git+https://github.com/DataDog/serverless-components?rev=ddb4378017a50761a89e3b9e9de3411b0d79211d#ddb4378017a50761a89e3b9e9de3411b0d79211d"
 dependencies = [
  "reqwest",
  "rustls",
@@ -943,7 +943,7 @@ dependencies = [
 [[package]]
 name = "dogstatsd"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=65eb3d052223b54620578673633e9a390ceb2c1c#65eb3d052223b54620578673633e9a390ceb2c1c"
+source = "git+https://github.com/DataDog/serverless-components?rev=ddb4378017a50761a89e3b9e9de3411b0d79211d#ddb4378017a50761a89e3b9e9de3411b0d79211d"
 dependencies = [
  "datadog-protos",
  "ddsketch-agent",
@@ -1624,7 +1624,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2973,7 +2973,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3010,7 +3010,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]

--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -512,8 +512,8 @@ dependencies = [
  "libdd-trace-normalization 2.0.0",
  "libdd-trace-obfuscation",
  "libdd-trace-protobuf 3.0.2",
- "libdd-trace-stats 4.0.0",
- "libdd-trace-utils 6.0.1",
+ "libdd-trace-stats 5.0.0",
+ "libdd-trace-utils 8.0.0",
  "libddwaf",
  "log",
  "mime",
@@ -783,13 +783,13 @@ dependencies = [
 [[package]]
 name = "datadog-agent-config"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=8ce37eb029410b7cf30847376772e3af6baa5f5c#8ce37eb029410b7cf30847376772e3af6baa5f5c"
+source = "git+https://github.com/DataDog/serverless-components?rev=65eb3d052223b54620578673633e9a390ceb2c1c#65eb3d052223b54620578673633e9a390ceb2c1c"
 dependencies = [
  "datadog-opentelemetry",
  "dogstatsd",
  "figment",
  "libdd-trace-obfuscation",
- "libdd-trace-utils 6.0.1",
+ "libdd-trace-utils 8.0.0",
  "log",
  "serde",
  "serde-aux",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "datadog-fips"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=8ce37eb029410b7cf30847376772e3af6baa5f5c#8ce37eb029410b7cf30847376772e3af6baa5f5c"
+source = "git+https://github.com/DataDog/serverless-components?rev=65eb3d052223b54620578673633e9a390ceb2c1c#65eb3d052223b54620578673633e9a390ceb2c1c"
 dependencies = [
  "reqwest",
  "rustls",
@@ -943,7 +943,7 @@ dependencies = [
 [[package]]
 name = "dogstatsd"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=8ce37eb029410b7cf30847376772e3af6baa5f5c#8ce37eb029410b7cf30847376772e3af6baa5f5c"
+source = "git+https://github.com/DataDog/serverless-components?rev=65eb3d052223b54620578673633e9a390ceb2c1c#65eb3d052223b54620578673633e9a390ceb2c1c"
 dependencies = [
  "datadog-protos",
  "ddsketch-agent",
@@ -1624,7 +1624,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1883,7 +1883,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 [[package]]
 name = "libdd-capabilities"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1894,7 +1894,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities-impl"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -1938,7 +1938,7 @@ dependencies = [
 [[package]]
 name = "libdd-common"
 version = "4.2.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2011,7 +2011,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "prost 0.14.3",
 ]
@@ -2033,7 +2033,7 @@ dependencies = [
 [[package]]
 name = "libdd-shared-runtime"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "async-trait",
  "futures",
@@ -2084,7 +2084,7 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "serde",
 ]
@@ -2102,7 +2102,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf 3.0.2",
@@ -2110,14 +2110,14 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-obfuscation"
-version = "3.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+version = "4.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "anyhow",
  "fluent-uri",
  "libdd-common 4.2.0",
  "libdd-trace-protobuf 3.0.2",
- "libdd-trace-utils 6.0.1",
+ "libdd-trace-utils 8.0.0",
  "log",
  "percent-encoding",
  "serde",
@@ -2138,7 +2138,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-protobuf"
 version = "3.0.2"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -2159,8 +2159,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-stats"
-version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+version = "5.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2170,11 +2170,11 @@ dependencies = [
  "libdd-capabilities",
  "libdd-capabilities-impl",
  "libdd-common 4.2.0",
- "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03)",
+ "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c)",
  "libdd-shared-runtime",
  "libdd-trace-obfuscation",
  "libdd-trace-protobuf 3.0.2",
- "libdd-trace-utils 6.0.1",
+ "libdd-trace-utils 8.0.0",
  "rmp-serde",
  "serde",
  "tokio",
@@ -2212,8 +2212,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-utils"
-version = "6.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=48da0d82cb32b43d4cdece35b794c9bcbc275a03#48da0d82cb32b43d4cdece35b794c9bcbc275a03"
+version = "8.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2973,7 +2973,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3010,7 +3010,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -82,9 +82,9 @@ libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog", rev
 libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", default-features = false }
 libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", default-features = false }
 datadog-opentelemetry = { git = "https://github.com/DataDog/dd-trace-rs", rev = "f51cefc4ad24bec81b38fb2f36b1ed93f21ae913", default-features = false }
-dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "65eb3d052223b54620578673633e9a390ceb2c1c", default-features = false }
-datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "65eb3d052223b54620578673633e9a390ceb2c1c", default-features = false }
-datadog-agent-config = { git = "https://github.com/DataDog/serverless-components", rev = "65eb3d052223b54620578673633e9a390ceb2c1c", default-features = false }
+dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "ddb4378017a50761a89e3b9e9de3411b0d79211d", default-features = false }
+datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "ddb4378017a50761a89e3b9e9de3411b0d79211d", default-features = false }
+datadog-agent-config = { git = "https://github.com/DataDog/serverless-components", rev = "ddb4378017a50761a89e3b9e9de3411b0d79211d", default-features = false }
 libddwaf = { version = "1.28.1", git = "https://github.com/DataDog/libddwaf-rust", rev = "d1534a158d976bd4f747bf9fcc58e0712d2d17fc", default-features = false, features = ["serde"] }
 
 [dev-dependencies]

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -74,17 +74,17 @@ indexmap = {version = "2.11.0", default-features = false}
 # be found in the clippy.toml file adjacent to this Cargo.toml.
 datadog-protos = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "f863626dbfe3c59bb390985fa6530b0621c2a0a2"}
 ddsketch-agent = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "f863626dbfe3c59bb390985fa6530b0621c2a0a2"}
-libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03", default-features = false }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03", default-features = false, features = ["mini_agent"] }
-libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03" }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03", default-features = false }
-libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "48da0d82cb32b43d4cdece35b794c9bcbc275a03", default-features = false }
+libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", default-features = false }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", default-features = false, features = ["mini_agent"] }
+libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", default-features = false }
+libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", default-features = false }
 datadog-opentelemetry = { git = "https://github.com/DataDog/dd-trace-rs", rev = "f51cefc4ad24bec81b38fb2f36b1ed93f21ae913", default-features = false }
-dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "8ce37eb029410b7cf30847376772e3af6baa5f5c", default-features = false }
-datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "8ce37eb029410b7cf30847376772e3af6baa5f5c", default-features = false }
-datadog-agent-config = { git = "https://github.com/DataDog/serverless-components", rev = "8ce37eb029410b7cf30847376772e3af6baa5f5c", default-features = false }
+dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "65eb3d052223b54620578673633e9a390ceb2c1c", default-features = false }
+datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "65eb3d052223b54620578673633e9a390ceb2c1c", default-features = false }
+datadog-agent-config = { git = "https://github.com/DataDog/serverless-components", rev = "65eb3d052223b54620578673633e9a390ceb2c1c", default-features = false }
 libddwaf = { version = "1.28.1", git = "https://github.com/DataDog/libddwaf-rust", rev = "d1534a158d976bd4f747bf9fcc58e0712d2d17fc", default-features = false, features = ["serde"] }
 
 [dev-dependencies]

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -698,30 +698,6 @@ mod lambda_config_tests {
         assert!(config.ext.capture_lambda_payload);
     }
 
-    // ---- ensure DD URL env vars with trailing slash can be parsed ----
-
-    #[test]
-    fn parse_dd_dd_url_with_trailing_slash() {
-        let config = load(|jail| {
-            jail.set_env("DD_DD_URL", "https://test.agent.datadoghq.com/");
-            Ok(())
-        });
-        assert_eq!(config.dd_url, "https://test.agent.datadoghq.com");
-        dogstatsd::datadog::DdDdUrl::new(config.dd_url.clone())
-            .expect("DD_DD_URL with a trailing slash should still parse");
-    }
-
-    #[test]
-    fn parse_dd_url_with_trailing_slash() {
-        let config = load(|jail| {
-            jail.set_env("DD_URL", "https://test.agent.datadoghq.com/");
-            Ok(())
-        });
-        assert_eq!(config.url, "https://test.agent.datadoghq.com");
-        dogstatsd::datadog::DdUrl::new(config.url.clone())
-            .expect("DD_URL with a trailing slash should still parse");
-    }
-
     // ---- malformed input falls back to default (forgiving deserializers) ----
 
     #[test]

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -698,6 +698,30 @@ mod lambda_config_tests {
         assert!(config.ext.capture_lambda_payload);
     }
 
+    // ---- ensure DD URL env vars with trailing slash can be parsed ----
+
+    #[test]
+    fn parse_dd_dd_url_with_trailing_slash() {
+        let config = load(|jail| {
+            jail.set_env("DD_DD_URL", "https://test.agent.datadoghq.com/");
+            Ok(())
+        });
+        assert_eq!(config.dd_url, "https://test.agent.datadoghq.com");
+        dogstatsd::datadog::DdDdUrl::new(config.dd_url.clone())
+            .expect("DD_DD_URL with a trailing slash should still parse");
+    }
+
+    #[test]
+    fn parse_dd_url_with_trailing_slash() {
+        let config = load(|jail| {
+            jail.set_env("DD_URL", "https://test.agent.datadoghq.com/");
+            Ok(())
+        });
+        assert_eq!(config.url, "https://test.agent.datadoghq.com");
+        dogstatsd::datadog::DdUrl::new(config.url.clone())
+            .expect("DD_URL with a trailing slash should still parse");
+    }
+
     // ---- malformed input falls back to default (forgiving deserializers) ----
 
     #[test]

--- a/integration-tests/lib/util.ts
+++ b/integration-tests/lib/util.ts
@@ -20,7 +20,7 @@ export const defaultGoRuntime = lambda.Runtime.PROVIDED_AL2023;
 export const defaultNodeLayerArn = process.env.NODE_TRACER_LAYER_ARN || 'arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node24-x:132';
 export const defaultPythonLayerArn = process.env.PYTHON_TRACER_LAYER_ARN || 'arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python313-ARM:117';
 export const defaultJavaLayerArn = process.env.JAVA_TRACER_LAYER_ARN || 'arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-java:25';
-export const defaultDotnetLayerArn = process.env.DOTNET_TRACER_LAYER_ARN || 'arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-dotnet-ARM:23';
+export const defaultDotnetLayerArn = process.env.DOTNET_TRACER_LAYER_ARN || 'arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-dotnet-ARM:25';
 export const defaultRubyLayerArn = process.env.RUBY_TRACER_LAYER_ARN || 'arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Ruby3-4-ARM:28';
 
 export const defaultDatadogEnvVariables = {


### PR DESCRIPTION
## Overview

`DD_URL`, `DD_DD_URL`, and `DD_APM_DD_URL` were not trimming trailing slashes before being used to build intake URLs. This caused failures such as failing `dogstatsd`'s `DdUrl`/`DdDdUrl` prefix validation, panicking with `can't parse DD_DD_URL: UrlPrefixError(...)` in `start_metrics_flushers`.

The fix lives upstream in `datadog-agent-config`: https://github.com/DataDog/serverless-components/pull/142.

This PR bumps bottlecap's `serverless-components` pin to the merged fix commit, and bumps bottlecap's own direct `libdatadog` pins to match.

Also bumps the dd-trace-dotnet layer version for integration tests.

## Motivation

[SVLS-9373](https://datadoghq.atlassian.net/browse/SVLS-9373)

## Testing
- Added tests in serverless-components
- Manually tested on a Lambda function that the extension no longer panics after these changes

[SVLS-9373]: https://datadoghq.atlassian.net/browse/SVLS-9373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ