### PR TITLE
[SVLS-9488] fix(secrets): recognize apiKey field in JSON Secrets Manager secrets

### DIFF
--- a/bottlecap/src/secrets/decrypt.rs
+++ b/bottlecap/src/secrets/decrypt.rs
@@ -217,16 +217,22 @@ async fn decrypt_aws_sm(
     extract_secret_string(&v)
 }
 
-// When a Secrets Manager secret is a JSON object, this key is used to extract the API key.
-// Falls back to the raw secret string if the key is absent or the value is not valid JSON.
+// When a Secrets Manager secret is a JSON object, these keys are used to extract the API key,
+// checked in order. `dd_api_key` is our own convention; `apiKey` matches the field name used by
+// AWS's Managed Rotation for Datadog API Key secret type. Falls back to the raw secret string if
+// neither key is present or the value is not valid JSON.
 const JSON_SECRET_DD_API_KEY: &str = "dd_api_key";
+const JSON_SECRET_API_KEY: &str = "apiKey";
 
 fn extract_secret_string(v: &Value) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
     if let Some(secret_string) = v["SecretString"].as_str() {
-        if let Ok(parsed) = serde_json::from_str::<Value>(secret_string)
-            && let Some(extracted) = parsed[JSON_SECRET_DD_API_KEY].as_str()
-        {
-            return Ok(extracted.to_string());
+        if let Ok(parsed) = serde_json::from_str::<Value>(secret_string) {
+            if let Some(extracted) = parsed[JSON_SECRET_DD_API_KEY].as_str() {
+                return Ok(extracted.to_string());
+            }
+            if let Some(extracted) = parsed[JSON_SECRET_API_KEY].as_str() {
+                return Ok(extracted.to_string());
+            }
         }
         Ok(secret_string.to_string())
     } else {
@@ -450,6 +456,20 @@ mod tests {
     #[test]
     fn test_json_secret_extraction() {
         let v = make_sm_response(r#"{"dd_api_key":"abc123"}"#);
+        let result = extract_secret_string(&v).expect("should extract dd_api_key");
+        assert_eq!(result, "abc123");
+    }
+
+    #[test]
+    fn test_json_secret_extraction_api_key() {
+        let v = make_sm_response(r#"{"apiKey":"abc123","apiKeyId":"some-uuid"}"#);
+        let result = extract_secret_string(&v).expect("should extract apiKey");
+        assert_eq!(result, "abc123");
+    }
+
+    #[test]
+    fn test_json_secret_dd_api_key_takes_precedence_over_api_key() {
+        let v = make_sm_response(r#"{"dd_api_key":"abc123","apiKey":"def456"}"#);
         let result = extract_secret_string(&v).expect("should extract dd_api_key");
         assert_eq!(result, "abc123");
     }


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/SVLS-9488

## Overview

AWS's [Managed Rotation for Datadog API Key](https://docs.aws.amazon.com/secretsmanager/latest/userguide/mes-partner-DatadogApiKey.html) Secrets Manager secret type stores the API key under the field `apiKey` (alongside `apiKeyId`), not our own `dd_api_key` convention added in #1146. As a result, `DD_API_KEY_SECRET_ARN` couldn't consume that AWS-managed secret type.

`extract_secret_string` now checks `dd_api_key` first (unchanged), then falls back to `apiKey`, before falling back to treating the secret as a raw string.

Fixes #1304

## Testing

- Added `test_json_secret_dd_api_key_takes_precedence_over_api_key` — when both fields are present, `dd_api_key` wins.
- Existing tests (`test_json_secret_extraction`, `test_json_secret_missing_key_falls_back_to_raw`, `test_plain_secret_unaffected`, `test_malformed_json_secret_falls_back_to_raw`) continue to pass unchanged.
- `cargo test --lib secrets::decrypt` — 11/11 passing.
- `cargo clippy` — clean on the changed file.
- Added `test_json_secret_extraction_api_key` — secret shaped like AWS's managed-rotation type (`{"apiKey":"...","apiKeyId":"..."}`) extracts the API key. ([sample function](https://us-east-1.console.aws.amazon.com/lambda/home?region=us-east-1#/functions/tianning-li-20260716-1213-sample-function/versions/5?subtab=envVars&tab=testing) with [sample log](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Ftianning-li-20260716-1213-sample-function/log-events/2026$252F07$252F16$252F$255B5$255D7aeb509a15c7467699d15ac4db9c9122))
<img width="1046" height="632" alt="image" src="https://github.com/user-attachments/assets/f93b217e-8d4d-4100-ad36-cd7b34d02578" />
