### PR TITLE
[SVLS-9534] chore: bump extension version to 99-next

### DIFF
--- a/bottlecap/src/tags/lambda/tags.rs
+++ b/bottlecap/src/tags/lambda/tags.rs
@@ -47,7 +47,7 @@ const FUNCTION_TAGS_KEY: &str = "_dd.tags.function";
 // TODO(astuyve) decide what to do with the version
 const EXTENSION_VERSION_KEY: &str = "dd_extension_version";
 // TODO(duncanista) figure out a better way to not hardcode this
-pub const EXTENSION_VERSION: &str = "98-next";
+pub const EXTENSION_VERSION: &str = "99-next";
 
 const REGION_KEY: &str = "region";
 const ACCOUNT_ID_KEY: &str = "account_id";


### PR DESCRIPTION
**Please include Jira ticket in title.**

## Overview

Bumps `EXTENSION_VERSION` from `98-next` to `99-next` in `bottlecap/src/tags/lambda/tags.rs`.

JIRA: https://datadoghq.atlassian.net/browse/SVLS-9534

## Testing

N/A — version constant bump only.