### PR TITLE
[SVLS-8800] fix: hold back cold-start invocation metric until durable tag is known

### DIFF
--- a/.gitlab/datasources/test-suites.yaml
+++ b/.gitlab/datasources/test-suites.yaml
@@ -7,3 +7,4 @@ test_suites:
   - name: oom
   - name: lmi-oom
   - name: payload-size
+  - name: durable-cold-start

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ All Rust code lives under `bottlecap/`. Run these from that directory unless not
 ## Code Style
 
 - Do not be overly defensive and add unnecessary checks or tests unless you have a good reason.
+- Keep comments concise. Do not explain the history of a change or reference past code unless necessary.
 
 ## Pull Requests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@ The Datadog Lambda Extension ("Bottlecap") is an AWS Lambda Extension written in
 
 All Rust code lives under `bottlecap/`. Run these from that directory unless noted.
 
+## Code Style
+
+- Do not be overly defensive and add unnecessary checks or tests unless you have a good reason.
+
 ## Pull Requests
 
 - When creating a PR, follow the PR template at `.github/pull_request_template.md`.

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -63,7 +63,6 @@ pub const DATADOG_INVOCATION_ERROR_KEY: &str = "x-datadog-invocation-error";
 const DATADOG_SPAN_ID_KEY: &str = "x-datadog-span-id";
 const TAG_SAMPLING_PRIORITY: &str = "_sampling_priority_v1";
 
-#[allow(clippy::struct_excessive_bools)]
 pub struct Processor {
     /// Buffer containing context of the previous 5 invocations
     context_buffer: ContextBuffer,
@@ -112,27 +111,32 @@ pub struct Processor {
     /// on `platform.report`. This flag ensures whichever event arrives first wins and the other is skipped,
     /// preventing double counting.
     init_duration_metric_emitted: bool,
-    /// Timestamp of the cold-start invocation metric in On-Demand mode, held back until
-    /// `platform.initStart` sets the durable tag so it's not missed on invocation #1.
+    /// How the cold-start invocation metric in On-Demand mode has been resolved relative to
+    /// `platform.initStart`, since either the first invocation or `platform.initStart` can
+    /// arrive first (the Extensions API's `next()` call is unbuffered, while Telemetry API
+    /// delivery lags, so we've observed the invocation arriving first in production, but that's
+    /// not a hard ordering guarantee).
     ///
-    /// Only used when `platform.initStart` hasn't already been processed by the time invocation
-    /// #1 arrives; see `platform_init_start_processed`.
-    pending_first_invocation_metric_timestamp: Option<i64>,
-    /// Whether the first On-Demand invocation has already been seen.
-    ///
-    /// Used instead of `context_buffer.is_empty()` to detect the first invocation, since the
-    /// buffer is also emptied between warm invocations once `platform.report` is processed
-    /// (an unordered, separate path from `on_invoke_event`), which would otherwise make later
-    /// invocations look like cold starts too and hold back their metric indefinitely.
-    first_on_demand_invocation_seen: bool,
-    /// Whether `platform.initStart` has already been processed.
-    ///
-    /// We've observed `platform.initStart` arrive after the Invoke event in production (the
-    /// Extensions API's `next()` call is unbuffered, while Telemetry API delivery lags), which
-    /// is why invocation #1's metric is normally held back. But that's not a hard ordering
-    /// guarantee, so if `platform.initStart` has already set the durable tag by the time
-    /// invocation #1 arrives, this flag lets us skip the hold-back and emit immediately.
-    platform_init_start_processed: bool,
+    /// Also replaces `context_buffer.is_empty()` for detecting the first invocation: the buffer
+    /// is emptied between warm invocations too, once `platform.report` is processed (an
+    /// unordered, separate path from `on_invoke_event`), so it can't be used to tell "first
+    /// invocation" from "buffer momentarily empty between warm invocations."
+    first_invocation_metric: FirstInvocationMetric,
+}
+
+/// See `Processor::first_invocation_metric`.
+enum FirstInvocationMetric {
+    /// Neither the first invocation nor `platform.initStart` has been seen yet.
+    Pending,
+    /// `platform.initStart` arrived first, so the durable tag is already known; the first
+    /// invocation's metric can be emitted immediately once it arrives.
+    InitStartSeen,
+    /// The first invocation arrived before `platform.initStart`; its metric is held back until
+    /// `platform.initStart` flushes it.
+    HeldBack(i64),
+    /// The first invocation's metric has been emitted, either immediately or after being held
+    /// back. Nothing left to track.
+    Resolved,
 }
 
 impl Processor {
@@ -176,24 +180,23 @@ impl Processor {
             durable_context_tx,
             restore_time: None,
             init_duration_metric_emitted: false,
-            pending_first_invocation_metric_timestamp: None,
-            first_on_demand_invocation_seen: false,
-            platform_init_start_processed: false,
+            first_invocation_metric: FirstInvocationMetric::Pending,
         }
     }
 
     /// Given a `request_id`, creates the context and adds the enhanced metric offsets to the context buffer.
     ///
     pub fn on_invoke_event(&mut self, request_id: String) {
-        // See `pending_first_invocation_metric_timestamp` and `first_on_demand_invocation_seen`.
-        let is_on_demand_cold_start =
-            !self.aws_config.is_managed_instance_mode() && !self.first_on_demand_invocation_seen;
-        if is_on_demand_cold_start {
-            self.first_on_demand_invocation_seen = true;
-        }
+        // See `first_invocation_metric`.
+        let is_first_on_demand_invocation = !self.aws_config.is_managed_instance_mode()
+            && matches!(
+                self.first_invocation_metric,
+                FirstInvocationMetric::Pending | FirstInvocationMetric::InitStartSeen
+            );
         // Only hold back if `platform.initStart` hasn't already resolved the durable tag.
         let should_hold_back_invocation_metric =
-            is_on_demand_cold_start && !self.platform_init_start_processed;
+            matches!(self.first_invocation_metric, FirstInvocationMetric::Pending)
+                && is_first_on_demand_invocation;
 
         // In Managed Instance mode, if awaiting the first invocation after init, find and update the empty context created on init start
         if self.aws_config.is_managed_instance_mode() && self.awaiting_first_invocation {
@@ -259,11 +262,14 @@ impl Processor {
                 .add_enhanced_metric_data(&request_id, enhanced_metric_offsets);
         }
 
-        // Hold back the metric for a cold start in On-Demand mode; see `pending_first_invocation_metric_timestamp`.
+        // Hold back the metric for a cold start in On-Demand mode; see `first_invocation_metric`.
         if should_hold_back_invocation_metric {
-            self.pending_first_invocation_metric_timestamp = Some(timestamp);
+            self.first_invocation_metric = FirstInvocationMetric::HeldBack(timestamp);
         } else {
             self.enhanced_metrics.increment_invocation_metric(timestamp);
+            if is_first_on_demand_invocation {
+                self.first_invocation_metric = FirstInvocationMetric::Resolved;
+            }
         }
         self.enhanced_metrics.set_invoked_received();
 
@@ -298,8 +304,9 @@ impl Processor {
 
     /// Flushes the metric held back by `on_invoke_event`, if any.
     fn flush_pending_first_invocation_metric(&mut self) {
-        if let Some(timestamp) = self.pending_first_invocation_metric_timestamp.take() {
+        if let FirstInvocationMetric::HeldBack(timestamp) = self.first_invocation_metric {
             self.enhanced_metrics.increment_invocation_metric(timestamp);
+            self.first_invocation_metric = FirstInvocationMetric::Resolved;
         }
     }
 
@@ -385,7 +392,9 @@ impl Processor {
         {
             self.enhanced_metrics.set_durable_function_tag();
         }
-        self.platform_init_start_processed = true;
+        if matches!(self.first_invocation_metric, FirstInvocationMetric::Pending) {
+            self.first_invocation_metric = FirstInvocationMetric::InitStartSeen;
+        }
         // Flush the held-back metric now that the durable tag (if any) has been set.
         self.flush_pending_first_invocation_metric();
 
@@ -2155,9 +2164,11 @@ mod tests {
         // Simulate the On-Demand race: the Invoke event reaches the processor before
         // `platform.initStart`. The invocation metric must not be emitted yet.
         processor.on_invoke_event("req-1".to_string());
-        let held_back_timestamp = processor
-            .pending_first_invocation_metric_timestamp
-            .expect("Expected the cold start invocation metric to be held back");
+        let FirstInvocationMetric::HeldBack(held_back_timestamp) =
+            processor.first_invocation_metric
+        else {
+            panic!("Expected the cold start invocation metric to be held back")
+        };
 
         // `platform.initStart` arrives afterwards and reports a durable runtime.
         processor.on_platform_init_start(
@@ -2166,9 +2177,10 @@ mod tests {
         );
 
         assert!(
-            processor
-                .pending_first_invocation_metric_timestamp
-                .is_none(),
+            matches!(
+                processor.first_invocation_metric,
+                FirstInvocationMetric::Resolved
+            ),
             "Expected the held-back invocation metric to be flushed by on_platform_init_start"
         );
 
@@ -2218,9 +2230,10 @@ mod tests {
             .unwrap_or_default();
         processor.on_invoke_event("req-1".to_string());
         assert!(
-            processor
-                .pending_first_invocation_metric_timestamp
-                .is_none(),
+            matches!(
+                processor.first_invocation_metric,
+                FirstInvocationMetric::Resolved
+            ),
             "Expected the invocation metric to be emitted immediately, not held back"
         );
 

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -113,6 +113,9 @@ pub struct Processor {
     init_duration_metric_emitted: bool,
     /// Timestamp of the cold-start invocation metric in On-Demand mode, held back until
     /// `platform.initStart` sets the durable tag so it's not missed on invocation #1.
+    ///
+    /// This assumes `platform.initStart` always arrives after the Invoke event, which is what
+    /// we've observed in production.
     pending_first_invocation_metric_timestamp: Option<i64>,
 }
 

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -63,7 +63,6 @@ pub const DATADOG_INVOCATION_ERROR_KEY: &str = "x-datadog-invocation-error";
 const DATADOG_SPAN_ID_KEY: &str = "x-datadog-span-id";
 const TAG_SAMPLING_PRIORITY: &str = "_sampling_priority_v1";
 
-#[allow(clippy::struct_excessive_bools)]
 pub struct Processor {
     /// Buffer containing context of the previous 5 invocations
     context_buffer: ContextBuffer,
@@ -115,14 +114,6 @@ pub struct Processor {
     /// Timestamp of the cold-start invocation metric in On-Demand mode, held back until
     /// `platform.initStart` sets the durable tag so it's not missed on invocation #1.
     pending_first_invocation_metric_timestamp: Option<i64>,
-    /// Whether `platform.initStart` has already been processed for this sandbox.
-    ///
-    /// Covers the case where the Invoke event reaches the processor after `platform.initStart`
-    /// (the reverse of the usual On-Demand race). Without this check, `on_invoke_event` would see
-    /// an empty `context_buffer` (init start doesn't insert a context in On-Demand mode) and hold
-    /// the metric back again, even though the durable tag is already resolved — and nothing would
-    /// flush it until `on_shutdown_event`, since `platform.initStart` won't fire again.
-    platform_init_start_processed: bool,
 }
 
 impl Processor {
@@ -167,17 +158,15 @@ impl Processor {
             restore_time: None,
             init_duration_metric_emitted: false,
             pending_first_invocation_metric_timestamp: None,
-            platform_init_start_processed: false,
         }
     }
 
     /// Given a `request_id`, creates the context and adds the enhanced metric offsets to the context buffer.
     ///
     pub fn on_invoke_event(&mut self, request_id: String) {
-        // See `pending_first_invocation_metric_timestamp` and `platform_init_start_processed`.
-        let is_on_demand_cold_start = !self.aws_config.is_managed_instance_mode()
-            && self.context_buffer.is_empty()
-            && !self.platform_init_start_processed;
+        // See `pending_first_invocation_metric_timestamp`.
+        let is_on_demand_cold_start =
+            !self.aws_config.is_managed_instance_mode() && self.context_buffer.is_empty();
 
         // In Managed Instance mode, if awaiting the first invocation after init, find and update the empty context created on init start
         if self.aws_config.is_managed_instance_mode() && self.awaiting_first_invocation {
@@ -363,8 +352,6 @@ impl Processor {
     /// This is used to create a cold start span, since this telemetry event does not
     /// provide a `request_id`, we try to guess which invocation is the cold start.
     pub fn on_platform_init_start(&mut self, time: DateTime<Utc>, runtime_version: Option<String>) {
-        self.platform_init_start_processed = true;
-
         if runtime_version
             .as_deref()
             .is_some_and(|rv| rv.contains("DurableFunction"))
@@ -2189,68 +2176,6 @@ mod tests {
         assert!(
             entry.is_some(),
             "Expected the flushed invocation metric to carry the durable_function:true tag"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_on_invoke_event_does_not_hold_metric_if_init_start_already_processed() {
-        let mut processor = setup();
-
-        // `platform.initStart` reaches the processor first (reverse of the usual On-Demand
-        // race). It resolves the durable tag but finds no context to attach a cold start span
-        // to yet, since On-Demand mode only looks up an existing context here.
-        processor.on_platform_init_start(
-            Utc::now(),
-            Some("python:3.14.DurableFunction.v6".to_string()),
-        );
-        assert!(processor.platform_init_start_processed);
-        assert!(
-            processor
-                .pending_first_invocation_metric_timestamp
-                .is_none(),
-            "Nothing should be pending yet, since no invocation has happened"
-        );
-
-        let now: i64 = std::time::UNIX_EPOCH
-            .elapsed()
-            .expect("unable to poll clock, unrecoverable")
-            .as_secs()
-            .try_into()
-            .unwrap_or_default();
-
-        // The Invoke event arrives afterwards. Without `platform_init_start_processed`, this
-        // would see an empty context_buffer and hold the metric back again — with nothing left
-        // to flush it until shutdown, since `platform.initStart` won't fire a second time.
-        processor.on_invoke_event("req-1".to_string());
-        assert!(
-            processor
-                .pending_first_invocation_metric_timestamp
-                .is_none(),
-            "Expected the invocation metric to be emitted immediately, not held back"
-        );
-
-        let runtime = processor
-            .runtime
-            .clone()
-            .expect("runtime should have been resolved by on_invoke_event");
-        let ts = (now / 10) * 10;
-        let expected_tags = dogstatsd::metric::SortedTags::parse(&format!(
-            "cold_start:true,durable_function:true,runtime:{runtime}"
-        ))
-        .ok();
-        let entry = processor
-            .enhanced_metrics
-            .aggr_handle
-            .get_entry_by_id(
-                crate::metrics::enhanced::constants::INVOCATIONS_METRIC.into(),
-                expected_tags,
-                ts,
-            )
-            .await
-            .unwrap();
-        assert!(
-            entry.is_some(),
-            "Expected the immediately-emitted invocation metric to carry the durable_function:true tag"
         );
     }
 

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -111,6 +111,17 @@ pub struct Processor {
     /// on `platform.report`. This flag ensures whichever event arrives first wins and the other is skipped,
     /// preventing double counting.
     init_duration_metric_emitted: bool,
+    /// Timestamp of the invocation metric for the sandbox's first (cold start) invocation in
+    /// On-Demand mode, held back from `enhanced_metrics` until `platform.initStart` is processed.
+    ///
+    /// The Extensions API's `/next` poll (which drives `on_invoke_event`) has no artificial
+    /// delay, while `platform.initStart` is delivered through the buffered Telemetry API. In
+    /// On-Demand mode the Invoke event consistently reaches the processor first, so emitting the
+    /// invocation metric immediately would race `set_durable_function_tag` and miss the
+    /// `durable_function:true` tag on invocation #1. Holding the metric here until
+    /// `on_platform_init_start` (or the next invocation, or shutdown) flushes it ensures the tag
+    /// is applied before the metric is counted.
+    pending_first_invocation_metric: Option<i64>,
 }
 
 impl Processor {
@@ -154,12 +165,24 @@ impl Processor {
             durable_context_tx,
             restore_time: None,
             init_duration_metric_emitted: false,
+            pending_first_invocation_metric: None,
         }
     }
 
     /// Given a `request_id`, creates the context and adds the enhanced metric offsets to the context buffer.
     ///
     pub fn on_invoke_event(&mut self, request_id: String) {
+        // Flush any invocation metric held back from a previous cold start. This is a fallback
+        // for the case where `platform.initStart` never arrived (or arrived very late) before
+        // this next invocation; see `pending_first_invocation_metric` for why it's held back.
+        self.flush_pending_first_invocation_metric();
+
+        // In On-Demand mode, the very first invocation of a cold sandbox races
+        // `platform.initStart` (see `pending_first_invocation_metric`); hold its invocation
+        // metric back instead of emitting it inline below.
+        let is_on_demand_cold_start =
+            !self.aws_config.is_managed_instance_mode() && self.context_buffer.is_empty();
+
         // In Managed Instance mode, if awaiting the first invocation after init, find and update the empty context created on init start
         if self.aws_config.is_managed_instance_mode() && self.awaiting_first_invocation {
             if self
@@ -224,8 +247,13 @@ impl Processor {
                 .add_enhanced_metric_data(&request_id, enhanced_metric_offsets);
         }
 
-        // Increment the invocation metric
-        self.enhanced_metrics.increment_invocation_metric(timestamp);
+        // Increment the invocation metric, unless it's an On-Demand cold start, in which case
+        // it's held back until `platform.initStart` (or a fallback) flushes it.
+        if is_on_demand_cold_start {
+            self.pending_first_invocation_metric = Some(timestamp);
+        } else {
+            self.enhanced_metrics.increment_invocation_metric(timestamp);
+        }
         self.enhanced_metrics.set_invoked_received();
 
         // Both modes: check for buffered UniversalInstrumentationStart by request_id first.
@@ -254,6 +282,14 @@ impl Processor {
                 self.inferrer.infer_span(&payload_value, &self.aws_config);
                 self.process_on_universal_instrumentation_start(request_id, headers, payload_value);
             }
+        }
+    }
+
+    /// Emits the invocation metric held back by `on_invoke_event` for an On-Demand cold start,
+    /// if one is pending. See `pending_first_invocation_metric` for why it's held back.
+    fn flush_pending_first_invocation_metric(&mut self) {
+        if let Some(timestamp) = self.pending_first_invocation_metric.take() {
+            self.enhanced_metrics.increment_invocation_metric(timestamp);
         }
     }
 
@@ -339,6 +375,10 @@ impl Processor {
         {
             self.enhanced_metrics.set_durable_function_tag();
         }
+        // Flush the held-back invocation metric now that the durable_function tag (if any) has
+        // been set, so invocation #1 is counted with the correct tag.
+        self.flush_pending_first_invocation_metric();
+
         let start_time: i64 = SystemTime::from(time)
             .duration_since(UNIX_EPOCH)
             .expect("time went backwards")
@@ -990,6 +1030,10 @@ impl Processor {
     }
 
     pub fn on_shutdown_event(&mut self) {
+        // Don't drop the invocation metric if the sandbox shuts down before
+        // `platform.initStart` (or a second invocation) had a chance to flush it.
+        self.flush_pending_first_invocation_metric();
+
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .expect("unable to poll clock, unrecoverable")
@@ -2092,6 +2136,78 @@ mod tests {
         assert!(
             entry.is_none(),
             "Expected no durable_function:true tag when runtime_version is None"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_on_invoke_event_cold_start_holds_invocation_metric_until_init_start() {
+        let mut processor = setup();
+
+        // Simulate the On-Demand race: the Invoke event reaches the processor before
+        // `platform.initStart`. The invocation metric must not be emitted yet.
+        processor.on_invoke_event("req-1".to_string());
+        assert!(
+            processor.pending_first_invocation_metric.is_some(),
+            "Expected the cold start invocation metric to be held back"
+        );
+
+        let now: i64 = std::time::UNIX_EPOCH
+            .elapsed()
+            .expect("unable to poll clock, unrecoverable")
+            .as_secs()
+            .try_into()
+            .unwrap_or_default();
+
+        // `platform.initStart` arrives afterwards and reports a durable runtime.
+        processor.on_platform_init_start(
+            Utc::now(),
+            Some("python:3.14.DurableFunction.v6".to_string()),
+        );
+
+        assert!(
+            processor.pending_first_invocation_metric.is_none(),
+            "Expected the held-back invocation metric to be flushed by on_platform_init_start"
+        );
+
+        let runtime = processor
+            .runtime
+            .clone()
+            .expect("runtime should have been resolved by on_invoke_event");
+        let ts = (now / 10) * 10;
+        let expected_tags = dogstatsd::metric::SortedTags::parse(&format!(
+            "cold_start:true,durable_function:true,runtime:{runtime}"
+        ))
+        .ok();
+        let entry = processor
+            .enhanced_metrics
+            .aggr_handle
+            .get_entry_by_id(
+                crate::metrics::enhanced::constants::INVOCATIONS_METRIC.into(),
+                expected_tags,
+                ts,
+            )
+            .await
+            .unwrap();
+        assert!(
+            entry.is_some(),
+            "Expected the flushed invocation metric to carry the durable_function:true tag"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_on_invoke_event_flushes_pending_metric_if_init_start_never_arrives() {
+        let mut processor = setup();
+
+        // First invocation of a cold sandbox: metric held back.
+        processor.on_invoke_event("req-1".to_string());
+        assert!(processor.pending_first_invocation_metric.is_some());
+
+        // A second invocation arrives without platform.initStart ever showing up. The held-back
+        // metric from req-1 must still be flushed (as a fallback), not lost.
+        processor.on_invoke_event("req-2".to_string());
+        assert!(
+            processor.pending_first_invocation_metric.is_none(),
+            "Expected the pending metric to be flushed as a fallback on the next invocation"
         );
     }
 

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -111,16 +111,8 @@ pub struct Processor {
     /// on `platform.report`. This flag ensures whichever event arrives first wins and the other is skipped,
     /// preventing double counting.
     init_duration_metric_emitted: bool,
-    /// Timestamp of the invocation metric for the sandbox's first (cold start) invocation in
-    /// On-Demand mode, held back from `enhanced_metrics` until `platform.initStart` is processed.
-    ///
-    /// The Extensions API's `/next` poll (which drives `on_invoke_event`) has no artificial
-    /// delay, while `platform.initStart` is delivered through the buffered Telemetry API. In
-    /// On-Demand mode the Invoke event consistently reaches the processor first, so emitting the
-    /// invocation metric immediately would race `set_durable_function_tag` and miss the
-    /// `durable_function:true` tag on invocation #1. Holding the metric here until
-    /// `on_platform_init_start` (or the next invocation, or shutdown) flushes it ensures the tag
-    /// is applied before the metric is counted.
+    /// Timestamp of the On-Demand cold-start invocation metric, held back until
+    /// `platform.initStart` sets the durable tag so it's not missed on invocation #1.
     pending_first_invocation_metric: Option<i64>,
 }
 
@@ -172,14 +164,10 @@ impl Processor {
     /// Given a `request_id`, creates the context and adds the enhanced metric offsets to the context buffer.
     ///
     pub fn on_invoke_event(&mut self, request_id: String) {
-        // Flush any invocation metric held back from a previous cold start. This is a fallback
-        // for the case where `platform.initStart` never arrived (or arrived very late) before
-        // this next invocation; see `pending_first_invocation_metric` for why it's held back.
+        // Fallback flush in case `platform.initStart` never arrived before this invocation.
         self.flush_pending_first_invocation_metric();
 
-        // In On-Demand mode, the very first invocation of a cold sandbox races
-        // `platform.initStart` (see `pending_first_invocation_metric`); hold its invocation
-        // metric back instead of emitting it inline below.
+        // See `pending_first_invocation_metric`.
         let is_on_demand_cold_start =
             !self.aws_config.is_managed_instance_mode() && self.context_buffer.is_empty();
 
@@ -247,8 +235,7 @@ impl Processor {
                 .add_enhanced_metric_data(&request_id, enhanced_metric_offsets);
         }
 
-        // Increment the invocation metric, unless it's an On-Demand cold start, in which case
-        // it's held back until `platform.initStart` (or a fallback) flushes it.
+        // Hold back the metric for an On-Demand cold start; see `pending_first_invocation_metric`.
         if is_on_demand_cold_start {
             self.pending_first_invocation_metric = Some(timestamp);
         } else {
@@ -285,8 +272,7 @@ impl Processor {
         }
     }
 
-    /// Emits the invocation metric held back by `on_invoke_event` for an On-Demand cold start,
-    /// if one is pending. See `pending_first_invocation_metric` for why it's held back.
+    /// Flushes the metric held back by `on_invoke_event`, if any.
     fn flush_pending_first_invocation_metric(&mut self) {
         if let Some(timestamp) = self.pending_first_invocation_metric.take() {
             self.enhanced_metrics.increment_invocation_metric(timestamp);
@@ -375,8 +361,7 @@ impl Processor {
         {
             self.enhanced_metrics.set_durable_function_tag();
         }
-        // Flush the held-back invocation metric now that the durable_function tag (if any) has
-        // been set, so invocation #1 is counted with the correct tag.
+        // Flush the held-back metric now that the durable tag (if any) has been set.
         self.flush_pending_first_invocation_metric();
 
         let start_time: i64 = SystemTime::from(time)
@@ -1030,8 +1015,7 @@ impl Processor {
     }
 
     pub fn on_shutdown_event(&mut self) {
-        // Don't drop the invocation metric if the sandbox shuts down before
-        // `platform.initStart` (or a second invocation) had a chance to flush it.
+        // Fallback flush in case the sandbox shuts down before it's otherwise flushed.
         self.flush_pending_first_invocation_metric();
 
         let now = std::time::SystemTime::now()

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -111,9 +111,9 @@ pub struct Processor {
     /// on `platform.report`. This flag ensures whichever event arrives first wins and the other is skipped,
     /// preventing double counting.
     init_duration_metric_emitted: bool,
-    /// Timestamp of the On-Demand cold-start invocation metric, held back until
+    /// Timestamp of the cold-start invocation metric in On-Demand mode, held back until
     /// `platform.initStart` sets the durable tag so it's not missed on invocation #1.
-    pending_first_invocation_metric: Option<i64>,
+    pending_first_invocation_metric_timestamp: Option<i64>,
 }
 
 impl Processor {
@@ -157,17 +157,14 @@ impl Processor {
             durable_context_tx,
             restore_time: None,
             init_duration_metric_emitted: false,
-            pending_first_invocation_metric: None,
+            pending_first_invocation_metric_timestamp: None,
         }
     }
 
     /// Given a `request_id`, creates the context and adds the enhanced metric offsets to the context buffer.
     ///
     pub fn on_invoke_event(&mut self, request_id: String) {
-        // Fallback flush in case `platform.initStart` never arrived before this invocation.
-        self.flush_pending_first_invocation_metric();
-
-        // See `pending_first_invocation_metric`.
+        // See `pending_first_invocation_metric_timestamp`.
         let is_on_demand_cold_start =
             !self.aws_config.is_managed_instance_mode() && self.context_buffer.is_empty();
 
@@ -235,9 +232,9 @@ impl Processor {
                 .add_enhanced_metric_data(&request_id, enhanced_metric_offsets);
         }
 
-        // Hold back the metric for an On-Demand cold start; see `pending_first_invocation_metric`.
+        // Hold back the metric for a cold start in On-Demand mode; see `pending_first_invocation_metric_timestamp`.
         if is_on_demand_cold_start {
-            self.pending_first_invocation_metric = Some(timestamp);
+            self.pending_first_invocation_metric_timestamp = Some(timestamp);
         } else {
             self.enhanced_metrics.increment_invocation_metric(timestamp);
         }
@@ -274,7 +271,7 @@ impl Processor {
 
     /// Flushes the metric held back by `on_invoke_event`, if any.
     fn flush_pending_first_invocation_metric(&mut self) {
-        if let Some(timestamp) = self.pending_first_invocation_metric.take() {
+        if let Some(timestamp) = self.pending_first_invocation_metric_timestamp.take() {
             self.enhanced_metrics.increment_invocation_metric(timestamp);
         }
     }
@@ -2131,7 +2128,9 @@ mod tests {
         // `platform.initStart`. The invocation metric must not be emitted yet.
         processor.on_invoke_event("req-1".to_string());
         assert!(
-            processor.pending_first_invocation_metric.is_some(),
+            processor
+                .pending_first_invocation_metric_timestamp
+                .is_some(),
             "Expected the cold start invocation metric to be held back"
         );
 
@@ -2149,7 +2148,9 @@ mod tests {
         );
 
         assert!(
-            processor.pending_first_invocation_metric.is_none(),
+            processor
+                .pending_first_invocation_metric_timestamp
+                .is_none(),
             "Expected the held-back invocation metric to be flushed by on_platform_init_start"
         );
 
@@ -2175,23 +2176,6 @@ mod tests {
         assert!(
             entry.is_some(),
             "Expected the flushed invocation metric to carry the durable_function:true tag"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_on_invoke_event_flushes_pending_metric_if_init_start_never_arrives() {
-        let mut processor = setup();
-
-        // First invocation of a cold sandbox: metric held back.
-        processor.on_invoke_event("req-1".to_string());
-        assert!(processor.pending_first_invocation_metric.is_some());
-
-        // A second invocation arrives without platform.initStart ever showing up. The held-back
-        // metric from req-1 must still be flushed (as a fallback), not lost.
-        processor.on_invoke_event("req-2".to_string());
-        assert!(
-            processor.pending_first_invocation_metric.is_none(),
-            "Expected the pending metric to be flushed as a fallback on the next invocation"
         );
     }
 

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -115,8 +115,8 @@ pub struct Processor {
     /// Timestamp of the cold-start invocation metric in On-Demand mode, held back until
     /// `platform.initStart` sets the durable tag so it's not missed on invocation #1.
     ///
-    /// This assumes `platform.initStart` always arrives after the Invoke event, which is what
-    /// we've observed in production.
+    /// Only used when `platform.initStart` hasn't already been processed by the time invocation
+    /// #1 arrives; see `platform_init_start_processed`.
     pending_first_invocation_metric_timestamp: Option<i64>,
     /// Whether the first On-Demand invocation has already been seen.
     ///
@@ -125,6 +125,14 @@ pub struct Processor {
     /// (an unordered, separate path from `on_invoke_event`), which would otherwise make later
     /// invocations look like cold starts too and hold back their metric indefinitely.
     first_on_demand_invocation_seen: bool,
+    /// Whether `platform.initStart` has already been processed.
+    ///
+    /// We've observed `platform.initStart` arrive after the Invoke event in production (the
+    /// Extensions API's `next()` call is unbuffered, while Telemetry API delivery lags), which
+    /// is why invocation #1's metric is normally held back. But that's not a hard ordering
+    /// guarantee, so if `platform.initStart` has already set the durable tag by the time
+    /// invocation #1 arrives, this flag lets us skip the hold-back and emit immediately.
+    platform_init_start_processed: bool,
 }
 
 impl Processor {
@@ -170,6 +178,7 @@ impl Processor {
             init_duration_metric_emitted: false,
             pending_first_invocation_metric_timestamp: None,
             first_on_demand_invocation_seen: false,
+            platform_init_start_processed: false,
         }
     }
 
@@ -182,6 +191,9 @@ impl Processor {
         if is_on_demand_cold_start {
             self.first_on_demand_invocation_seen = true;
         }
+        // Only hold back if `platform.initStart` hasn't already resolved the durable tag.
+        let should_hold_back_invocation_metric =
+            is_on_demand_cold_start && !self.platform_init_start_processed;
 
         // In Managed Instance mode, if awaiting the first invocation after init, find and update the empty context created on init start
         if self.aws_config.is_managed_instance_mode() && self.awaiting_first_invocation {
@@ -248,7 +260,7 @@ impl Processor {
         }
 
         // Hold back the metric for a cold start in On-Demand mode; see `pending_first_invocation_metric_timestamp`.
-        if is_on_demand_cold_start {
+        if should_hold_back_invocation_metric {
             self.pending_first_invocation_metric_timestamp = Some(timestamp);
         } else {
             self.enhanced_metrics.increment_invocation_metric(timestamp);
@@ -373,6 +385,7 @@ impl Processor {
         {
             self.enhanced_metrics.set_durable_function_tag();
         }
+        self.platform_init_start_processed = true;
         // Flush the held-back metric now that the durable tag (if any) has been set.
         self.flush_pending_first_invocation_metric();
 
@@ -2181,6 +2194,58 @@ mod tests {
         assert!(
             entry.is_some(),
             "Expected the flushed invocation metric to carry the durable_function:true tag"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_on_invoke_event_does_not_hold_metric_if_init_start_already_processed() {
+        let mut processor = setup();
+
+        // Simulate the reverse order: `platform.initStart` arrives before the Invoke event
+        // and reports a durable runtime.
+        processor.on_platform_init_start(
+            Utc::now(),
+            Some("python:3.14.DurableFunction.v6".to_string()),
+        );
+
+        // The durable tag is already known, so the metric must be emitted immediately
+        // instead of being held back.
+        let now: i64 = std::time::UNIX_EPOCH
+            .elapsed()
+            .expect("unable to poll clock, unrecoverable")
+            .as_secs()
+            .try_into()
+            .unwrap_or_default();
+        processor.on_invoke_event("req-1".to_string());
+        assert!(
+            processor
+                .pending_first_invocation_metric_timestamp
+                .is_none(),
+            "Expected the invocation metric to be emitted immediately, not held back"
+        );
+
+        let runtime = processor
+            .runtime
+            .clone()
+            .expect("runtime should have been resolved by on_invoke_event");
+        let ts = (now / 10) * 10;
+        let expected_tags = dogstatsd::metric::SortedTags::parse(&format!(
+            "cold_start:true,durable_function:true,runtime:{runtime}"
+        ))
+        .ok();
+        let entry = processor
+            .enhanced_metrics
+            .aggr_handle
+            .get_entry_by_id(
+                crate::metrics::enhanced::constants::INVOCATIONS_METRIC.into(),
+                expected_tags,
+                ts,
+            )
+            .await
+            .unwrap();
+        assert!(
+            entry.is_some(),
+            "Expected the invocation metric to carry the durable_function:true tag"
         );
     }
 

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -121,11 +121,11 @@ pub struct Processor {
     /// is emptied between warm invocations too, once `platform.report` is processed (an
     /// unordered, separate path from `on_invoke_event`), so it can't be used to tell "first
     /// invocation" from "buffer momentarily empty between warm invocations."
-    first_invocation_metric: FirstInvocationMetric,
+    first_invocation_metric_status: FirstInvocationMetricStatus,
 }
 
-/// See `Processor::first_invocation_metric`.
-enum FirstInvocationMetric {
+/// See `Processor::first_invocation_metric_status`.
+enum FirstInvocationMetricStatus {
     /// Neither the first invocation nor `platform.initStart` has been seen yet.
     Pending,
     /// `platform.initStart` arrived first, so the durable tag is already known; the first
@@ -180,23 +180,24 @@ impl Processor {
             durable_context_tx,
             restore_time: None,
             init_duration_metric_emitted: false,
-            first_invocation_metric: FirstInvocationMetric::Pending,
+            first_invocation_metric_status: FirstInvocationMetricStatus::Pending,
         }
     }
 
     /// Given a `request_id`, creates the context and adds the enhanced metric offsets to the context buffer.
     ///
     pub fn on_invoke_event(&mut self, request_id: String) {
-        // See `first_invocation_metric`.
+        // See `first_invocation_metric_status`.
         let is_first_on_demand_invocation = !self.aws_config.is_managed_instance_mode()
             && matches!(
-                self.first_invocation_metric,
-                FirstInvocationMetric::Pending | FirstInvocationMetric::InitStartSeen
+                self.first_invocation_metric_status,
+                FirstInvocationMetricStatus::Pending | FirstInvocationMetricStatus::InitStartSeen
             );
         // Only hold back if `platform.initStart` hasn't already resolved the durable tag.
-        let should_hold_back_invocation_metric =
-            matches!(self.first_invocation_metric, FirstInvocationMetric::Pending)
-                && is_first_on_demand_invocation;
+        let should_hold_back_invocation_metric = matches!(
+            self.first_invocation_metric_status,
+            FirstInvocationMetricStatus::Pending
+        ) && is_first_on_demand_invocation;
 
         // In Managed Instance mode, if awaiting the first invocation after init, find and update the empty context created on init start
         if self.aws_config.is_managed_instance_mode() && self.awaiting_first_invocation {
@@ -262,13 +263,13 @@ impl Processor {
                 .add_enhanced_metric_data(&request_id, enhanced_metric_offsets);
         }
 
-        // Hold back the metric for a cold start in On-Demand mode; see `first_invocation_metric`.
+        // Hold back the metric for a cold start in On-Demand mode; see `first_invocation_metric_status`.
         if should_hold_back_invocation_metric {
-            self.first_invocation_metric = FirstInvocationMetric::HeldBack(timestamp);
+            self.first_invocation_metric_status = FirstInvocationMetricStatus::HeldBack(timestamp);
         } else {
             self.enhanced_metrics.increment_invocation_metric(timestamp);
             if is_first_on_demand_invocation {
-                self.first_invocation_metric = FirstInvocationMetric::Resolved;
+                self.first_invocation_metric_status = FirstInvocationMetricStatus::Resolved;
             }
         }
         self.enhanced_metrics.set_invoked_received();
@@ -304,9 +305,11 @@ impl Processor {
 
     /// Flushes the metric held back by `on_invoke_event`, if any.
     fn flush_pending_first_invocation_metric(&mut self) {
-        if let FirstInvocationMetric::HeldBack(timestamp) = self.first_invocation_metric {
+        if let FirstInvocationMetricStatus::HeldBack(timestamp) =
+            self.first_invocation_metric_status
+        {
             self.enhanced_metrics.increment_invocation_metric(timestamp);
-            self.first_invocation_metric = FirstInvocationMetric::Resolved;
+            self.first_invocation_metric_status = FirstInvocationMetricStatus::Resolved;
         }
     }
 
@@ -392,8 +395,11 @@ impl Processor {
         {
             self.enhanced_metrics.set_durable_function_tag();
         }
-        if matches!(self.first_invocation_metric, FirstInvocationMetric::Pending) {
-            self.first_invocation_metric = FirstInvocationMetric::InitStartSeen;
+        if matches!(
+            self.first_invocation_metric_status,
+            FirstInvocationMetricStatus::Pending
+        ) {
+            self.first_invocation_metric_status = FirstInvocationMetricStatus::InitStartSeen;
         }
         // Flush the held-back metric now that the durable tag (if any) has been set.
         self.flush_pending_first_invocation_metric();
@@ -2164,8 +2170,8 @@ mod tests {
         // Simulate the On-Demand race: the Invoke event reaches the processor before
         // `platform.initStart`. The invocation metric must not be emitted yet.
         processor.on_invoke_event("req-1".to_string());
-        let FirstInvocationMetric::HeldBack(held_back_timestamp) =
-            processor.first_invocation_metric
+        let FirstInvocationMetricStatus::HeldBack(held_back_timestamp) =
+            processor.first_invocation_metric_status
         else {
             panic!("Expected the cold start invocation metric to be held back")
         };
@@ -2178,8 +2184,8 @@ mod tests {
 
         assert!(
             matches!(
-                processor.first_invocation_metric,
-                FirstInvocationMetric::Resolved
+                processor.first_invocation_metric_status,
+                FirstInvocationMetricStatus::Resolved
             ),
             "Expected the held-back invocation metric to be flushed by on_platform_init_start"
         );
@@ -2231,8 +2237,8 @@ mod tests {
         processor.on_invoke_event("req-1".to_string());
         assert!(
             matches!(
-                processor.first_invocation_metric,
-                FirstInvocationMetric::Resolved
+                processor.first_invocation_metric_status,
+                FirstInvocationMetricStatus::Resolved
             ),
             "Expected the invocation metric to be emitted immediately, not held back"
         );

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -63,6 +63,7 @@ pub const DATADOG_INVOCATION_ERROR_KEY: &str = "x-datadog-invocation-error";
 const DATADOG_SPAN_ID_KEY: &str = "x-datadog-span-id";
 const TAG_SAMPLING_PRIORITY: &str = "_sampling_priority_v1";
 
+#[allow(clippy::struct_excessive_bools)]
 pub struct Processor {
     /// Buffer containing context of the previous 5 invocations
     context_buffer: ContextBuffer,
@@ -117,6 +118,13 @@ pub struct Processor {
     /// This assumes `platform.initStart` always arrives after the Invoke event, which is what
     /// we've observed in production.
     pending_first_invocation_metric_timestamp: Option<i64>,
+    /// Whether the first On-Demand invocation has already been seen.
+    ///
+    /// Used instead of `context_buffer.is_empty()` to detect the first invocation, since the
+    /// buffer is also emptied between warm invocations once `platform.report` is processed
+    /// (an unordered, separate path from `on_invoke_event`), which would otherwise make later
+    /// invocations look like cold starts too and hold back their metric indefinitely.
+    first_on_demand_invocation_seen: bool,
 }
 
 impl Processor {
@@ -161,15 +169,19 @@ impl Processor {
             restore_time: None,
             init_duration_metric_emitted: false,
             pending_first_invocation_metric_timestamp: None,
+            first_on_demand_invocation_seen: false,
         }
     }
 
     /// Given a `request_id`, creates the context and adds the enhanced metric offsets to the context buffer.
     ///
     pub fn on_invoke_event(&mut self, request_id: String) {
-        // See `pending_first_invocation_metric_timestamp`.
+        // See `pending_first_invocation_metric_timestamp` and `first_on_demand_invocation_seen`.
         let is_on_demand_cold_start =
-            !self.aws_config.is_managed_instance_mode() && self.context_buffer.is_empty();
+            !self.aws_config.is_managed_instance_mode() && !self.first_on_demand_invocation_seen;
+        if is_on_demand_cold_start {
+            self.first_on_demand_invocation_seen = true;
+        }
 
         // In Managed Instance mode, if awaiting the first invocation after init, find and update the empty context created on init start
         if self.aws_config.is_managed_instance_mode() && self.awaiting_first_invocation {
@@ -2130,19 +2142,9 @@ mod tests {
         // Simulate the On-Demand race: the Invoke event reaches the processor before
         // `platform.initStart`. The invocation metric must not be emitted yet.
         processor.on_invoke_event("req-1".to_string());
-        assert!(
-            processor
-                .pending_first_invocation_metric_timestamp
-                .is_some(),
-            "Expected the cold start invocation metric to be held back"
-        );
-
-        let now: i64 = std::time::UNIX_EPOCH
-            .elapsed()
-            .expect("unable to poll clock, unrecoverable")
-            .as_secs()
-            .try_into()
-            .unwrap_or_default();
+        let held_back_timestamp = processor
+            .pending_first_invocation_metric_timestamp
+            .expect("Expected the cold start invocation metric to be held back");
 
         // `platform.initStart` arrives afterwards and reports a durable runtime.
         processor.on_platform_init_start(
@@ -2161,7 +2163,7 @@ mod tests {
             .runtime
             .clone()
             .expect("runtime should have been resolved by on_invoke_event");
-        let ts = (now / 10) * 10;
+        let ts = (held_back_timestamp / 10) * 10;
         let expected_tags = dogstatsd::metric::SortedTags::parse(&format!(
             "cold_start:true,durable_function:true,runtime:{runtime}"
         ))

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -63,6 +63,7 @@ pub const DATADOG_INVOCATION_ERROR_KEY: &str = "x-datadog-invocation-error";
 const DATADOG_SPAN_ID_KEY: &str = "x-datadog-span-id";
 const TAG_SAMPLING_PRIORITY: &str = "_sampling_priority_v1";
 
+#[allow(clippy::struct_excessive_bools)]
 pub struct Processor {
     /// Buffer containing context of the previous 5 invocations
     context_buffer: ContextBuffer,
@@ -114,6 +115,14 @@ pub struct Processor {
     /// Timestamp of the cold-start invocation metric in On-Demand mode, held back until
     /// `platform.initStart` sets the durable tag so it's not missed on invocation #1.
     pending_first_invocation_metric_timestamp: Option<i64>,
+    /// Whether `platform.initStart` has already been processed for this sandbox.
+    ///
+    /// Covers the case where the Invoke event reaches the processor after `platform.initStart`
+    /// (the reverse of the usual On-Demand race). Without this check, `on_invoke_event` would see
+    /// an empty `context_buffer` (init start doesn't insert a context in On-Demand mode) and hold
+    /// the metric back again, even though the durable tag is already resolved — and nothing would
+    /// flush it until `on_shutdown_event`, since `platform.initStart` won't fire again.
+    platform_init_start_processed: bool,
 }
 
 impl Processor {
@@ -158,15 +167,17 @@ impl Processor {
             restore_time: None,
             init_duration_metric_emitted: false,
             pending_first_invocation_metric_timestamp: None,
+            platform_init_start_processed: false,
         }
     }
 
     /// Given a `request_id`, creates the context and adds the enhanced metric offsets to the context buffer.
     ///
     pub fn on_invoke_event(&mut self, request_id: String) {
-        // See `pending_first_invocation_metric_timestamp`.
-        let is_on_demand_cold_start =
-            !self.aws_config.is_managed_instance_mode() && self.context_buffer.is_empty();
+        // See `pending_first_invocation_metric_timestamp` and `platform_init_start_processed`.
+        let is_on_demand_cold_start = !self.aws_config.is_managed_instance_mode()
+            && self.context_buffer.is_empty()
+            && !self.platform_init_start_processed;
 
         // In Managed Instance mode, if awaiting the first invocation after init, find and update the empty context created on init start
         if self.aws_config.is_managed_instance_mode() && self.awaiting_first_invocation {
@@ -352,6 +363,8 @@ impl Processor {
     /// This is used to create a cold start span, since this telemetry event does not
     /// provide a `request_id`, we try to guess which invocation is the cold start.
     pub fn on_platform_init_start(&mut self, time: DateTime<Utc>, runtime_version: Option<String>) {
+        self.platform_init_start_processed = true;
+
         if runtime_version
             .as_deref()
             .is_some_and(|rv| rv.contains("DurableFunction"))
@@ -2176,6 +2189,68 @@ mod tests {
         assert!(
             entry.is_some(),
             "Expected the flushed invocation metric to carry the durable_function:true tag"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_on_invoke_event_does_not_hold_metric_if_init_start_already_processed() {
+        let mut processor = setup();
+
+        // `platform.initStart` reaches the processor first (reverse of the usual On-Demand
+        // race). It resolves the durable tag but finds no context to attach a cold start span
+        // to yet, since On-Demand mode only looks up an existing context here.
+        processor.on_platform_init_start(
+            Utc::now(),
+            Some("python:3.14.DurableFunction.v6".to_string()),
+        );
+        assert!(processor.platform_init_start_processed);
+        assert!(
+            processor
+                .pending_first_invocation_metric_timestamp
+                .is_none(),
+            "Nothing should be pending yet, since no invocation has happened"
+        );
+
+        let now: i64 = std::time::UNIX_EPOCH
+            .elapsed()
+            .expect("unable to poll clock, unrecoverable")
+            .as_secs()
+            .try_into()
+            .unwrap_or_default();
+
+        // The Invoke event arrives afterwards. Without `platform_init_start_processed`, this
+        // would see an empty context_buffer and hold the metric back again — with nothing left
+        // to flush it until shutdown, since `platform.initStart` won't fire a second time.
+        processor.on_invoke_event("req-1".to_string());
+        assert!(
+            processor
+                .pending_first_invocation_metric_timestamp
+                .is_none(),
+            "Expected the invocation metric to be emitted immediately, not held back"
+        );
+
+        let runtime = processor
+            .runtime
+            .clone()
+            .expect("runtime should have been resolved by on_invoke_event");
+        let ts = (now / 10) * 10;
+        let expected_tags = dogstatsd::metric::SortedTags::parse(&format!(
+            "cold_start:true,durable_function:true,runtime:{runtime}"
+        ))
+        .ok();
+        let entry = processor
+            .enhanced_metrics
+            .aggr_handle
+            .get_entry_by_id(
+                crate::metrics::enhanced::constants::INVOCATIONS_METRIC.into(),
+                expected_tags,
+                ts,
+            )
+            .await
+            .unwrap();
+        assert!(
+            entry.is_some(),
+            "Expected the immediately-emitted invocation metric to carry the durable_function:true tag"
         );
     }
 

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -116,11 +116,6 @@ pub struct Processor {
     /// arrive first (the Extensions API's `next()` call is unbuffered, while Telemetry API
     /// delivery lags, so we've observed the invocation arriving first in production, but that's
     /// not a hard ordering guarantee).
-    ///
-    /// Also replaces `context_buffer.is_empty()` for detecting the first invocation: the buffer
-    /// is emptied between warm invocations too, once `platform.report` is processed (an
-    /// unordered, separate path from `on_invoke_event`), so it can't be used to tell "first
-    /// invocation" from "buffer momentarily empty between warm invocations."
     first_invocation_metric_status: FirstInvocationMetricStatus,
 }
 

--- a/integration-tests/bin/app.ts
+++ b/integration-tests/bin/app.ts
@@ -10,6 +10,7 @@ import {Oom} from '../lib/stacks/oom';
 import {LmiOom} from '../lib/stacks/lmi-oom';
 import {CustomMetrics} from '../lib/stacks/custom-metrics';
 import {PayloadSize} from '../lib/stacks/payload-size';
+import {DurableColdStart} from '../lib/stacks/durable-cold-start';
 import {AuthRoleStack} from '../lib/auth-role';
 import {ACCOUNT, IDENTIFIER, REGION} from '../config';
 import {CapacityProviderStack} from "../lib/capacity-provider";
@@ -52,6 +53,9 @@ const stacks = [
         env,
     }),
     new PayloadSize(app, `${IDENTIFIER}-payload-size`, {
+        env,
+    }),
+    new DurableColdStart(app, `${IDENTIFIER}-durable-cold-start`, {
         env,
     }),
 ]

--- a/integration-tests/lib/stacks/durable-cold-start.ts
+++ b/integration-tests/lib/stacks/durable-cold-start.ts
@@ -1,0 +1,71 @@
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { Construct } from 'constructs';
+import {
+  createLogGroup,
+  defaultDatadogEnvVariables,
+  defaultDatadogSecretPolicy,
+  getExtensionLayer,
+  getDefaultNodeLayer,
+  defaultNodeRuntime,
+} from '../util';
+
+// Durable-function cold-start metric tag test.
+// The Lambda Telemetry API only reports a `platform.initStart` runtimeVersion
+// containing "DurableFunction" for functions actually configured with
+// `durableConfig`, so this stack deploys one durable and one non-durable
+// function to exercise bottlecap's `durable_function:true` tagging on the
+// cold-start `aws.lambda.enhanced.invocations` metric end-to-end.
+export class DurableColdStart extends cdk.Stack {
+  constructor(scope: Construct, id: string, props: cdk.StackProps) {
+    super(scope, id, props);
+
+    const extensionLayer = getExtensionLayer(this);
+    const nodeLayer = getDefaultNodeLayer(this);
+
+    const durableFunctionName = `${id}-durable-lambda`;
+    const durableFunction = new lambda.Function(this, durableFunctionName, {
+      runtime: defaultNodeRuntime,
+      architecture: lambda.Architecture.ARM_64,
+      handler: '/opt/nodejs/node_modules/datadog-lambda-js/handler.handler',
+      code: lambda.Code.fromAsset('./lambda/default-node'),
+      functionName: durableFunctionName,
+      timeout: cdk.Duration.seconds(30),
+      memorySize: 256,
+      durableConfig: {
+        executionTimeout: cdk.Duration.minutes(5),
+      },
+      environment: {
+        ...defaultDatadogEnvVariables,
+        DD_SERVICE: durableFunctionName,
+        DD_TRACE_ENABLED: 'true',
+        DD_LAMBDA_HANDLER: 'index.handler',
+      },
+      logGroup: createLogGroup(this, durableFunctionName),
+    });
+    durableFunction.addToRolePolicy(defaultDatadogSecretPolicy);
+    durableFunction.addLayers(extensionLayer);
+    durableFunction.addLayers(nodeLayer);
+
+    const nonDurableFunctionName = `${id}-non-durable-lambda`;
+    const nonDurableFunction = new lambda.Function(this, nonDurableFunctionName, {
+      runtime: defaultNodeRuntime,
+      architecture: lambda.Architecture.ARM_64,
+      handler: '/opt/nodejs/node_modules/datadog-lambda-js/handler.handler',
+      code: lambda.Code.fromAsset('./lambda/default-node'),
+      functionName: nonDurableFunctionName,
+      timeout: cdk.Duration.seconds(30),
+      memorySize: 256,
+      environment: {
+        ...defaultDatadogEnvVariables,
+        DD_SERVICE: nonDurableFunctionName,
+        DD_TRACE_ENABLED: 'true',
+        DD_LAMBDA_HANDLER: 'index.handler',
+      },
+      logGroup: createLogGroup(this, nonDurableFunctionName),
+    });
+    nonDurableFunction.addToRolePolicy(defaultDatadogSecretPolicy);
+    nonDurableFunction.addLayers(extensionLayer);
+    nonDurableFunction.addLayers(nodeLayer);
+  }
+}

--- a/integration-tests/lib/stacks/durable-cold-start.ts
+++ b/integration-tests/lib/stacks/durable-cold-start.ts
@@ -10,12 +10,7 @@ import {
   defaultNodeRuntime,
 } from '../util';
 
-// Durable-function cold-start metric tag test.
-// The Lambda Telemetry API only reports a `platform.initStart` runtimeVersion
-// containing "DurableFunction" for functions actually configured with
-// `durableConfig`, so this stack deploys one durable and one non-durable
-// function to exercise bottlecap's `durable_function:true` tagging on the
-// cold-start `aws.lambda.enhanced.invocations` metric end-to-end.
+// Deploys a durable and a non-durable function to test the cold-start durable_function tag.
 export class DurableColdStart extends cdk.Stack {
   constructor(scope: Construct, id: string, props: cdk.StackProps) {
     super(scope, id, props);

--- a/integration-tests/tests/durable-cold-start.test.ts
+++ b/integration-tests/tests/durable-cold-start.test.ts
@@ -57,7 +57,7 @@ describe('Durable Function Cold-Start Metric Tag Integration Tests', () => {
       windowStart,
       windowEnd,
     );
-    expect(totalCount).toBeGreaterThanOrEqual(2);
+    expect(totalCount).toBe(2);
     expect(taggedCount).toBe(totalCount);
   });
 
@@ -75,7 +75,7 @@ describe('Durable Function Cold-Start Metric Tag Integration Tests', () => {
       windowStart,
       windowEnd,
     );
-    expect(totalCount).toBeGreaterThanOrEqual(2);
+    expect(totalCount).toBe(2);
     expect(taggedCount).toBe(0);
   });
 });

--- a/integration-tests/tests/durable-cold-start.test.ts
+++ b/integration-tests/tests/durable-cold-start.test.ts
@@ -1,8 +1,4 @@
-// Verifies bottlecap holds the cold-start `aws.lambda.enhanced.invocations`
-// metric until the Telemetry API's `platform.initStart` event reports the
-// runtime, so the metric carries `durable_function:true` for a real
-// durable-configured Lambda function (#1301). A plain (non-durable) function
-// is invoked alongside as a guard against the tag being set unconditionally.
+// Verifies the cold-start invocations metric has durable_function:true only for a durable function.
 import { hasMetricWithTag } from './utils/datadog';
 import { forceColdStart, invokeLambda } from './utils/lambda';
 import { IDENTIFIER, DEFAULT_DATADOG_INDEXING_WAIT_MS } from '../config';
@@ -23,15 +19,10 @@ describe('Durable Function Cold-Start Metric Tag Integration Tests', () => {
 
     await Promise.all(functionNames.map((fn) => forceColdStart(fn)));
 
-    // Back up the query window by 60s so the metric bucket (which Datadog
-    // aligns to the rollup interval boundary, often before the invocation)
-    // falls inside the range we pass to /api/v1/query.
+    // Back up 60s so the metric's rollup bucket falls inside the query range.
     invocationStartTime = Date.now() - 60_000;
 
-    // Durable functions reject unqualified-ARN invokes ("You cannot invoke a
-    // durable function using an unqualified ARN"); `:$LATEST` satisfies that
-    // without publishing a version. Metric queries below use the base
-    // (unqualified) function name, which is unaffected by this qualifier.
+    // Durable functions reject unqualified-ARN invokes; `:$LATEST` avoids publishing a version.
     await Promise.all([
       invokeLambda(`${durableFunctionName}:$LATEST`),
       invokeLambda(nonDurableFunctionName),

--- a/integration-tests/tests/durable-cold-start.test.ts
+++ b/integration-tests/tests/durable-cold-start.test.ts
@@ -1,0 +1,70 @@
+// Verifies bottlecap holds the cold-start `aws.lambda.enhanced.invocations`
+// metric until the Telemetry API's `platform.initStart` event reports the
+// runtime, so the metric carries `durable_function:true` for a real
+// durable-configured Lambda function (#1301). A plain (non-durable) function
+// is invoked alongside as a guard against the tag being set unconditionally.
+import { hasMetricWithTag } from './utils/datadog';
+import { forceColdStart, invokeLambda } from './utils/lambda';
+import { IDENTIFIER, DEFAULT_DATADOG_INDEXING_WAIT_MS } from '../config';
+
+const stackName = `${IDENTIFIER}-durable-cold-start`;
+
+const INVOCATIONS_METRIC = 'aws.lambda.enhanced.invocations';
+
+describe('Durable Function Cold-Start Metric Tag Integration Tests', () => {
+  let invocationStartTime: number;
+  let metricsEndTime: number;
+
+  const durableFunctionName = `${stackName}-durable-lambda`;
+  const nonDurableFunctionName = `${stackName}-non-durable-lambda`;
+
+  beforeAll(async () => {
+    const functionNames = [durableFunctionName, nonDurableFunctionName];
+
+    await Promise.all(functionNames.map((fn) => forceColdStart(fn)));
+
+    // Back up the query window by 60s so the metric bucket (which Datadog
+    // aligns to the rollup interval boundary, often before the invocation)
+    // falls inside the range we pass to /api/v1/query.
+    invocationStartTime = Date.now() - 60_000;
+
+    // Durable functions reject unqualified-ARN invokes ("You cannot invoke a
+    // durable function using an unqualified ARN"); `:$LATEST` satisfies that
+    // without publishing a version. Metric queries below use the base
+    // (unqualified) function name, which is unaffected by this qualifier.
+    await Promise.all([
+      invokeLambda(`${durableFunctionName}:$LATEST`),
+      invokeLambda(nonDurableFunctionName),
+    ]);
+
+    await new Promise((resolve) =>
+      setTimeout(resolve, DEFAULT_DATADOG_INDEXING_WAIT_MS),
+    );
+
+    metricsEndTime = Date.now();
+
+    console.log('Lambdas invoked and indexing wait complete');
+  }, 1800000);
+
+  it('durable function cold-start invocation metric should have durable_function:true', async () => {
+    const hasTag = await hasMetricWithTag(
+      INVOCATIONS_METRIC,
+      durableFunctionName,
+      'durable_function:true',
+      invocationStartTime,
+      metricsEndTime,
+    );
+    expect(hasTag).toBe(true);
+  });
+
+  it('non-durable function cold-start invocation metric should NOT have durable_function:true', async () => {
+    const hasTag = await hasMetricWithTag(
+      INVOCATIONS_METRIC,
+      nonDurableFunctionName,
+      'durable_function:true',
+      invocationStartTime,
+      metricsEndTime,
+    );
+    expect(hasTag).toBe(false);
+  });
+});

--- a/integration-tests/tests/durable-cold-start.test.ts
+++ b/integration-tests/tests/durable-cold-start.test.ts
@@ -1,6 +1,6 @@
-// Verifies the invocations metric has durable_function:true only for a durable function, on
-// both the cold-start invocation and a subsequent warm invocation.
-import { hasMetricWithTag } from './utils/datadog';
+// Verifies the invocations metric has durable_function:true only for a durable function, and
+// that the tag persists across a second (warm) invocation instead of only being set on cold start.
+import { getMetricCount, getMetricCountWithTag } from './utils/datadog';
 import { forceColdStart, invokeLambda } from './utils/lambda';
 import { IDENTIFIER, DEFAULT_DATADOG_INDEXING_WAIT_MS } from '../config';
 
@@ -9,10 +9,8 @@ const stackName = `${IDENTIFIER}-durable-cold-start`;
 const INVOCATIONS_METRIC = 'aws.lambda.enhanced.invocations';
 
 describe('Durable Function Cold-Start Metric Tag Integration Tests', () => {
-  let coldStartWindowStart: number;
-  let coldStartWindowEnd: number;
-  let warmInvokeWindowStart: number;
-  let warmInvokeWindowEnd: number;
+  let windowStart: number;
+  let windowEnd: number;
 
   const durableFunctionName = `${stackName}-durable-lambda`;
   const nonDurableFunctionName = `${stackName}-non-durable-lambda`;
@@ -24,70 +22,60 @@ describe('Durable Function Cold-Start Metric Tag Integration Tests', () => {
       invokeLambda(nonDurableFunctionName),
     ]);
 
-  const waitForIndexing = () =>
-    new Promise((resolve) =>
-      setTimeout(resolve, DEFAULT_DATADOG_INDEXING_WAIT_MS),
-    );
-
   beforeAll(async () => {
     const functionNames = [durableFunctionName, nonDurableFunctionName];
     await Promise.all(functionNames.map((fn) => forceColdStart(fn)));
 
     // Back up 60s so the metric's rollup bucket falls inside the query range.
-    coldStartWindowStart = Date.now() - 60_000;
-    await invokeBoth(); // invocation #1 (cold start)
-    await waitForIndexing();
-    coldStartWindowEnd = Date.now();
+    windowStart = Date.now() - 60_000;
 
-    warmInvokeWindowStart = Date.now() - 60_000;
-    await invokeBoth(); // invocation #2 (warm)
-    await waitForIndexing();
-    warmInvokeWindowEnd = Date.now();
+    // Invoke twice back-to-back (cold start, then warm) and wait for indexing once, rather than
+    // waiting after each invocation. Whether the tag was set on both invocations (rather than
+    // only the first) is checked below by comparing tagged vs. total invocation counts.
+    await invokeBoth();
+    await invokeBoth();
 
-    console.log('Lambdas invoked twice and indexing waits complete');
-  }, 3600000);
+    await new Promise((resolve) =>
+      setTimeout(resolve, DEFAULT_DATADOG_INDEXING_WAIT_MS),
+    );
+    windowEnd = Date.now();
 
-  it('durable function cold-start invocation metric should have durable_function:true', async () => {
-    const hasTag = await hasMetricWithTag(
+    console.log('Lambdas invoked twice and indexing wait complete');
+  }, 1800000);
+
+  it('durable function invocation metric should have durable_function:true on every invocation', async () => {
+    const totalCount = await getMetricCount(
+      INVOCATIONS_METRIC,
+      durableFunctionName,
+      windowStart,
+      windowEnd,
+    );
+    const taggedCount = await getMetricCountWithTag(
       INVOCATIONS_METRIC,
       durableFunctionName,
       'durable_function:true',
-      coldStartWindowStart,
-      coldStartWindowEnd,
+      windowStart,
+      windowEnd,
     );
-    expect(hasTag).toBe(true);
+    expect(totalCount).toBeGreaterThanOrEqual(2);
+    expect(taggedCount).toBe(totalCount);
   });
 
-  it('non-durable function cold-start invocation metric should NOT have durable_function:true', async () => {
-    const hasTag = await hasMetricWithTag(
+  it('non-durable function invocation metric should NOT have durable_function:true on any invocation', async () => {
+    const totalCount = await getMetricCount(
+      INVOCATIONS_METRIC,
+      nonDurableFunctionName,
+      windowStart,
+      windowEnd,
+    );
+    const taggedCount = await getMetricCountWithTag(
       INVOCATIONS_METRIC,
       nonDurableFunctionName,
       'durable_function:true',
-      coldStartWindowStart,
-      coldStartWindowEnd,
+      windowStart,
+      windowEnd,
     );
-    expect(hasTag).toBe(false);
-  });
-
-  it('durable function warm invocation metric should still have durable_function:true', async () => {
-    const hasTag = await hasMetricWithTag(
-      INVOCATIONS_METRIC,
-      durableFunctionName,
-      'durable_function:true',
-      warmInvokeWindowStart,
-      warmInvokeWindowEnd,
-    );
-    expect(hasTag).toBe(true);
-  });
-
-  it('non-durable function warm invocation metric should still NOT have durable_function:true', async () => {
-    const hasTag = await hasMetricWithTag(
-      INVOCATIONS_METRIC,
-      nonDurableFunctionName,
-      'durable_function:true',
-      warmInvokeWindowStart,
-      warmInvokeWindowEnd,
-    );
-    expect(hasTag).toBe(false);
+    expect(totalCount).toBeGreaterThanOrEqual(2);
+    expect(taggedCount).toBe(0);
   });
 });

--- a/integration-tests/tests/durable-cold-start.test.ts
+++ b/integration-tests/tests/durable-cold-start.test.ts
@@ -1,4 +1,5 @@
-// Verifies the cold-start invocations metric has durable_function:true only for a durable function.
+// Verifies the invocations metric has durable_function:true only for a durable function, on
+// both the cold-start invocation and a subsequent warm invocation.
 import { hasMetricWithTag } from './utils/datadog';
 import { forceColdStart, invokeLambda } from './utils/lambda';
 import { IDENTIFIER, DEFAULT_DATADOG_INDEXING_WAIT_MS } from '../config';
@@ -8,42 +9,51 @@ const stackName = `${IDENTIFIER}-durable-cold-start`;
 const INVOCATIONS_METRIC = 'aws.lambda.enhanced.invocations';
 
 describe('Durable Function Cold-Start Metric Tag Integration Tests', () => {
-  let invocationStartTime: number;
-  let metricsEndTime: number;
+  let coldStartWindowStart: number;
+  let coldStartWindowEnd: number;
+  let warmInvokeWindowStart: number;
+  let warmInvokeWindowEnd: number;
 
   const durableFunctionName = `${stackName}-durable-lambda`;
   const nonDurableFunctionName = `${stackName}-non-durable-lambda`;
 
-  beforeAll(async () => {
-    const functionNames = [durableFunctionName, nonDurableFunctionName];
-
-    await Promise.all(functionNames.map((fn) => forceColdStart(fn)));
-
-    // Back up 60s so the metric's rollup bucket falls inside the query range.
-    invocationStartTime = Date.now() - 60_000;
-
-    // Durable functions reject unqualified-ARN invokes; `:$LATEST` avoids publishing a version.
-    await Promise.all([
+  // Durable functions reject unqualified-ARN invokes; `:$LATEST` avoids publishing a version.
+  const invokeBoth = () =>
+    Promise.all([
       invokeLambda(`${durableFunctionName}:$LATEST`),
       invokeLambda(nonDurableFunctionName),
     ]);
 
-    await new Promise((resolve) =>
+  const waitForIndexing = () =>
+    new Promise((resolve) =>
       setTimeout(resolve, DEFAULT_DATADOG_INDEXING_WAIT_MS),
     );
 
-    metricsEndTime = Date.now();
+  beforeAll(async () => {
+    const functionNames = [durableFunctionName, nonDurableFunctionName];
+    await Promise.all(functionNames.map((fn) => forceColdStart(fn)));
 
-    console.log('Lambdas invoked and indexing wait complete');
-  }, 1800000);
+    // Back up 60s so the metric's rollup bucket falls inside the query range.
+    coldStartWindowStart = Date.now() - 60_000;
+    await invokeBoth(); // invocation #1 (cold start)
+    await waitForIndexing();
+    coldStartWindowEnd = Date.now();
+
+    warmInvokeWindowStart = Date.now() - 60_000;
+    await invokeBoth(); // invocation #2 (warm)
+    await waitForIndexing();
+    warmInvokeWindowEnd = Date.now();
+
+    console.log('Lambdas invoked twice and indexing waits complete');
+  }, 3600000);
 
   it('durable function cold-start invocation metric should have durable_function:true', async () => {
     const hasTag = await hasMetricWithTag(
       INVOCATIONS_METRIC,
       durableFunctionName,
       'durable_function:true',
-      invocationStartTime,
-      metricsEndTime,
+      coldStartWindowStart,
+      coldStartWindowEnd,
     );
     expect(hasTag).toBe(true);
   });
@@ -53,8 +63,30 @@ describe('Durable Function Cold-Start Metric Tag Integration Tests', () => {
       INVOCATIONS_METRIC,
       nonDurableFunctionName,
       'durable_function:true',
-      invocationStartTime,
-      metricsEndTime,
+      coldStartWindowStart,
+      coldStartWindowEnd,
+    );
+    expect(hasTag).toBe(false);
+  });
+
+  it('durable function warm invocation metric should still have durable_function:true', async () => {
+    const hasTag = await hasMetricWithTag(
+      INVOCATIONS_METRIC,
+      durableFunctionName,
+      'durable_function:true',
+      warmInvokeWindowStart,
+      warmInvokeWindowEnd,
+    );
+    expect(hasTag).toBe(true);
+  });
+
+  it('non-durable function warm invocation metric should still NOT have durable_function:true', async () => {
+    const hasTag = await hasMetricWithTag(
+      INVOCATIONS_METRIC,
+      nonDurableFunctionName,
+      'durable_function:true',
+      warmInvokeWindowStart,
+      warmInvokeWindowEnd,
     );
     expect(hasTag).toBe(false);
   });

--- a/integration-tests/tests/utils/datadog.ts
+++ b/integration-tests/tests/utils/datadog.ts
@@ -370,6 +370,40 @@ export async function getMetricCount(
   return pointlist.reduce((acc, [, value]) => acc + (value || 0), 0);
 }
 
+/**
+ * Same as `getMetricCount`, but filtered by an additional tag (e.g. "durable_function:true").
+ * Used to check whether every emission of a metric over a window carried a given tag, by
+ * comparing against the untagged `getMetricCount` total for the same window.
+ */
+export async function getMetricCountWithTag(
+  metricName: string,
+  functionName: string,
+  tagFilter: string,
+  fromTime: number,
+  toTime: number,
+): Promise<number> {
+  const baseFunctionName = getServiceName(functionName).toLowerCase();
+  const query = `sum:${metricName}{functionname:${baseFunctionName},${tagFilter}}.as_count()`;
+
+  console.log(`Querying metric count with tag filter: ${query}`);
+
+  const response = await requestWithRetry(() => datadogClient.get('/api/v1/query', {
+    params: {
+      query,
+      from: Math.floor(fromTime / 1000),
+      to: Math.floor(toTime / 1000),
+    },
+  }), query);
+
+  const series = response.data.series || [];
+  if (series.length === 0) {
+    return 0;
+  }
+
+  const pointlist: [number, number][] = series[0].pointlist || [];
+  return pointlist.reduce((acc, [, value]) => acc + (value || 0), 0);
+}
+
 async function getMetrics(
   metricName: string,
   functionName: string,


### PR DESCRIPTION
## Problem
For durable functions, the `aws.lambda.enhanced.invocations` metric for the first invocation (after cold start) doesn't have the tag `durable_function:true` as expected.

This is because the metric is emitted in `on_invoke_event()`, which, from what we observed, always happens before the extension receives `platform.initStart` event, which carries the information of whether the function is a durable function. As a result, the `durable_function:true` tag is only set on the metric for subsequent invocations but not for the first one.

## Fix
Delay the flushing of `aws.lambda.enhanced.invocations` metric for the first invocation, if the extension doesn't yet know whether the function is a durable function.

Use an enum to track the state of the first invocation:
```
enum FirstInvocationMetricStatus {
    Pending,
    InitStartSeen,
    HeldBack(i64),
    Resolved,
}
```

This covers both cases about the order of `on_invoke_event()` event and `platform.initStart` event:
1. Common case: `on_invoke_event()` comes first, then `platform.initStart`:
    - To start with: `Pending`
    - `on_invoke_event()` comes: hold metric and move to `HeldBack`
    - `platform.initStart` comes: flush metric and move to `Resolved`
2. Rare case: `platform.initStart` comes before `on_invoke_event()`
    - To start with: `Pending`
    - `platform.initStart` comes: `InitStartSeen`
    - `on_invoke_event()` comes: flush metric immediately and move to `HeldBack`

Also, flush the metric at shutdown, in case `platform.initStart` is never received for whatever reason.

## Testing
### Manual testing
For a durable function, all data points for the `aws.lambda.enhanced.invocations` metric have the tag `durable_function:true` set.
<img width="1463" height="605" alt="image" src="https://github.com/user-attachments/assets/c0804406-aa91-4cd0-81de-56ba9eac215d" />

### Automated testing
Passed the added integration test.