### PR TITLE
[SLES-2907] chore(deps): bump dd-trace-rs to datadog-opentelemetry-v0.5.0

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -793,7 +793,7 @@ dependencies = [
 [[package]]
 name = "datadog-agent-config"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=215d89872f0fc9888849d169e6db15b23dc46dad#215d89872f0fc9888849d169e6db15b23dc46dad"
+source = "git+https://github.com/DataDog/serverless-components?rev=56779dec9f4c9bcc48abcc9833ca4fa4b9d8d627#56779dec9f4c9bcc48abcc9833ca4fa4b9d8d627"
 dependencies = [
  "datadog-opentelemetry",
  "dogstatsd",
@@ -811,7 +811,7 @@ dependencies = [
 [[package]]
 name = "datadog-fips"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=215d89872f0fc9888849d169e6db15b23dc46dad#215d89872f0fc9888849d169e6db15b23dc46dad"
+source = "git+https://github.com/DataDog/serverless-components?rev=56779dec9f4c9bcc48abcc9833ca4fa4b9d8d627#56779dec9f4c9bcc48abcc9833ca4fa4b9d8d627"
 dependencies = [
  "reqwest",
  "rustls",
@@ -960,7 +960,7 @@ dependencies = [
 [[package]]
 name = "dogstatsd"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=215d89872f0fc9888849d169e6db15b23dc46dad#215d89872f0fc9888849d169e6db15b23dc46dad"
+source = "git+https://github.com/DataDog/serverless-components?rev=56779dec9f4c9bcc48abcc9833ca4fa4b9d8d627#56779dec9f4c9bcc48abcc9833ca4fa4b9d8d627"
 dependencies = [
  "datadog-protos",
  "ddsketch-agent",
@@ -1641,7 +1641,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -3159,7 +3159,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3196,7 +3196,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]

--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -37,9 +37,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
@@ -507,10 +507,10 @@ dependencies = [
  "indexmap",
  "itertools 0.14.0",
  "lazy_static",
- "libdd-capabilities",
+ "libdd-capabilities 2.0.0",
  "libdd-common 4.2.0",
  "libdd-trace-normalization 2.0.0",
- "libdd-trace-obfuscation",
+ "libdd-trace-obfuscation 4.0.0",
  "libdd-trace-protobuf 3.0.2",
  "libdd-trace-stats 5.0.0",
  "libdd-trace-utils 8.0.0",
@@ -781,14 +781,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "datadog-agent-config"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=ddb4378017a50761a89e3b9e9de3411b0d79211d#ddb4378017a50761a89e3b9e9de3411b0d79211d"
+source = "git+https://github.com/DataDog/serverless-components?rev=215d89872f0fc9888849d169e6db15b23dc46dad#215d89872f0fc9888849d169e6db15b23dc46dad"
 dependencies = [
  "datadog-opentelemetry",
  "dogstatsd",
  "figment",
- "libdd-trace-obfuscation",
+ "libdd-trace-obfuscation 4.0.0",
  "libdd-trace-utils 8.0.0",
  "log",
  "serde",
@@ -801,7 +811,7 @@ dependencies = [
 [[package]]
 name = "datadog-fips"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=ddb4378017a50761a89e3b9e9de3411b0d79211d#ddb4378017a50761a89e3b9e9de3411b0d79211d"
+source = "git+https://github.com/DataDog/serverless-components?rev=215d89872f0fc9888849d169e6db15b23dc46dad#215d89872f0fc9888849d169e6db15b23dc46dad"
 dependencies = [
  "reqwest",
  "rustls",
@@ -811,26 +821,33 @@ dependencies = [
 
 [[package]]
 name = "datadog-opentelemetry"
-version = "0.3.0"
-source = "git+https://github.com/DataDog/dd-trace-rs?rev=f51cefc4ad24bec81b38fb2f36b1ed93f21ae913#f51cefc4ad24bec81b38fb2f36b1ed93f21ae913"
+version = "0.5.0"
+source = "git+https://github.com/DataDog/dd-trace-rs?rev=50bfea8755b75e448a80ac04d53fa7edd414eefe#50bfea8755b75e448a80ac04d53fa7edd414eefe"
 dependencies = [
  "anyhow",
  "arc-swap",
  "base64 0.21.7",
+ "ctor",
  "foldhash 0.1.5",
  "hashbrown 0.15.5",
  "http-body-util",
  "hyper 1.8.1",
  "hyper-util",
- "libdd-common 2.0.1",
+ "libc",
+ "libdd-capabilities-impl 3.0.0",
+ "libdd-common 5.1.0",
  "libdd-data-pipeline",
+ "libdd-library-config",
+ "libdd-sampling",
+ "libdd-shared-runtime 2.0.0",
  "libdd-telemetry",
- "libdd-tinybytes 1.1.0",
- "libdd-trace-utils 2.0.2",
+ "libdd-tinybytes 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-trace-utils 9.0.0",
  "lru",
- "opentelemetry",
- "opentelemetry-semantic-conventions 0.31.0",
- "opentelemetry_sdk",
+ "opentelemetry 0.32.0",
+ "opentelemetry-semantic-conventions 0.32.1",
+ "opentelemetry_sdk 0.32.1",
+ "percent-encoding",
  "rand 0.8.6",
  "rustc_version_runtime",
  "serde",
@@ -943,7 +960,7 @@ dependencies = [
 [[package]]
 name = "dogstatsd"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=ddb4378017a50761a89e3b9e9de3411b0d79211d#ddb4378017a50761a89e3b9e9de3411b0d79211d"
+source = "git+https://github.com/DataDog/serverless-components?rev=215d89872f0fc9888849d169e6db15b23dc46dad#215d89872f0fc9888849d169e6db15b23dc46dad"
 dependencies = [
  "datadog-protos",
  "ddsketch-agent",
@@ -1624,7 +1641,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1892,6 +1909,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libdd-capabilities"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a946c29c5fe7cc2adec7a66a35f7cfc138ba75c988d09a7a99c12de7d3b9a7"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "http 1.4.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "libdd-capabilities-impl"
 version = "2.0.0"
 source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
@@ -1899,40 +1928,23 @@ dependencies = [
  "bytes",
  "http 1.4.0",
  "http-body-util",
- "libdd-capabilities",
+ "libdd-capabilities 2.0.0",
  "libdd-common 4.2.0",
  "tokio",
 ]
 
 [[package]]
-name = "libdd-common"
-version = "2.0.1"
+name = "libdd-capabilities-impl"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e5593b91f61eee38cddc9fdcbc99c9fad697b5d925e226bd500d86b4295380b"
+checksum = "1e948ad5c65d8598fd3889762ea4767b9a521ebfb2f7b72f6e52162aa4d7f353"
 dependencies = [
- "anyhow",
  "bytes",
- "cc",
- "const_format",
- "futures",
- "futures-core",
- "futures-util",
- "hex",
  "http 1.4.0",
- "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-util",
- "libc",
- "nix 0.29.0",
- "pin-project",
- "regex",
- "serde",
- "static_assertions",
- "thiserror 1.0.69",
+ "libdd-capabilities 2.1.0",
+ "libdd-common 5.1.0",
  "tokio",
- "tower-service",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1970,25 +1982,63 @@ dependencies = [
 ]
 
 [[package]]
-name = "libdd-data-pipeline"
-version = "2.0.1"
+name = "libdd-common"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2704d0fcc9281cc844a63d15188aecc84d45725b77e489cc04ad30959b2000"
+checksum = "59de587e652491cb19fd8b7d8e59901794ca56e3961c8c1b97707479d7fe7ec8"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "cc",
+ "const_format",
+ "futures",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "libc",
+ "nix 0.29.0",
+ "pin-project",
+ "regex",
+ "serde",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "tokio",
+ "tower-service",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "libdd-data-pipeline"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433f9bfe60850c0638a273dfb2bd873f5abc12c9983ce74ebffe055a7a3c21c9"
 dependencies = [
  "anyhow",
  "arc-swap",
+ "async-trait",
  "bytes",
  "either",
+ "getrandom 0.2.17",
  "http 1.4.0",
  "http-body-util",
- "libdd-common 2.0.1",
- "libdd-ddsketch 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-capabilities 2.1.0",
+ "libdd-capabilities-impl 3.0.0",
+ "libdd-common 5.1.0",
+ "libdd-ddsketch 1.1.0",
  "libdd-dogstatsd-client",
+ "libdd-shared-runtime 2.0.0",
  "libdd-telemetry",
- "libdd-tinybytes 1.1.0",
- "libdd-trace-protobuf 2.0.0",
- "libdd-trace-stats 1.0.3",
- "libdd-trace-utils 2.0.2",
+ "libdd-tinybytes 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-trace-normalization 3.0.0",
+ "libdd-trace-obfuscation 5.0.0",
+ "libdd-trace-protobuf 4.0.0",
+ "libdd-trace-stats 6.0.0",
+ "libdd-trace-utils 9.0.0",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -2002,32 +2052,62 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b31b2435e2e8eaba0e35a96df3e1407b68f8ef76055383ceb2ba5a09e5a1bb5"
-dependencies = [
- "prost 0.14.3",
-]
-
-[[package]]
-name = "libdd-ddsketch"
-version = "1.0.1"
 source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "prost 0.14.3",
 ]
 
 [[package]]
-name = "libdd-dogstatsd-client"
-version = "1.0.1"
+name = "libdd-ddsketch"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a457381568835e7c3646f3f2d44ff4f3ebcda44d87332e2fdaeb20e6a8365dcd"
+checksum = "a3f04a8501bc5f52f005f637beb18c900c69ad6deedb5f3104cd0a8c36bc8046"
+dependencies = [
+ "prost 0.14.3",
+]
+
+[[package]]
+name = "libdd-dogstatsd-client"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c29c7bd569824c4d8ffe7171bb77e6b69c2161517ed75436ff458b40d41a663d"
 dependencies = [
  "anyhow",
  "cadence",
  "http 1.4.0",
- "libdd-common 2.0.1",
+ "libdd-common 5.1.0",
  "serde",
  "tracing",
+]
+
+[[package]]
+name = "libdd-library-config"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab46ec324c1b916ca06c4a369da171a08eb9f112620e6f6f004860e589892715"
+dependencies = [
+ "anyhow",
+ "libc",
+ "libdd-trace-protobuf 4.0.0",
+ "memfd",
+ "prost 0.14.3",
+ "rand 0.8.6",
+ "rmp",
+ "rmp-serde",
+ "serde",
+ "serde_yaml",
+]
+
+[[package]]
+name = "libdd-sampling"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6c34dd818feb6a2c1de996017d2f8e3190615c62fa5513f3b9559bce727dfb"
+dependencies = [
+ "libdd-common 5.1.0",
+ "lru",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2038,8 +2118,8 @@ dependencies = [
  "async-trait",
  "futures",
  "futures-util",
- "libdd-capabilities",
- "libdd-capabilities-impl",
+ "libdd-capabilities 2.0.0",
+ "libdd-capabilities-impl 2.0.0",
  "libdd-common 4.2.0",
  "tokio",
  "tokio-util",
@@ -2048,20 +2128,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "libdd-telemetry"
-version = "3.0.0"
+name = "libdd-shared-runtime"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7bb67a865fe7e8a16aacc7bc43a805fb3b907c713e0b212e7a7abe6e0735cb"
+checksum = "bab1ad16a0bfcf1ce826e2314c162b04daf4324c71da5a28583ea40e76be8772"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-util",
+ "libdd-capabilities 2.1.0",
+ "libdd-capabilities-impl 3.0.0",
+ "libdd-common 5.1.0",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "libdd-telemetry"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c791d810acbe99b0c7fc4285824f4e27a4b2b9137d4aec8a5df220ca55b34942"
 dependencies = [
  "anyhow",
+ "async-trait",
  "base64 0.22.1",
+ "bytes",
  "futures",
  "hashbrown 0.15.5",
  "http 1.4.0",
  "http-body-util",
  "libc",
- "libdd-common 2.0.1",
- "libdd-ddsketch 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-common 5.1.0",
+ "libdd-ddsketch 1.1.0",
+ "libdd-shared-runtime 2.0.0",
  "serde",
  "serde_json",
  "sys-info",
@@ -2074,9 +2175,9 @@ dependencies = [
 
 [[package]]
 name = "libdd-tinybytes"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47838e12ae2665250b4cdba4e3119230b79e3c522bb9f48dd0c87346f5a8f44"
+checksum = "97db80e3f3f9d19643ac444d6267951a5dab622ad9828c51149d49150625cfe8"
 dependencies = [
  "serde",
 ]
@@ -2091,21 +2192,21 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-normalization"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a737b43f01d6a0cbd1399c5b89863a5d2663fe7b19bf1d3ea28048abab396353"
-dependencies = [
- "anyhow",
- "libdd-trace-protobuf 2.0.0",
-]
-
-[[package]]
-name = "libdd-trace-normalization"
 version = "2.0.0"
 source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf 3.0.2",
+]
+
+[[package]]
+name = "libdd-trace-normalization"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4184666070c137e058b2c16acd147c3f045b51de3efe81e0bec62044f29fc6c6"
+dependencies = [
+ "anyhow",
+ "libdd-trace-protobuf 4.0.0",
 ]
 
 [[package]]
@@ -2125,14 +2226,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "libdd-trace-protobuf"
-version = "2.0.0"
+name = "libdd-trace-obfuscation"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0a54921e03174f3ff7ad8506ff9e13637e546ef0b1f369ae463eacebda8e88"
+checksum = "d313153f515b9dd31a483bc7e4d432ecb76e53dd33f67f4eeaa415319372b68d"
 dependencies = [
- "prost 0.14.3",
+ "anyhow",
+ "fluent-uri",
+ "libdd-common 5.1.0",
+ "libdd-trace-protobuf 4.0.0",
+ "libdd-trace-utils 9.0.0",
+ "log",
+ "percent-encoding",
  "serde",
- "serde_bytes",
+ "serde_json",
 ]
 
 [[package]]
@@ -2146,15 +2253,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "libdd-trace-stats"
-version = "1.0.3"
+name = "libdd-trace-protobuf"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea447dc8a5d84c6b5eb6ea877c4fea4149fd29f6b45fcfc5cfd7edf82a18e056"
+checksum = "210492f004b4c343cca736aab2a8c93109034e0c00111bc7376661370439a11c"
 dependencies = [
- "hashbrown 0.15.5",
- "libdd-ddsketch 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libdd-trace-protobuf 2.0.0",
- "libdd-trace-utils 2.0.2",
+ "prost 0.14.3",
+ "serde",
+ "serde_bytes",
 ]
 
 [[package]]
@@ -2167,12 +2273,12 @@ dependencies = [
  "async-trait",
  "hashbrown 0.15.5",
  "http 1.4.0",
- "libdd-capabilities",
- "libdd-capabilities-impl",
+ "libdd-capabilities 2.0.0",
+ "libdd-capabilities-impl 2.0.0",
  "libdd-common 4.2.0",
- "libdd-ddsketch 1.0.1 (git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c)",
- "libdd-shared-runtime",
- "libdd-trace-obfuscation",
+ "libdd-ddsketch 1.0.1",
+ "libdd-shared-runtime 1.0.0",
+ "libdd-trace-obfuscation 4.0.0",
  "libdd-trace-protobuf 3.0.2",
  "libdd-trace-utils 8.0.0",
  "rmp-serde",
@@ -2183,30 +2289,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "libdd-trace-utils"
-version = "2.0.2"
+name = "libdd-trace-stats"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a59e9a0a41bb17d06fb85a70db3be04e53ddfb8f61a593939bb9677729214db"
+checksum = "f23a575e3ecccfbbbd1612ddb1cb8b08e0c12ae0a62052ef995f05d93976a55b"
 dependencies = [
  "anyhow",
- "bytes",
- "futures",
+ "arc-swap",
+ "async-trait",
+ "hashbrown 0.15.5",
  "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "indexmap",
- "libdd-common 2.0.1",
- "libdd-tinybytes 1.1.0",
- "libdd-trace-normalization 1.0.2",
- "libdd-trace-protobuf 2.0.0",
- "prost 0.14.3",
- "rand 0.8.6",
- "rmp",
+ "libdd-capabilities 2.1.0",
+ "libdd-capabilities-impl 3.0.0",
+ "libdd-common 5.1.0",
+ "libdd-ddsketch 1.1.0",
+ "libdd-dogstatsd-client",
+ "libdd-shared-runtime 2.0.0",
+ "libdd-telemetry",
+ "libdd-trace-obfuscation 5.0.0",
+ "libdd-trace-protobuf 4.0.0",
+ "libdd-trace-utils 9.0.0",
  "rmp-serde",
- "rmpv",
  "serde",
- "serde_json",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -2225,10 +2331,10 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "indexmap",
- "libdd-capabilities",
- "libdd-capabilities-impl",
+ "libdd-capabilities 2.0.0",
+ "libdd-capabilities-impl 2.0.0",
  "libdd-common 4.2.0",
- "libdd-tinybytes 1.1.1",
+ "libdd-tinybytes 1.1.1 (git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c)",
  "libdd-trace-normalization 2.0.0",
  "libdd-trace-protobuf 3.0.2",
  "prost 0.14.3",
@@ -2241,6 +2347,42 @@ dependencies = [
  "tokio",
  "tracing",
  "zstd",
+]
+
+[[package]]
+name = "libdd-trace-utils"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2529075e0b7494767011c027750951f302b3ee8a5f5d15ab7a6e95e88a755182"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "getrandom 0.2.17",
+ "hex",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "indexmap",
+ "libdd-capabilities 2.1.0",
+ "libdd-capabilities-impl 3.0.0",
+ "libdd-common 5.1.0",
+ "libdd-tinybytes 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-trace-normalization 3.0.0",
+ "libdd-trace-protobuf 4.0.0",
+ "prost 0.14.3",
+ "rand 0.8.6",
+ "rmp",
+ "rmp-serde",
+ "rmpv",
+ "rustc-hash",
+ "serde",
+ "serde-transcode",
+ "serde_json",
+ "thin-vec",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2360,6 +2502,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "mime"
@@ -2515,6 +2666,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "opentelemetry-proto"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2522,8 +2686,8 @@ checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "base64 0.22.1",
  "const-hex",
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.31.0",
+ "opentelemetry_sdk 0.31.0",
  "prost 0.14.3",
  "serde",
  "serde_json",
@@ -2539,9 +2703,9 @@ checksum = "83d059a296a47436748557a353c5e6c5705b9470ef6c95cfc52c21a8814ddac2"
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
+checksum = "c913ac17a6c451661ee255f4625d143e51647ae78ebd969b75e41c4442f4fe47"
 
 [[package]]
 name = "opentelemetry_sdk"
@@ -2552,8 +2716,24 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "percent-encoding",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry 0.32.0",
+ "percent-encoding",
+ "portable-atomic",
  "rand 0.9.4",
  "thiserror 2.0.18",
 ]
@@ -2736,6 +2916,12 @@ dependencies = [
  "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -2973,7 +3159,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3010,7 +3196,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3496,6 +3682,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-transcode"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "590c0e25c2a5bb6e85bf5c1bce768ceb86b316e7a01bdf07d2cb4ec2271990e2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde-value"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3846,6 +4041,12 @@ dependencies = [
  "rustversion",
  "winapi",
 ]
+
+[[package]]
+name = "thin-vec"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
 
 [[package]]
 name = "thiserror"

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -81,12 +81,10 @@ libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "a820
 libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
 libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", default-features = false }
 libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", default-features = false }
-# TODO(SLES-2907): serverless-components rev is DataDog/serverless-components#144 (unmerged).
-# Re-pin to the merged commit once that PR lands.
 datadog-opentelemetry = { git = "https://github.com/DataDog/dd-trace-rs", rev = "50bfea8755b75e448a80ac04d53fa7edd414eefe", default-features = false, features = ["_unstable_propagation"] }
-dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "215d89872f0fc9888849d169e6db15b23dc46dad", default-features = false }
-datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "215d89872f0fc9888849d169e6db15b23dc46dad", default-features = false }
-datadog-agent-config = { git = "https://github.com/DataDog/serverless-components", rev = "215d89872f0fc9888849d169e6db15b23dc46dad", default-features = false }
+dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "56779dec9f4c9bcc48abcc9833ca4fa4b9d8d627", default-features = false }
+datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "56779dec9f4c9bcc48abcc9833ca4fa4b9d8d627", default-features = false }
+datadog-agent-config = { git = "https://github.com/DataDog/serverless-components", rev = "56779dec9f4c9bcc48abcc9833ca4fa4b9d8d627", default-features = false }
 libddwaf = { version = "1.28.1", git = "https://github.com/DataDog/libddwaf-rust", rev = "d1534a158d976bd4f747bf9fcc58e0712d2d17fc", default-features = false, features = ["serde"] }
 
 [dev-dependencies]

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -81,10 +81,12 @@ libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "a820
 libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
 libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", default-features = false }
 libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", default-features = false }
-datadog-opentelemetry = { git = "https://github.com/DataDog/dd-trace-rs", rev = "f51cefc4ad24bec81b38fb2f36b1ed93f21ae913", default-features = false }
-dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "ddb4378017a50761a89e3b9e9de3411b0d79211d", default-features = false }
-datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "ddb4378017a50761a89e3b9e9de3411b0d79211d", default-features = false }
-datadog-agent-config = { git = "https://github.com/DataDog/serverless-components", rev = "ddb4378017a50761a89e3b9e9de3411b0d79211d", default-features = false }
+# TODO(SLES-2907): serverless-components rev is DataDog/serverless-components#144 (unmerged).
+# Re-pin to the merged commit once that PR lands.
+datadog-opentelemetry = { git = "https://github.com/DataDog/dd-trace-rs", rev = "50bfea8755b75e448a80ac04d53fa7edd414eefe", default-features = false, features = ["_unstable_propagation"] }
+dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "215d89872f0fc9888849d169e6db15b23dc46dad", default-features = false }
+datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "215d89872f0fc9888849d169e6db15b23dc46dad", default-features = false }
+datadog-agent-config = { git = "https://github.com/DataDog/serverless-components", rev = "215d89872f0fc9888849d169e6db15b23dc46dad", default-features = false }
 libddwaf = { version = "1.28.1", git = "https://github.com/DataDog/libddwaf-rust", rev = "d1534a158d976bd4f747bf9fcc58e0712d2d17fc", default-features = false, features = ["serde"] }
 
 [dev-dependencies]

--- a/bottlecap/LICENSE-3rdparty.csv
+++ b/bottlecap/LICENSE-3rdparty.csv
@@ -40,6 +40,7 @@ crc32fast,https://github.com/srijs/rust-crc32fast,MIT OR Apache-2.0,"Sam Rijs <s
 crossbeam-channel,https://github.com/crossbeam-rs/crossbeam,MIT OR Apache-2.0,The crossbeam-channel Authors
 crossbeam-utils,https://github.com/crossbeam-rs/crossbeam,MIT OR Apache-2.0,The crossbeam-utils Authors
 crypto-common,https://github.com/RustCrypto/traits,MIT OR Apache-2.0,RustCrypto Developers
+ctor,https://github.com/mmastrac/rust-ctor,Apache-2.0 OR MIT,Matt Mastracci <matthew@mastracci.com>
 datadog-agent-config,https://github.com/DataDog/serverless-components,Apache-2.0,The datadog-agent-config Authors
 datadog-fips,https://github.com/DataDog/serverless-components,Apache-2.0,The datadog-fips Authors
 datadog-opentelemetry,https://github.com/DataDog/dd-trace-rs/tree/main/datadog-opentelemetry,Apache-2.0,Datadog Inc. <info@datadoghq.com>
@@ -118,6 +119,8 @@ libdd-common,https://github.com/DataDog/libdatadog/tree/main/datadog-common,Apac
 libdd-data-pipeline,https://github.com/DataDog/libdatadog/tree/main/libdd-data-pipeline,Apache-2.0,The libdd-data-pipeline Authors
 libdd-ddsketch,https://github.com/DataDog/libdatadog/tree/main/libdd-ddsketch,Apache-2.0,The libdd-ddsketch Authors
 libdd-dogstatsd-client,https://github.com/DataDog/libdatadog/tree/main/libdd-dogstatsd-client,Apache-2.0,The libdd-dogstatsd-client Authors
+libdd-library-config,https://github.com/DataDog/libdatadog/tree/main/libdd-library-config,Apache-2.0,The libdd-library-config Authors
+libdd-sampling,https://github.com/DataDog/libdatadog/tree/main/libdd-sampling,Apache-2.0,Datadog Inc. <info@datadoghq.com>
 libdd-shared-runtime,https://github.com/DataDog/libdatadog/tree/main/libdd-shared-runtime,Apache-2.0,The libdd-shared-runtime Authors
 libdd-telemetry,https://github.com/DataDog/libdatadog/tree/main/libdd-telemetry,Apache-2.0,The libdd-telemetry Authors
 libdd-tinybytes,https://github.com/DataDog/libdatadog/tree/main/libdd-tinybytes,Apache-2.0,The libdd-tinybytes Authors
@@ -137,6 +140,7 @@ lru-slab,https://github.com/Ralith/lru-slab,MIT OR Apache-2.0 OR Zlib,Benjamin S
 matchers,https://github.com/hawkw/matchers,MIT,Eliza Weisman <eliza@buoyant.io>
 matchit,https://github.com/ibraheemdev/matchit,MIT AND BSD-3-Clause,Ibraheem Ahmed <ibraheem@ibraheem.ca>
 memchr,https://github.com/BurntSushi/memchr,Unlicense OR MIT,"Andrew Gallant <jamslam@gmail.com>, bluss"
+memfd,https://github.com/lucab/memfd-rs,MIT OR Apache-2.0,"Luca Bruno <lucab@lucabruno.net>, Simonas Kazlauskas <memfd@kazlauskas.me>"
 mime,https://github.com/hyperium/mime,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
 mime_guess,https://github.com/abonander/mime_guess,MIT,Austin Bonander <austin.bonander@gmail.com>
 miniz_oxide,https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide,MIT OR Zlib OR Apache-2.0,"Frommi <daniil.liferenko@gmail.com>, oyvindln <oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com"
@@ -162,6 +166,7 @@ pin-project,https://github.com/taiki-e/pin-project,Apache-2.0 OR MIT,The pin-pro
 pin-project-internal,https://github.com/taiki-e/pin-project,Apache-2.0 OR MIT,The pin-project-internal Authors
 pin-project-lite,https://github.com/taiki-e/pin-project-lite,Apache-2.0 OR MIT,The pin-project-lite Authors
 pin-utils,https://github.com/rust-lang-nursery/pin-utils,MIT OR Apache-2.0,Josef Brandl <mail@josefbrandl.de>
+portable-atomic,https://github.com/taiki-e/portable-atomic,Apache-2.0 OR MIT,The portable-atomic Authors
 potential_utf,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
 powerfmt,https://github.com/jhpratt/powerfmt,MIT OR Apache-2.0,Jacob Pratt <jacob@jhpratt.dev>
 ppv-lite86,https://github.com/cryptocorrosion/cryptocorrosion,MIT OR Apache-2.0,The CryptoCorrosion Contributors
@@ -215,6 +220,7 @@ security-framework-sys,https://github.com/kornelski/rust-security-framework,MIT 
 semver,https://github.com/dtolnay/semver,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 serde,https://github.com/serde-rs/serde,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
 serde-aux,https://github.com/iddm/serde-aux,MIT,Victor Polevoy <maintainer@vpolevoy.com>
+serde-transcode,https://github.com/sfackler/serde-transcode,MIT OR Apache-2.0,Steven Fackler <sfackler@palantir.com>
 serde-value,https://github.com/arcnmx/serde-value,MIT,arcnmx
 serde_bytes,https://github.com/serde-rs/bytes,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 serde_core,https://github.com/serde-rs/serde,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
@@ -241,6 +247,7 @@ sync_wrapper,https://github.com/Actyx/sync_wrapper,Apache-2.0,Actyx AG <develope
 synstructure,https://github.com/mystor/synstructure,MIT,Nika Layzell <nika@thelayzells.com>
 sys-info,https://github.com/FillZpp/sys-info-rs,MIT,Siyu Wang <FillZpp.pub@gmail.com>
 tempfile,https://github.com/Stebalien/tempfile,MIT OR Apache-2.0,"Steven Allen <steven@stebalien.com>, The Rust Project Developers, Ashley Mannix <ashleymannix@live.com.au>, Jason White <me@jasonwhite.io>"
+thin-vec,https://github.com/mozilla/thin-vec,MIT OR Apache-2.0,Aria Beingessner <a.beingessner@gmail.com>
 thiserror,https://github.com/dtolnay/thiserror,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 thiserror-impl,https://github.com/dtolnay/thiserror,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 thread_local,https://github.com/Amanieu/thread_local-rs,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>

--- a/bottlecap/src/config/propagation_wrapper.rs
+++ b/bottlecap/src/config/propagation_wrapper.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use datadog_opentelemetry::configuration::TracePropagationBehaviorExtract;
 use datadog_opentelemetry::propagation::PropagationConfig;
 
 use crate::config::{Config, TracePropagationStyle};
@@ -43,6 +44,12 @@ impl PropagationConfig for PropConfig {
 
     fn trace_propagation_extract_first(&self) -> bool {
         self.0.trace_propagation_extract_first
+    }
+
+    fn trace_propagation_behavior_extract(&self) -> TracePropagationBehaviorExtract {
+        // Bottlecap does not expose DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT; upstream's
+        // default (`Continue`) matches bottlecap's existing extraction behavior.
+        TracePropagationBehaviorExtract::default()
     }
 
     fn datadog_tags_max_length(&self) -> usize {

--- a/bottlecap/src/lifecycle/invocation/triggers/step_function_event.rs
+++ b/bottlecap/src/lifecycle/invocation/triggers/step_function_event.rs
@@ -253,7 +253,11 @@ impl ServiceNameResolver for StepFunctionEvent {
 mod tests {
     use super::*;
     use crate::lifecycle::invocation::triggers::test_utils::read_json_file;
-    use datadog_opentelemetry::constants::SAMPLING_DECISION_MAKER_TAG_KEY as DATADOG_SAMPLING_DECISION_KEY;
+
+    // dd-trace-rs no longer re-exports this constant publicly (moved to
+    // libdd-sampling internally); the tag key itself is part of the stable
+    // wire protocol, so it's hardcoded here instead of adding a new dependency.
+    const DATADOG_SAMPLING_DECISION_KEY: &str = "_dd.p.dm";
 
     #[test]
     fn test_new_event() {

--- a/bottlecap/src/traces/propagation/mod.rs
+++ b/bottlecap/src/traces/propagation/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use crate::config;
 use datadog_opentelemetry::propagation::{
     self as dd_propagation, ExtractResult, carrier::Extractor, context::SpanContext,
+    datadog::DATADOG_HIGHER_ORDER_TRACE_ID_BITS_KEY,
 };
 
 pub mod carrier;
@@ -50,11 +51,30 @@ impl DatadogCompositePropagator {
             }
         };
 
+        Self::preserve_high_order_trace_id_bits(&mut context);
+
         if self.config.trace_propagation_http_baggage_enabled {
             Self::attach_baggage(&mut context, carrier);
         }
 
         Some(context)
+    }
+
+    // The b3/b3multi extractors return a full 128-bit `trace_id` without setting
+    // `_dd.p.tid` (unlike the Datadog format extractor), but downstream code casts
+    // `trace_id` to u64 and relies on that tag to avoid losing the high bits.
+    fn preserve_high_order_trace_id_bits(context: &mut SpanContext) {
+        let high = (context.trace_id >> 64) as u64;
+        if high != 0
+            && !context
+                .tags
+                .contains_key(DATADOG_HIGHER_ORDER_TRACE_ID_BITS_KEY)
+        {
+            context.tags.insert(
+                DATADOG_HIGHER_ORDER_TRACE_ID_BITS_KEY.to_string(),
+                format!("{high:016x}"),
+            );
+        }
     }
 
     fn attach_baggage(context: &mut SpanContext, carrier: &dyn Extractor) {
@@ -118,6 +138,85 @@ mod tests {
         ]);
         let context = propagator.extract(&carrier);
         assert!(context.is_some());
+    }
+
+    #[test]
+    fn test_extract_b3_single_preserves_high_order_trace_id_bits() {
+        let config = config::Config {
+            trace_propagation_style_extract: vec![TracePropagationStyle::B3SingleHeader],
+            ..Default::default()
+        };
+
+        let propagator = DatadogCompositePropagator::new(Arc::new(config));
+
+        let carrier = HashMap::from([(
+            "b3".to_string(),
+            "80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1-1".to_string(),
+        )]);
+
+        let context = propagator.extract(&carrier).expect("context");
+        assert_eq!(
+            context.trace_id,
+            0x80f1_98ee_5634_3ba8_64fe_8b2a_57d3_eff7u128
+        );
+        assert_eq!(
+            context
+                .tags
+                .get("_dd.p.tid")
+                .expect("Missing _dd.p.tid tag"),
+            "80f198ee56343ba8"
+        );
+    }
+
+    #[test]
+    fn test_extract_b3_multi_preserves_high_order_trace_id_bits() {
+        let config = config::Config {
+            trace_propagation_style_extract: vec![TracePropagationStyle::B3Multi],
+            ..Default::default()
+        };
+
+        let propagator = DatadogCompositePropagator::new(Arc::new(config));
+
+        let carrier = HashMap::from([
+            (
+                "x-b3-traceid".to_string(),
+                "80f198ee56343ba864fe8b2a57d3eff7".to_string(),
+            ),
+            ("x-b3-spanid".to_string(), "e457b5a2e4d86bd1".to_string()),
+            ("x-b3-sampled".to_string(), "1".to_string()),
+        ]);
+
+        let context = propagator.extract(&carrier).expect("context");
+        assert_eq!(
+            context.trace_id,
+            0x80f1_98ee_5634_3ba8_64fe_8b2a_57d3_eff7u128
+        );
+        assert_eq!(
+            context
+                .tags
+                .get("_dd.p.tid")
+                .expect("Missing _dd.p.tid tag"),
+            "80f198ee56343ba8"
+        );
+    }
+
+    #[test]
+    fn test_extract_b3_single_64_bit_trace_id_does_not_set_tid_tag() {
+        let config = config::Config {
+            trace_propagation_style_extract: vec![TracePropagationStyle::B3SingleHeader],
+            ..Default::default()
+        };
+
+        let propagator = DatadogCompositePropagator::new(Arc::new(config));
+
+        let carrier = HashMap::from([(
+            "b3".to_string(),
+            "80f198ee56343ba8-e457b5a2e4d86bd1-1".to_string(),
+        )]);
+
+        let context = propagator.extract(&carrier).expect("context");
+        assert_eq!(context.trace_id, 0x80f1_98ee_5634_3ba8u128);
+        assert!(!context.tags.contains_key("_dd.p.tid"));
     }
 
     #[test]

--- a/bottlecap/src/traces/propagation/mod.rs
+++ b/bottlecap/src/traces/propagation/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use crate::config;
 use datadog_opentelemetry::propagation::{
-    self as dd_propagation, carrier::Extractor, context::SpanContext,
+    self as dd_propagation, ExtractResult, carrier::Extractor, context::SpanContext,
 };
 
 pub mod carrier;
@@ -43,7 +43,12 @@ impl DatadogCompositePropagator {
     }
 
     pub fn extract(&self, carrier: &dyn Extractor) -> Option<SpanContext> {
-        let mut context = self.inner.extract(carrier)?;
+        let mut context = match self.inner.extract(carrier) {
+            ExtractResult::Continue(context) => context,
+            ExtractResult::Passthrough | ExtractResult::Ignore | ExtractResult::Restart(_) => {
+                return None;
+            }
+        };
 
         if self.config.trace_propagation_http_baggage_enabled {
             Self::attach_baggage(&mut context, carrier);


### PR DESCRIPTION
## Overview

Bumps `datadog-opentelemetry` (dd-trace-rs) from `f51cefc4` (pre-`v0.3.0`) to
`50bfea87` (`datadog-opentelemetry-v0.5.0`), adding
`features = ["_unstable_propagation"]` since the `propagation` module
bottlecap uses is now feature-gated upstream (was unconditionally public at
our old pin).

Also bumps `dogstatsd`/`datadog-fips`/`datadog-agent-config` to the
`serverless-components` commit that carries the matching dd-trace-rs pin —
[DataDog/serverless-components#144](https://github.com/DataDog/serverless-components/pull/144),

v0.5.0 adds native B3 (single- and multi-header) trace propagation support,
fixing `Failed to parse trace propagation style: Unknown trace propagation
style: 'b3multi', ignoring` errors reported by a customer — see
[SLES-2907](https://datadoghq.atlassian.net/browse/SLES-2907).

### Code changes required by the bump

- `src/config/propagation_wrapper.rs` — implements the new required
  `PropagationConfig::trace_propagation_behavior_extract` method (hardcoded
  to `Continue`, matching prior implicit behavior; bottlecap doesn't expose
  `DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT`).
- `src/traces/propagation/mod.rs` — `DatadogCompositePropagator::extract` now
  returns `ExtractResult` instead of `Option<SpanContext>`; adapted the
  wrapper to match on it (`Continue(ctx) -> Some(ctx)`, everything else ->
  `None`, preserving current behavior).
- `src/lifecycle/invocation/triggers/step_function_event.rs` — the
  `datadog_opentelemetry::constants` re-export was removed upstream (moved
  to `libdd-sampling` internally); hardcoded the one test-only usage of
  `SAMPLING_DECISION_MAKER_TAG_KEY` (`"_dd.p.dm"`) rather than adding a new
  dependency for it.

## Testing

- `cargo check --all-targets` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test --lib` — 530/530 pass
- `dd-rust-license-tool check` — passes
- `cargo tree --duplicates` — no new `datadog-opentelemetry`/`tonic`/`prost`
  duplication; `opentelemetry`/`opentelemetry_sdk`/`-semantic-conventions`
  do pick up a new duplicate version (0.31 direct vs. 0.32 via dd-trace-rs) —
  non-blocking, binary-size-only, bottlecap never shares those types across
  the `datadog_opentelemetry` boundary
- `--features fips` hits a pre-existing local-macOS-only dylib loading issue
  in `libddwaf-sys`, confirmed identical on unmodified `main` (needs
  Linux/CI, unrelated to this change)

[SLES-2907]: https://datadoghq.atlassian.net/browse/SLES-2907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Dependency graph:
<img width="3136" height="1336" alt="mermaid-diagram-1783968869812" src="https://github.com/user-attachments/assets/da389d30-1808-4bbf-aa1a-392d229ec828" />
