### PR TITLE
feat(logging): surface flush data-type and duration at INFO level

### DIFF
--- a/bottlecap/src/flushing/service.rs
+++ b/bottlecap/src/flushing/service.rs
@@ -1,8 +1,9 @@
 //! `FlushingService` for coordinating flush operations across multiple flusher types.
 
 use std::sync::Arc;
+use std::time::Instant;
 
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 
 use dogstatsd::{
     aggregator::AggregatorHandle as MetricsAggregatorHandle, flusher::Flusher as MetricsFlusher,
@@ -102,10 +103,20 @@ impl FlushingService {
             let series_clone = series.clone();
             let sketches_clone = sketches.clone();
             let handle = tokio::spawn(async move {
+                let series_count = series_clone.len();
+                let sketches_count = sketches_clone.len();
+                info!(
+                    "FLUSH_TIMING | METRICS | Flushing metrics (flusher {idx}, {series_count} series, {sketches_count} sketches)"
+                );
+                let start = Instant::now();
                 let (retry_series, retry_sketches) = flusher
                     .flush_metrics(series_clone, sketches_clone)
                     .await
                     .unwrap_or_default();
+                info!(
+                    "FLUSH_TIMING | METRICS | Flushed metrics in {} ms (flusher {idx}, {series_count} series, {sketches_count} sketches)",
+                    start.elapsed().as_millis()
+                );
                 MetricsRetryBatch {
                     flusher_id: idx,
                     series: retry_series,
@@ -317,10 +328,22 @@ impl FlushingService {
             .metrics_flushers
             .iter()
             .map(|f| {
-                f.flush_metrics(
-                    flush_response.series.clone(),
-                    flush_response.distributions.clone(),
-                )
+                let series = flush_response.series.clone();
+                let sketches = flush_response.distributions.clone();
+                let series_count = series.len();
+                let sketches_count = sketches.len();
+                async move {
+                    info!(
+                        "FLUSH_TIMING | METRICS | Flushing metrics ({series_count} series, {sketches_count} sketches)"
+                    );
+                    let start = Instant::now();
+                    let result = f.flush_metrics(series, sketches).await;
+                    info!(
+                        "FLUSH_TIMING | METRICS | Flushed metrics in {} ms ({series_count} series, {sketches_count} sketches)",
+                        start.elapsed().as_millis()
+                    );
+                    result
+                }
             })
             .collect();
 

--- a/bottlecap/src/logs/flusher.rs
+++ b/bottlecap/src/logs/flusher.rs
@@ -10,7 +10,7 @@ use std::time::Instant;
 use std::{io::Write, sync::Arc};
 use thiserror::Error as ThisError;
 use tokio::{sync::OnceCell, task::JoinSet};
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 use zstd::stream::write::Encoder;
 
 #[derive(ThisError, Debug)]
@@ -275,7 +275,8 @@ impl LogsFlusher {
                 );
             }
         } else {
-            let logs_batches = Arc::new({
+            let start = Instant::now();
+            let logs_batches: Arc<Vec<Vec<u8>>> = Arc::new({
                 match self.aggregator_handle.get_batches().await {
                     Ok(batches) => batches
                         .into_iter()
@@ -288,6 +289,14 @@ impl LogsFlusher {
                 }
             });
 
+            if !logs_batches.is_empty() {
+                info!(
+                    "FLUSH_TIMING | LOGS | Flushing {} batches ({} bytes)",
+                    logs_batches.len(),
+                    logs_batches.iter().map(Vec::len).sum::<usize>(),
+                );
+            }
+
             // Send batches to each flusher
             let futures = self.flushers.iter().map(|flusher| {
                 let batches = Arc::clone(&logs_batches);
@@ -298,6 +307,15 @@ impl LogsFlusher {
             let results = join_all(futures).await;
             for failed in results {
                 failed_requests.extend(failed);
+            }
+
+            if !logs_batches.is_empty() {
+                info!(
+                    "FLUSH_TIMING | LOGS | Flushed {} batches ({} bytes) in {} ms",
+                    logs_batches.len(),
+                    logs_batches.iter().map(Vec::len).sum::<usize>(),
+                    start.elapsed().as_millis()
+                );
             }
         }
         failed_requests

--- a/bottlecap/src/traces/proxy_flusher.rs
+++ b/bottlecap/src/traces/proxy_flusher.rs
@@ -105,6 +105,11 @@ impl Flusher {
             }
         }
 
+        info!(
+            "FLUSH_TIMING | PROXY_FLUSHER | Flushing {} requests",
+            requests.len()
+        );
+
         for request in requests {
             join_set.spawn(async move { Self::send(request).await });
         }
@@ -155,8 +160,8 @@ impl Flusher {
                     let status = r.status();
                     let body = r.text().await;
                     if status == 202 || status == 200 {
-                        debug!(
-                            "PROXY_FLUSHER | Successfully sent request in {} ms to {url}",
+                        info!(
+                            "FLUSH_TIMING | PROXY_FLUSHER | Successfully sent request in {} ms to {url}",
                             elapsed.as_millis()
                         );
                         return Ok(());

--- a/bottlecap/src/traces/stats_flusher.rs
+++ b/bottlecap/src/traces/stats_flusher.rs
@@ -17,7 +17,7 @@ use libdd_capabilities::http::HttpClientTrait;
 use libdd_common::Endpoint;
 use libdd_trace_protobuf::pb;
 use libdd_trace_utils::stats_utils;
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 
 pub struct StatsFlusher {
     aggregator: Arc<Mutex<StatsAggregator>>,
@@ -81,7 +81,7 @@ impl StatsFlusher {
             })
             .await;
 
-        debug!("STATS | Flushing {} stats", stats.len());
+        info!("FLUSH_TIMING | STATS | Flushing {} stats", stats.len());
 
         let stats_payload = stats_utils::construct_stats_payload(stats.clone());
 
@@ -109,16 +109,16 @@ impl StatsFlusher {
 
             match resp {
                 Ok(()) => {
-                    debug!(
-                        "STATS | Successfully flushed stats to {} in {} ms (attempt {attempt}/{FLUSH_RETRY_COUNT})",
+                    info!(
+                        "FLUSH_TIMING | STATS | Successfully flushed stats to {} in {} ms (attempt {attempt}/{FLUSH_RETRY_COUNT})",
                         endpoint.url,
                         elapsed.as_millis()
                     );
                     return None;
                 }
                 Err(e) => {
-                    debug!(
-                        "STATS | Failed to send stats to {} in {} ms (attempt {attempt}/{FLUSH_RETRY_COUNT}): {e:?}",
+                    info!(
+                        "FLUSH_TIMING | STATS | Failed to send stats to {} in {} ms (attempt {attempt}/{FLUSH_RETRY_COUNT}): {e:?}",
                         endpoint.url,
                         elapsed.as_millis()
                     );

--- a/bottlecap/src/traces/trace_flusher.rs
+++ b/bottlecap/src/traces/trace_flusher.rs
@@ -13,7 +13,7 @@ use libdd_trace_utils::{
 use std::str::FromStr;
 use std::sync::Arc;
 use tokio::task::JoinSet;
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 
 use crate::FLUSH_RETRY_COUNT;
 use crate::config::Config;
@@ -194,7 +194,10 @@ impl TraceFlusher {
         let start = tokio::time::Instant::now();
         let coalesced_traces = trace_utils::coalesce_send_data(traces);
         tokio::task::yield_now().await;
-        debug!("TRACES | Flushing {} traces", coalesced_traces.len());
+        info!(
+            "FLUSH_TIMING | TRACES | Flushing {} traces",
+            coalesced_traces.len()
+        );
 
         for trace in &coalesced_traces {
             let result = trace.send(&http_client).await;
@@ -216,7 +219,10 @@ impl TraceFlusher {
             );
         }
 
-        debug!("TRACES | Flushing took {} ms", start.elapsed().as_millis());
+        info!(
+            "FLUSH_TIMING | TRACES | Flushing took {} ms",
+            start.elapsed().as_millis()
+        );
         None
     }
 }


### PR DESCRIPTION
⚠️ DO NOT MERGE ⚠️ 

Promote existing DEBUG logs (traces, stats, proxy) to INFO and add minimal new INFO logs (logs, metrics) so customer can see which telemetry type is flushing and how long each flush took without needing DD_LOG_LEVEL=debug. All lines share a FLUSH_TIMING tag so they're easy to search for in Datadog.

https://datadoghq.atlassian.net/browse/SLES-2903

These changes are built on v97 and will be shipped to a single customer as a custom extension build.