### PR TITLE
[SLES-2907] chore(deps): align libdatadog rev, dedupe libdd-* crates

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -507,13 +507,13 @@ dependencies = [
  "indexmap",
  "itertools 0.14.0",
  "lazy_static",
- "libdd-capabilities 2.0.0",
- "libdd-common 4.2.0",
- "libdd-trace-normalization 2.0.0",
- "libdd-trace-obfuscation 4.0.0",
- "libdd-trace-protobuf 3.0.2",
- "libdd-trace-stats 5.0.0",
- "libdd-trace-utils 8.0.0",
+ "libdd-capabilities",
+ "libdd-common",
+ "libdd-trace-normalization",
+ "libdd-trace-obfuscation",
+ "libdd-trace-protobuf",
+ "libdd-trace-stats",
+ "libdd-trace-utils",
  "libddwaf",
  "log",
  "mime",
@@ -614,6 +614,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -662,6 +668,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -793,13 +809,13 @@ dependencies = [
 [[package]]
 name = "datadog-agent-config"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=56779dec9f4c9bcc48abcc9833ca4fa4b9d8d627#56779dec9f4c9bcc48abcc9833ca4fa4b9d8d627"
+source = "git+https://github.com/DataDog/serverless-components?rev=f9ce8b718160b7bd5a329371a54a1d88bf3ac69a#f9ce8b718160b7bd5a329371a54a1d88bf3ac69a"
 dependencies = [
  "datadog-opentelemetry",
  "dogstatsd",
  "figment",
- "libdd-trace-obfuscation 4.0.0",
- "libdd-trace-utils 8.0.0",
+ "libdd-trace-obfuscation",
+ "libdd-trace-utils",
  "log",
  "serde",
  "serde-aux",
@@ -811,7 +827,7 @@ dependencies = [
 [[package]]
 name = "datadog-fips"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=56779dec9f4c9bcc48abcc9833ca4fa4b9d8d627#56779dec9f4c9bcc48abcc9833ca4fa4b9d8d627"
+source = "git+https://github.com/DataDog/serverless-components?rev=f9ce8b718160b7bd5a329371a54a1d88bf3ac69a#f9ce8b718160b7bd5a329371a54a1d88bf3ac69a"
 dependencies = [
  "reqwest",
  "rustls",
@@ -834,15 +850,15 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "libc",
- "libdd-capabilities-impl 3.0.0",
- "libdd-common 5.1.0",
+ "libdd-capabilities-impl",
+ "libdd-common",
  "libdd-data-pipeline",
  "libdd-library-config",
  "libdd-sampling",
- "libdd-shared-runtime 2.0.0",
+ "libdd-shared-runtime",
  "libdd-telemetry",
- "libdd-tinybytes 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libdd-trace-utils 9.0.0",
+ "libdd-tinybytes",
+ "libdd-trace-utils",
  "lru",
  "opentelemetry 0.32.0",
  "opentelemetry-semantic-conventions 0.32.1",
@@ -960,7 +976,7 @@ dependencies = [
 [[package]]
 name = "dogstatsd"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=56779dec9f4c9bcc48abcc9833ca4fa4b9d8d627#56779dec9f4c9bcc48abcc9833ca4fa4b9d8d627"
+source = "git+https://github.com/DataDog/serverless-components?rev=f9ce8b718160b7bd5a329371a54a1d88bf3ac69a#f9ce8b718160b7bd5a329371a54a1d88bf3ac69a"
 dependencies = [
  "datadog-protos",
  "ddsketch-agent",
@@ -1814,6 +1830,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1899,58 +1959,32 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libdd-capabilities"
-version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
-dependencies = [
- "anyhow",
- "bytes",
- "http 1.4.0",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "libdd-capabilities"
 version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a946c29c5fe7cc2adec7a66a35f7cfc138ba75c988d09a7a99c12de7d3b9a7"
+source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
 dependencies = [
  "anyhow",
  "bytes",
  "http 1.4.0",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "libdd-capabilities-impl"
-version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
-dependencies = [
- "bytes",
- "http 1.4.0",
- "http-body-util",
- "libdd-capabilities 2.0.0",
- "libdd-common 4.2.0",
- "tokio",
 ]
 
 [[package]]
 name = "libdd-capabilities-impl"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e948ad5c65d8598fd3889762ea4767b9a521ebfb2f7b72f6e52162aa4d7f353"
+source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
 dependencies = [
  "bytes",
  "http 1.4.0",
  "http-body-util",
- "libdd-capabilities 2.1.0",
- "libdd-common 5.1.0",
+ "libdd-capabilities",
+ "libdd-common",
  "tokio",
 ]
 
 [[package]]
 name = "libdd-common"
-version = "4.2.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
+version = "5.1.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1972,6 +2006,7 @@ dependencies = [
  "regex",
  "rustls",
  "rustls-native-certs",
+ "rustls-platform-verifier",
  "serde",
  "static_assertions",
  "thiserror 1.0.69",
@@ -1982,41 +2017,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "libdd-common"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59de587e652491cb19fd8b7d8e59901794ca56e3961c8c1b97707479d7fe7ec8"
-dependencies = [
- "anyhow",
- "bytes",
- "cc",
- "const_format",
- "futures",
- "futures-core",
- "futures-util",
- "hex",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.8.1",
- "hyper-util",
- "libc",
- "nix 0.29.0",
- "pin-project",
- "regex",
- "serde",
- "static_assertions",
- "thiserror 1.0.69",
- "tokio",
- "tower-service",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "libdd-data-pipeline"
 version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433f9bfe60850c0638a273dfb2bd873f5abc12c9983ce74ebffe055a7a3c21c9"
+source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2026,19 +2029,19 @@ dependencies = [
  "getrandom 0.2.17",
  "http 1.4.0",
  "http-body-util",
- "libdd-capabilities 2.1.0",
- "libdd-capabilities-impl 3.0.0",
- "libdd-common 5.1.0",
- "libdd-ddsketch 1.1.0",
+ "libdd-capabilities",
+ "libdd-capabilities-impl",
+ "libdd-common",
+ "libdd-ddsketch",
  "libdd-dogstatsd-client",
- "libdd-shared-runtime 2.0.0",
+ "libdd-shared-runtime",
  "libdd-telemetry",
- "libdd-tinybytes 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libdd-trace-normalization 3.0.0",
- "libdd-trace-obfuscation 5.0.0",
- "libdd-trace-protobuf 4.0.0",
- "libdd-trace-stats 6.0.0",
- "libdd-trace-utils 9.0.0",
+ "libdd-tinybytes",
+ "libdd-trace-normalization",
+ "libdd-trace-obfuscation",
+ "libdd-trace-protobuf",
+ "libdd-trace-stats",
+ "libdd-trace-utils",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -2051,17 +2054,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-ddsketch"
-version = "1.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
-dependencies = [
- "prost 0.14.3",
-]
-
-[[package]]
-name = "libdd-ddsketch"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f04a8501bc5f52f005f637beb18c900c69ad6deedb5f3104cd0a8c36bc8046"
+source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
 dependencies = [
  "prost 0.14.3",
 ]
@@ -2069,13 +2063,12 @@ dependencies = [
 [[package]]
 name = "libdd-dogstatsd-client"
 version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c29c7bd569824c4d8ffe7171bb77e6b69c2161517ed75436ff458b40d41a663d"
+source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
 dependencies = [
  "anyhow",
  "cadence",
  "http 1.4.0",
- "libdd-common 5.1.0",
+ "libdd-common",
  "serde",
  "tracing",
 ]
@@ -2083,12 +2076,11 @@ dependencies = [
 [[package]]
 name = "libdd-library-config"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab46ec324c1b916ca06c4a369da171a08eb9f112620e6f6f004860e589892715"
+source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
 dependencies = [
  "anyhow",
  "libc",
- "libdd-trace-protobuf 4.0.0",
+ "libdd-trace-protobuf",
  "memfd",
  "prost 0.14.3",
  "rand 0.8.6",
@@ -2101,10 +2093,9 @@ dependencies = [
 [[package]]
 name = "libdd-sampling"
 version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6c34dd818feb6a2c1de996017d2f8e3190615c62fa5513f3b9559bce727dfb"
+source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
 dependencies = [
- "libdd-common 5.1.0",
+ "libdd-common",
  "lru",
  "serde",
  "serde_json",
@@ -2112,33 +2103,15 @@ dependencies = [
 
 [[package]]
 name = "libdd-shared-runtime"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
-dependencies = [
- "async-trait",
- "futures",
- "futures-util",
- "libdd-capabilities 2.0.0",
- "libdd-capabilities-impl 2.0.0",
- "libdd-common 4.2.0",
- "tokio",
- "tokio-util",
- "tracing",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "libdd-shared-runtime"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab1ad16a0bfcf1ce826e2314c162b04daf4324c71da5a28583ea40e76be8772"
+source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
 dependencies = [
  "async-trait",
  "futures",
  "futures-util",
- "libdd-capabilities 2.1.0",
- "libdd-capabilities-impl 3.0.0",
- "libdd-common 5.1.0",
+ "libdd-capabilities",
+ "libdd-capabilities-impl",
+ "libdd-common",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2148,8 +2121,7 @@ dependencies = [
 [[package]]
 name = "libdd-telemetry"
 version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c791d810acbe99b0c7fc4285824f4e27a4b2b9137d4aec8a5df220ca55b34942"
+source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2160,9 +2132,9 @@ dependencies = [
  "http 1.4.0",
  "http-body-util",
  "libc",
- "libdd-common 5.1.0",
- "libdd-ddsketch 1.1.0",
- "libdd-shared-runtime 2.0.0",
+ "libdd-common",
+ "libdd-ddsketch",
+ "libdd-shared-runtime",
  "serde",
  "serde_json",
  "sys-info",
@@ -2176,66 +2148,30 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97db80e3f3f9d19643ac444d6267951a5dab622ad9828c51149d49150625cfe8"
+source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "libdd-tinybytes"
-version = "1.1.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "libdd-trace-normalization"
-version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
-dependencies = [
- "anyhow",
- "libdd-trace-protobuf 3.0.2",
 ]
 
 [[package]]
 name = "libdd-trace-normalization"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4184666070c137e058b2c16acd147c3f045b51de3efe81e0bec62044f29fc6c6"
+source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
 dependencies = [
  "anyhow",
- "libdd-trace-protobuf 4.0.0",
-]
-
-[[package]]
-name = "libdd-trace-obfuscation"
-version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
-dependencies = [
- "anyhow",
- "fluent-uri",
- "libdd-common 4.2.0",
- "libdd-trace-protobuf 3.0.2",
- "libdd-trace-utils 8.0.0",
- "log",
- "percent-encoding",
- "serde",
- "serde_json",
+ "libdd-trace-protobuf",
 ]
 
 [[package]]
 name = "libdd-trace-obfuscation"
 version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d313153f515b9dd31a483bc7e4d432ecb76e53dd33f67f4eeaa415319372b68d"
+source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
 dependencies = [
  "anyhow",
  "fluent-uri",
- "libdd-common 5.1.0",
- "libdd-trace-protobuf 4.0.0",
- "libdd-trace-utils 9.0.0",
+ "libdd-common",
+ "libdd-trace-protobuf",
+ "libdd-trace-utils",
  "log",
  "percent-encoding",
  "serde",
@@ -2244,71 +2180,35 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-protobuf"
-version = "3.0.2"
-source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
-dependencies = [
- "prost 0.14.3",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "libdd-trace-protobuf"
 version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "210492f004b4c343cca736aab2a8c93109034e0c00111bc7376661370439a11c"
+source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
 dependencies = [
  "prost 0.14.3",
  "serde",
  "serde_bytes",
-]
-
-[[package]]
-name = "libdd-trace-stats"
-version = "5.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
-dependencies = [
- "anyhow",
- "arc-swap",
- "async-trait",
- "hashbrown 0.15.5",
- "http 1.4.0",
- "libdd-capabilities 2.0.0",
- "libdd-capabilities-impl 2.0.0",
- "libdd-common 4.2.0",
- "libdd-ddsketch 1.0.1",
- "libdd-shared-runtime 1.0.0",
- "libdd-trace-obfuscation 4.0.0",
- "libdd-trace-protobuf 3.0.2",
- "libdd-trace-utils 8.0.0",
- "rmp-serde",
- "serde",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
 name = "libdd-trace-stats"
 version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23a575e3ecccfbbbd1612ddb1cb8b08e0c12ae0a62052ef995f05d93976a55b"
+source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
 dependencies = [
  "anyhow",
  "arc-swap",
  "async-trait",
+ "futures",
  "hashbrown 0.15.5",
  "http 1.4.0",
- "libdd-capabilities 2.1.0",
- "libdd-capabilities-impl 3.0.0",
- "libdd-common 5.1.0",
- "libdd-ddsketch 1.1.0",
+ "libdd-capabilities",
+ "libdd-capabilities-impl",
+ "libdd-common",
+ "libdd-ddsketch",
  "libdd-dogstatsd-client",
- "libdd-shared-runtime 2.0.0",
+ "libdd-shared-runtime",
  "libdd-telemetry",
- "libdd-trace-obfuscation 5.0.0",
- "libdd-trace-protobuf 4.0.0",
- "libdd-trace-utils 9.0.0",
+ "libdd-trace-obfuscation",
+ "libdd-trace-protobuf",
+ "libdd-trace-utils",
  "rmp-serde",
  "serde",
  "tokio",
@@ -2318,8 +2218,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-utils"
-version = "8.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c#a820699426f28cbabb3a74d87c7309d030b52e7c"
+version = "9.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2327,50 +2227,17 @@ dependencies = [
  "flate2",
  "futures",
  "getrandom 0.2.17",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "indexmap",
- "libdd-capabilities 2.0.0",
- "libdd-capabilities-impl 2.0.0",
- "libdd-common 4.2.0",
- "libdd-tinybytes 1.1.1 (git+https://github.com/DataDog/libdatadog?rev=a820699426f28cbabb3a74d87c7309d030b52e7c)",
- "libdd-trace-normalization 2.0.0",
- "libdd-trace-protobuf 3.0.2",
- "prost 0.14.3",
- "rand 0.8.6",
- "rmp",
- "rmp-serde",
- "rmpv",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "zstd",
-]
-
-[[package]]
-name = "libdd-trace-utils"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2529075e0b7494767011c027750951f302b3ee8a5f5d15ab7a6e95e88a755182"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "bytes",
- "futures",
- "getrandom 0.2.17",
  "hex",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "indexmap",
- "libdd-capabilities 2.1.0",
- "libdd-capabilities-impl 3.0.0",
- "libdd-common 5.1.0",
- "libdd-tinybytes 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libdd-trace-normalization 3.0.0",
- "libdd-trace-protobuf 4.0.0",
+ "libdd-capabilities",
+ "libdd-capabilities-impl",
+ "libdd-common",
+ "libdd-tinybytes",
+ "libdd-trace-normalization",
+ "libdd-trace-protobuf",
  "prost 0.14.3",
  "rand 0.8.6",
  "rmp",
@@ -2383,6 +2250,7 @@ dependencies = [
  "thin-vec",
  "tokio",
  "tracing",
+ "zstd",
 ]
 
 [[package]]
@@ -3549,6 +3417,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4730,6 +4625,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4807,6 +4711,15 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4839,6 +4752,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -4891,6 +4819,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -4909,6 +4843,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -4924,6 +4864,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4957,6 +4903,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -4972,6 +4924,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4993,6 +4951,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -5008,6 +4972,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -809,7 +809,7 @@ dependencies = [
 [[package]]
 name = "datadog-agent-config"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=f9ce8b718160b7bd5a329371a54a1d88bf3ac69a#f9ce8b718160b7bd5a329371a54a1d88bf3ac69a"
+source = "git+https://github.com/DataDog/serverless-components?rev=d0c7f44191445e20d309734675d5e8b91d2a5d51#d0c7f44191445e20d309734675d5e8b91d2a5d51"
 dependencies = [
  "datadog-opentelemetry",
  "dogstatsd",
@@ -827,7 +827,7 @@ dependencies = [
 [[package]]
 name = "datadog-fips"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=f9ce8b718160b7bd5a329371a54a1d88bf3ac69a#f9ce8b718160b7bd5a329371a54a1d88bf3ac69a"
+source = "git+https://github.com/DataDog/serverless-components?rev=d0c7f44191445e20d309734675d5e8b91d2a5d51#d0c7f44191445e20d309734675d5e8b91d2a5d51"
 dependencies = [
  "reqwest",
  "rustls",
@@ -976,7 +976,7 @@ dependencies = [
 [[package]]
 name = "dogstatsd"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=f9ce8b718160b7bd5a329371a54a1d88bf3ac69a#f9ce8b718160b7bd5a329371a54a1d88bf3ac69a"
+source = "git+https://github.com/DataDog/serverless-components?rev=d0c7f44191445e20d309734675d5e8b91d2a5d51#d0c7f44191445e20d309734675d5e8b91d2a5d51"
 dependencies = [
  "datadog-protos",
  "ddsketch-agent",
@@ -1657,7 +1657,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3027,7 +3027,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3064,7 +3064,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -82,9 +82,9 @@ libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog", rev
 libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783", default-features = false }
 libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783", default-features = false }
 datadog-opentelemetry = { git = "https://github.com/DataDog/dd-trace-rs", rev = "50bfea8755b75e448a80ac04d53fa7edd414eefe", default-features = false, features = ["_unstable_propagation"] }
-dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "f9ce8b718160b7bd5a329371a54a1d88bf3ac69a", default-features = false }
-datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "f9ce8b718160b7bd5a329371a54a1d88bf3ac69a", default-features = false }
-datadog-agent-config = { git = "https://github.com/DataDog/serverless-components", rev = "f9ce8b718160b7bd5a329371a54a1d88bf3ac69a", default-features = false }
+dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "d0c7f44191445e20d309734675d5e8b91d2a5d51", default-features = false }
+datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "d0c7f44191445e20d309734675d5e8b91d2a5d51", default-features = false }
+datadog-agent-config = { git = "https://github.com/DataDog/serverless-components", rev = "d0c7f44191445e20d309734675d5e8b91d2a5d51", default-features = false }
 libddwaf = { version = "1.28.1", git = "https://github.com/DataDog/libddwaf-rust", rev = "d1534a158d976bd4f747bf9fcc58e0712d2d17fc", default-features = false, features = ["serde"] }
 
 [dev-dependencies]

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -74,17 +74,17 @@ indexmap = {version = "2.11.0", default-features = false}
 # be found in the clippy.toml file adjacent to this Cargo.toml.
 datadog-protos = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "f863626dbfe3c59bb390985fa6530b0621c2a0a2"}
 ddsketch-agent = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "f863626dbfe3c59bb390985fa6530b0621c2a0a2"}
-libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", default-features = false }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", default-features = false, features = ["mini_agent"] }
-libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c" }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", default-features = false }
-libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "a820699426f28cbabb3a74d87c7309d030b52e7c", default-features = false }
+libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783", default-features = false }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783", default-features = false, features = ["mini_agent"] }
+libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783", default-features = false }
+libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783", default-features = false }
 datadog-opentelemetry = { git = "https://github.com/DataDog/dd-trace-rs", rev = "50bfea8755b75e448a80ac04d53fa7edd414eefe", default-features = false, features = ["_unstable_propagation"] }
-dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "56779dec9f4c9bcc48abcc9833ca4fa4b9d8d627", default-features = false }
-datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "56779dec9f4c9bcc48abcc9833ca4fa4b9d8d627", default-features = false }
-datadog-agent-config = { git = "https://github.com/DataDog/serverless-components", rev = "56779dec9f4c9bcc48abcc9833ca4fa4b9d8d627", default-features = false }
+dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "f9ce8b718160b7bd5a329371a54a1d88bf3ac69a", default-features = false }
+datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "f9ce8b718160b7bd5a329371a54a1d88bf3ac69a", default-features = false }
+datadog-agent-config = { git = "https://github.com/DataDog/serverless-components", rev = "f9ce8b718160b7bd5a329371a54a1d88bf3ac69a", default-features = false }
 libddwaf = { version = "1.28.1", git = "https://github.com/DataDog/libddwaf-rust", rev = "d1534a158d976bd4f747bf9fcc58e0712d2d17fc", default-features = false, features = ["serde"] }
 
 [dev-dependencies]
@@ -169,3 +169,26 @@ fips = [
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage,coverage_nightly)'] }
+
+# datadog-opentelemetry (dd-trace-rs) depends on these libdatadog crates via
+# crates.io, while we depend on them directly via a git rev. Without this,
+# both copies get compiled. Pointing the crates.io versions at the same git
+# rev pinned above collapses them back to one. Verify with
+# `cargo tree --duplicates | grep ^libdd-` after bumping either side.
+[patch.crates-io]
+libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
+libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
+libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
+libdd-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
+libdd-dogstatsd-client = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
+libdd-sampling = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
+libdd-shared-runtime = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
+libdd-telemetry = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
+libdd-tinybytes = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
+libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
+libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }

--- a/bottlecap/LICENSE-3rdparty.csv
+++ b/bottlecap/LICENSE-3rdparty.csv
@@ -27,8 +27,10 @@ byteorder,https://github.com/BurntSushi/byteorder,Unlicense OR MIT,Andrew Gallan
 bytes,https://github.com/tokio-rs/bytes,MIT,"Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>"
 cadence,https://github.com/56quarters/cadence,Apache-2.0 OR MIT,Nick Pillitteri
 cc,https://github.com/rust-lang/cc-rs,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
+cesu8,https://github.com/emk/cesu8-rs,Apache-2.0 OR MIT,Eric Kidd <git@randomhacks.net>
 cfg-if,https://github.com/rust-lang/cfg-if,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
 chrono,https://github.com/chronotope/chrono,MIT OR Apache-2.0,The chrono Authors
+combine,https://github.com/Marwes/combine,MIT,Markus Westerlind <marwes91@gmail.com>
 const-hex,https://github.com/danipopes/const-hex,MIT OR Apache-2.0,DaniPopes <57450786+DaniPopes@users.noreply.github.com>
 const_format,https://github.com/rodrimati1992/const_format_crates,Zlib,rodrimati1992 <rodrimatt1985@gmail.com>
 const_format_proc_macros,https://github.com/rodrimati1992/const_format_crates,Zlib,rodrimati1992 <rodrimatt1985@gmail.com>
@@ -108,6 +110,10 @@ ipnet,https://github.com/krisprice/ipnet,MIT OR Apache-2.0,Kris Price <kris@kris
 iri-string,https://github.com/lo48576/iri-string,MIT OR Apache-2.0,YOSHIOKA Takuma <nop_thread@nops.red>
 itertools,https://github.com/rust-itertools/itertools,MIT OR Apache-2.0,bluss
 itoa,https://github.com/dtolnay/itoa,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+jni,https://github.com/jni-rs/jni-rs,MIT OR Apache-2.0,Josh Chase <josh@prevoty.com>
+jni-sys,https://github.com/jni-rs/jni-sys,MIT OR Apache-2.0,Steven Fackler <sfackler@gmail.com>
+jni-sys,https://github.com/jni-rs/jni-sys,MIT OR Apache-2.0,"Steven Fackler <sfackler@gmail.com>, Robert Bragg <robert@sixbynine.org>"
+jni-sys-macros,https://github.com/jni-rs/jni-sys,MIT OR Apache-2.0,Robert Bragg <robert@sixbynine.org>
 jobserver,https://github.com/rust-lang/jobserver-rs,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
 js-sys,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys,MIT OR Apache-2.0,The wasm-bindgen Developers
 lazy_static,https://github.com/rust-lang-nursery/lazy-static.rs,MIT OR Apache-2.0,Marvin Löbel <loebel.marvin@gmail.com>
@@ -208,6 +214,8 @@ rustls,https://github.com/rustls/rustls,Apache-2.0 OR ISC OR MIT,The rustls Auth
 rustls-native-certs,https://github.com/rustls/rustls-native-certs,Apache-2.0 OR ISC OR MIT,The rustls-native-certs Authors
 rustls-pemfile,https://github.com/rustls/pemfile,Apache-2.0 OR ISC OR MIT,The rustls-pemfile Authors
 rustls-pki-types,https://github.com/rustls/pki-types,MIT OR Apache-2.0,The rustls-pki-types Authors
+rustls-platform-verifier,https://github.com/rustls/rustls-platform-verifier,MIT OR Apache-2.0,The rustls-platform-verifier Authors
+rustls-platform-verifier-android,https://github.com/rustls/rustls-platform-verifier,MIT OR Apache-2.0,The rustls-platform-verifier-android Authors
 rustls-webpki,https://github.com/rustls/webpki,ISC,The rustls-webpki Authors
 rustversion,https://github.com/dtolnay/rustversion,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 rusty-fork,https://github.com/altsysrq/rusty-fork,MIT OR Apache-2.0,Jason Lingle
@@ -307,6 +315,7 @@ wasm-metadata,https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wa
 wasmparser,https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Yury Delendik <ydelendik@mozilla.com>
 web-sys,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys,MIT OR Apache-2.0,The wasm-bindgen Developers
 web-time,https://github.com/daxpedda/web-time,MIT OR Apache-2.0,The web-time Authors
+webpki-root-certs,https://github.com/rustls/webpki-roots,CDLA-Permissive-2.0,The webpki-root-certs Authors
 webpki-roots,https://github.com/rustls/webpki-roots,CDLA-Permissive-2.0,The webpki-roots Authors
 windows,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
 windows-link,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-link Authors

--- a/bottlecap/src/traces/stats_concentrator_service.rs
+++ b/bottlecap/src/traces/stats_concentrator_service.rs
@@ -222,9 +222,11 @@ impl StatsConcentratorService {
     ) {
         let flush_result = self.concentrator.flush(SystemTime::now(), force_flush);
         // Obfuscation is disabled (see `SpanConcentrator::new` above), so every bucket ends up
-        // in `unobfuscated_buckets`; combine both to stay correct if that ever changes.
-        let mut stats_buckets = flush_result.obfuscated_buckets;
-        stats_buckets.extend(flush_result.unobfuscated_buckets);
+        // in `unobfuscated_buckets`; combine both to stay correct if that ever changes. Start
+        // from `unobfuscated_buckets` since it's normally the only non-empty one, avoiding a
+        // reallocation to grow the (usually empty) `obfuscated_buckets` vec.
+        let mut stats_buckets = flush_result.unobfuscated_buckets;
+        stats_buckets.extend(flush_result.obfuscated_buckets);
         let stats = if stats_buckets.is_empty() {
             None
         } else {

--- a/bottlecap/src/traces/stats_concentrator_service.rs
+++ b/bottlecap/src/traces/stats_concentrator_service.rs
@@ -186,8 +186,8 @@ impl StatsConcentratorService {
                 .iter()
                 .map(ToString::to_string)
                 .collect(),
-            // Use libdd-trace-stats' default cardinality limit.
-            None,
+            // Disable the cardinality limit to match pre-existing (unbounded) behavior.
+            Some(usize::MAX),
             // Bottlecap does not perform client-side stats obfuscation.
             None,
         );
@@ -280,6 +280,16 @@ mod tests {
     /// The span is non-root (`parent_id=1`) and not measured, so it will only be
     /// eligible for stats if `span_kinds_stats_computed` includes its `span.kind`.
     fn create_span_kind_span(span_kind: &str, meta: Vec<(&str, &str)>) -> pb::Span {
+        create_span_kind_span_with_resource(span_kind, "test-resource", meta)
+    }
+
+    /// Same as `create_span_kind_span`, but with a caller-provided resource name so tests can
+    /// generate many distinct aggregation keys.
+    fn create_span_kind_span_with_resource(
+        span_kind: &str,
+        resource: &str,
+        meta: Vec<(&str, &str)>,
+    ) -> pb::Span {
         let now_ns = i64::try_from(
             SystemTime::now()
                 .duration_since(SystemTime::UNIX_EPOCH)
@@ -295,7 +305,7 @@ mod tests {
         pb::Span {
             service: "test-service".to_string(),
             name: "test-op".to_string(),
-            resource: "test-resource".to_string(),
+            resource: resource.to_string(),
             trace_id: 1,
             span_id: 2,
             parent_id: 1, // non-root
@@ -384,6 +394,41 @@ mod tests {
         assert!(
             peer_tags.iter().any(|t| t.starts_with("db.system:")),
             "Expected peer_tags to contain db.system, got: {peer_tags:?}"
+        );
+    }
+
+    /// The concentrator is configured with no cardinality limit (`Some(usize::MAX)`), so
+    /// exceeding `libdd_trace_stats`' default limit of 7,000 distinct aggregation keys per
+    /// bucket must not collapse any of them into the `tracer_blocked_value` overflow key.
+    #[tokio::test]
+    async fn test_no_cardinality_limit_applied() {
+        use libdd_trace_stats::span_concentrator::DEFAULT_MAX_ENTRIES_PER_BUCKET;
+
+        const OVERFLOW_KEY: &str = "tracer_blocked_value";
+        let span_count = DEFAULT_MAX_ENTRIES_PER_BUCKET + 1;
+
+        let config = Arc::new(Config::default());
+        let (service, handle) = StatsConcentratorService::new(config);
+        tokio::spawn(service.run());
+
+        for i in 0..span_count {
+            let resource = format!("test-resource-{i}");
+            let span = create_span_kind_span_with_resource("client", &resource, vec![]);
+            handle.add(&span).unwrap();
+        }
+
+        let result = handle.flush(true).await.unwrap();
+
+        let payload = result.expect("Expected stats for the generated spans, but got None.");
+        let all_stats: Vec<_> = payload.stats.iter().flat_map(|b| &b.stats).collect();
+        assert_eq!(
+            all_stats.len(),
+            span_count,
+            "Expected one stats entry per distinct resource with no cardinality limit applied."
+        );
+        assert!(
+            all_stats.iter().all(|s| s.resource != OVERFLOW_KEY),
+            "Expected no stats entries collapsed into the '{OVERFLOW_KEY}' overflow key."
         );
     }
 }

--- a/bottlecap/src/traces/stats_concentrator_service.rs
+++ b/bottlecap/src/traces/stats_concentrator_service.rs
@@ -188,7 +188,7 @@ impl StatsConcentratorService {
                 .collect(),
             // Disable the cardinality limit to match pre-existing (unbounded) behavior.
             Some(usize::MAX),
-            // Bottlecap does not perform client-side stats obfuscation.
+            // Bottlecap does not perform agent-side stats obfuscation.
             None,
         );
         let service: StatsConcentratorService = Self {

--- a/bottlecap/src/traces/stats_concentrator_service.rs
+++ b/bottlecap/src/traces/stats_concentrator_service.rs
@@ -186,6 +186,10 @@ impl StatsConcentratorService {
                 .iter()
                 .map(ToString::to_string)
                 .collect(),
+            // Use libdd-trace-stats' default cardinality limit.
+            None,
+            // Bottlecap does not perform client-side stats obfuscation.
+            None,
         );
         let service: StatsConcentratorService = Self {
             concentrator,
@@ -216,7 +220,11 @@ impl StatsConcentratorService {
         force_flush: bool,
         response_tx: oneshot::Sender<Option<ClientStatsPayload>>,
     ) {
-        let stats_buckets = self.concentrator.flush(SystemTime::now(), force_flush);
+        let flush_result = self.concentrator.flush(SystemTime::now(), force_flush);
+        // Obfuscation is disabled (see `SpanConcentrator::new` above), so every bucket ends up
+        // in `unobfuscated_buckets`; combine both to stay correct if that ever changes.
+        let mut stats_buckets = flush_result.obfuscated_buckets;
+        stats_buckets.extend(flush_result.unobfuscated_buckets);
         let stats = if stats_buckets.is_empty() {
             None
         } else {

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -753,6 +753,7 @@ mod tests {
             env: "test-env".to_string(),
             hostname: String::new(),
             app_version: String::new(),
+            container_debug: None,
         };
 
         let received_payload = if let TracerPayloadCollection::V07(payload) =

--- a/bottlecap/tests/apm_integration_test.rs
+++ b/bottlecap/tests/apm_integration_test.rs
@@ -141,6 +141,7 @@ async fn stats_payload_roundtrip_through_fake_intake() {
                 http_method: "GET".to_string(),
                 service_source: String::new(),
                 span_derived_primary_tags: vec![],
+                additional_metric_tags: vec![],
             }],
         }],
         agent_aggregation: String::new(),
@@ -232,6 +233,7 @@ async fn trace_payload_roundtrip_through_fake_intake() {
         env: "test-env".to_string(),
         hostname: String::new(),
         app_version: "1.2.3".to_string(),
+        container_debug: None,
     };
 
     let tags = header_tags();


### PR DESCRIPTION
## Overview

Follows up on the `dd-trace-rs` v0.5.0 bump ([#1302](https://github.com/DataDog/datadog-lambda-extension/pull/1302)): bumps the shared `libdatadog` git rev (`libdd-capabilities`, `libdd-common`, `libdd-trace-protobuf`, `libdd-trace-utils`, `libdd-trace-normalization`, `libdd-trace-obfuscation`, `libdd-trace-stats`) from `a820699` to `85ce322a`, matching the exact versions `datadog-opentelemetry` v0.5.0 pulls from crates.io. Adds a `[patch.crates-io]` block redirecting those (and the other transitively-pulled `libdd-*` crates) to the same rev, collapsing what would otherwise be two compiled copies of each.

This addresses the duplication [Copilot flagged on serverless-components#144](https://github.com/DataDog/serverless-components/pull/144#discussion_r3572767510) where broke type identity for `ReplaceRule`/`Endpoint`/`Span`/etc. across the git-vs-registry boundary throughout the trace pipeline) or leaving the duplication as-is.

### Why not just add this to #1302?

#1302 skipped this on purpose. The duplication only cost +256 bytes on the release binary (LTO strips the unreachable copy), while actually fixing it means an untested major-version bump across six libdatadog crates, including `libdd-trace-obfuscation` — the code that redacts sensitive data from spans. Not something to risk on the same PR as an urgent customer fix (SLES-2907, B3 propagation errors). This PR does that bump on its own, with its own tests.

**Depends on [DataDog/serverless-components#145](https://github.com/DataDog/serverless-components/pull/145)** (which itself builds on [#144](https://github.com/DataDog/serverless-components/pull/144)) — the `dogstatsd`/`datadog-fips`/`datadog-agent-config` rev pin here must stay in sync with whatever commit that PR lands at. Opened as draft for that reason.

JIRA: [SLES-2907](https://datadoghq.atlassian.net/browse/SLES-2907)

### Code changes at the new rev

Most of the API changes in `SpanConcentrator` are just things the compiler forces on you, with no behavior change:

- `new()` gained an obfuscation-config param. We pass `None` — bottlecap has never done client-side stats obfuscation.
- `flush()` now returns `FlushResult { obfuscated_buckets, unobfuscated_buckets }` instead of a flat `Vec`. We concatenate both — obfuscation is off, so everything ends up in `unobfuscated_buckets` anyway.
- `pb::TracerPayload` gained `container_debug`, `pb::ClientGroupedStats` gained `additional_metric_tags`. Added the missing fields to 3 struct literals so things compile; both are left at their defaults.

`SpanConcentrator::new` also gained a cardinality-override param — the new rev defaults to capping trace-stats aggregation at 7,000 distinct keys per 10-second bucket, added in [DataDog/libdatadog#2158](https://github.com/DataDog/libdatadog/pull/2158) to bound `SpanConcentrator`'s own memory use ([#2158](https://github.com/DataDog/libdatadog/pull/2158) has the math: ~45.6 MB typical, ~700 MB worst case across 3 buckets with the limit on). This is an APM/trace-stats decision, unrelated to Datadog's custom-metrics cardinality limits.

The scope of this PR is dependency consolidation, not adopting a new safety feature, so we pass `Some(usize::MAX)` to keep this rev bump behavior-neutral: no Lambda workload will ever produce `usize::MAX` distinct keys in a 10-second window, so stats collapsing never triggers, matching pre-bump behavior exactly. Passing `None` instead would opt into new behavior (collapsing above 7,000 keys into a generic `tracer_blocked_value` bucket for workloads that never hit that before) — worth considering on its own merits given Lambda's memory constraints, but that's a deliberate product/safety decision that deserves its own PR and review, not something to fold into a dependency bump. `test_no_cardinality_limit_applied` covers the unbounded behavior we're keeping.

## Testing

- `cargo build --all-targets` — clean
- `cargo test --all-targets` — 548/548 pass across all test binaries
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo tree --duplicates | grep ^libdd-` — empty (zero `libdd-*` duplicates)
- `dd-rust-license-tool check` — passes
- Verified against the real `serverless-components#145` commit (not a local `file://` override used during earlier iteration)


[SLES-2907]: https://datadoghq.atlassian.net/browse/SLES-2907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ