### PR TITLE
fix(integration-tests): retry .NET trace lookup with extra indexing wait

### DIFF
--- a/integration-tests/config.ts
+++ b/integration-tests/config.ts
@@ -12,6 +12,11 @@ export const ASYNC_DATADOG_INDEXING_WAIT_MS = 90 * 1000; // 90 seconds
 // Extended wait time for tests that need more time (e.g., OTLP tests)
 export const DATADOG_INDEXING_WAIT_5_MIN_MS = 5 * 60 * 1000; // 5 minutes
 
+// Extra wait applied only to .NET when its trace hasn't landed yet after the default wait.
+// The .NET tracer's CLR profiler bootstrap (AWS_LAMBDA_EXEC_WRAPPER + JIT) is slower and more
+// variable than Node/Python/Java, so .NET traces intermittently miss the default indexing window.
+export const DOTNET_EXTRA_INDEXING_WAIT_MS = 3 * 60 * 1000; // 3 minutes
+
 
 export function getIdentifier(): string {
   if (process.env.IDENTIFIER) {

--- a/integration-tests/tests/utils/default.ts
+++ b/integration-tests/tests/utils/default.ts
@@ -5,7 +5,7 @@ import {
   DatadogTelemetry,
   getEnhancedMetrics,
 } from './datadog';
-import { DEFAULT_DATADOG_INDEXING_WAIT_MS } from '../../config';
+import { DEFAULT_DATADOG_INDEXING_WAIT_MS, DOTNET_EXTRA_INDEXING_WAIT_MS } from '../../config';
 
 export interface FunctionConfig {
   functionName: string;
@@ -94,7 +94,16 @@ export async function invokeAndCollectTelemetry(
 
     for (const inv of results) {
       try {
-        const data = await getInvocationTracesLogsByRequestId(functionName, inv.requestId);
+        let data = await getInvocationTracesLogsByRequestId(functionName, inv.requestId);
+
+        if (runtime === 'dotnet' && (!data.traces || data.traces.length === 0)) {
+          console.log(
+            `No trace found yet for dotnet requestId ${inv.requestId}, waiting an extra ${DOTNET_EXTRA_INDEXING_WAIT_MS}ms before retrying`,
+          );
+          await sleep(DOTNET_EXTRA_INDEXING_WAIT_MS);
+          data = await getInvocationTracesLogsByRequestId(functionName, inv.requestId);
+        }
+
         data.statusCode = inv.statusCode;
         threadTelemetry.push(data);
       } catch (err) {


### PR DESCRIPTION
## Overview

`dd-gitlab/integration-suite: [lmi|on-demand|snapstart]` jobs have been intermittently failing on `.NET`-runtime trace assertions (e.g. `should send one trace to Datadog` → received 0 traces), while Node/Python/Java pass reliably in the same runs. Seen 3 times in a row on #1299, confirmed unrelated to that PR's diff.

Root cause: `invokeAndCollectTelemetry` (`integration-tests/tests/utils/default.ts`) does a single fixed sleep (`DEFAULT_DATADOG_INDEXING_WAIT_MS`, 5 minutes) after invoking all functions, then does a **single point-in-time** trace query per request ID — there's no poll/backoff for "trace not indexed yet" (`requestWithRetry` only retries on Datadog API 429s). `.NET` on Lambda bootstraps via a CLR profiler exec wrapper (`AWS_LAMBDA_EXEC_WRAPPER=/opt/datadog_wrapper` + JIT), which is slower and more variable than Node/Python/Java's instrumentation init, so `.NET` disproportionately loses the race against the fixed wait window.

This PR gives `.NET` one extra 3-minute wait + retry specifically when its trace hasn't shown up yet, without slowing down the other runtimes that share the same invocation batch/wait.

## Testing

- `npx tsc --noEmit` passes with no errors.
- Retriggering `dd-gitlab/integration-suite: [lmi|on-demand|snapstart]` on this branch to confirm the .NET trace assertions no longer flake.