### PR TITLE
[APMSVLS-469] feat(traces): add error sampler to keep/rescue traces with errors

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -485,6 +485,7 @@ dependencies = [
  "chrono",
  "cookie",
  "datadog-agent-config",
+ "datadog-agent-trace-sampler",
  "datadog-fips",
  "datadog-opentelemetry",
  "datadog-protos",
@@ -824,6 +825,11 @@ dependencies = [
  "tokio",
  "tracing",
 ]
+
+[[package]]
+name = "datadog-agent-trace-sampler"
+version = "0.1.0"
+source = "git+https://github.com/DataDog/serverless-components?rev=9daae40afa87f52fad1489f4d7cfd4a579037d2d#9daae40afa87f52fad1489f4d7cfd4a579037d2d"
 
 [[package]]
 name = "datadog-fips"
@@ -1658,7 +1664,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -3275,7 +3281,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3312,7 +3318,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -95,6 +95,7 @@ datadog-opentelemetry = { git = "https://github.com/DataDog/dd-trace-rs", rev = 
 dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "9daae40afa87f52fad1489f4d7cfd4a579037d2d", default-features = false }
 datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "9daae40afa87f52fad1489f4d7cfd4a579037d2d", default-features = false }
 datadog-agent-config = { git = "https://github.com/DataDog/serverless-components", rev = "9daae40afa87f52fad1489f4d7cfd4a579037d2d", default-features = false }
+datadog-agent-trace-sampler = { git = "https://github.com/DataDog/serverless-components", rev = "9daae40afa87f52fad1489f4d7cfd4a579037d2d", default-features = false }
 libddwaf = { version = "1.28.1", git = "https://github.com/DataDog/libddwaf-rust", rev = "d1534a158d976bd4f747bf9fcc58e0712d2d17fc", default-features = false, features = ["serde"] }
 
 [dev-dependencies]

--- a/bottlecap/LICENSE-3rdparty.csv
+++ b/bottlecap/LICENSE-3rdparty.csv
@@ -44,6 +44,7 @@ crossbeam-utils,https://github.com/crossbeam-rs/crossbeam,MIT OR Apache-2.0,The 
 crypto-common,https://github.com/RustCrypto/traits,MIT OR Apache-2.0,RustCrypto Developers
 ctor,https://github.com/mmastrac/rust-ctor,Apache-2.0 OR MIT,Matt Mastracci <matthew@mastracci.com>
 datadog-agent-config,https://github.com/DataDog/serverless-components,Apache-2.0,The datadog-agent-config Authors
+datadog-agent-trace-sampler,https://github.com/DataDog/serverless-components,Apache-2.0,The datadog-agent-trace-sampler Authors
 datadog-fips,https://github.com/DataDog/serverless-components,Apache-2.0,The datadog-fips Authors
 datadog-opentelemetry,https://github.com/DataDog/dd-trace-rs/tree/main/datadog-opentelemetry,Apache-2.0,Datadog Inc. <info@datadoghq.com>
 datadog-protos,https://github.com/DataDog/saluki,Apache-2.0,The datadog-protos Authors

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -1225,10 +1225,16 @@ fn start_trace_agent(
 
     // The Agent's error sampler knob has no effect here: the extension's
     // sampler is a plain on/off switch, not a TPS budget.
-    if env::var("DD_APM_ERROR_TPS").is_ok() {
-        warn!(
-            "DD_APM_ERROR_TPS is not supported by the Lambda extension; set DD_SERVERLESS_ERROR_SAMPLER_ENABLED=true to rescue errored traces"
-        );
+    if env::var("DD_APM_ERROR_TPS").is_ok_and(|v| !v.trim().is_empty()) {
+        if config.ext.serverless_error_sampler_enabled {
+            warn!(
+                "DD_APM_ERROR_TPS is not supported by the Lambda extension; error trace rescue is on/off only and is already enabled"
+            );
+        } else {
+            warn!(
+                "DD_APM_ERROR_TPS is not supported by the Lambda extension; set DD_SERVERLESS_ERROR_SAMPLER_ENABLED=true to rescue errored traces"
+            );
+        }
     }
 
     let trace_processor = Arc::new(trace_processor::ServerlessTraceProcessor {

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -1228,6 +1228,11 @@ fn start_trace_agent(
         error_sampler: Arc::new(std::sync::Mutex::new(
             datadog_agent_trace_sampler::ErrorsSampler::new(
                 datadog_agent_trace_sampler::ErrorSamplerConfig {
+                    // Hardcoded for now (config wiring via DD_APM_ERROR_SAMPLER_MODE
+                    // is deferred): Lambda's per-invocation trace volume is low and
+                    // freeze/thaw breaks the RateLimited mode's 30s wall-clock
+                    // window, so AlwaysKeep is the right default. See APMSVLS-469.
+                    mode: datadog_agent_trace_sampler::ErrorSamplerMode::AlwaysKeep,
                     target_tps: config.ext.apm_error_tps,
                     extra_sample_rate: config.ext.apm_extra_sample_rate,
                 },

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -1225,27 +1225,7 @@ fn start_trace_agent(
 
     let trace_processor = Arc::new(trace_processor::ServerlessTraceProcessor {
         obfuscation_config: Arc::new(obfuscation_config),
-        error_sampler: Arc::new(std::sync::Mutex::new(
-            datadog_agent_trace_sampler::ErrorsSampler::new(
-                datadog_agent_trace_sampler::ErrorSamplerConfig {
-                    // Hardcoded for now (config wiring via DD_APM_ERROR_SAMPLER_MODE
-                    // is deferred): Lambda's per-invocation trace volume is low and
-                    // freeze/thaw breaks the RateLimited mode's 30s wall-clock
-                    // window, so AlwaysKeep is the right default. See APMSVLS-469.
-                    mode: datadog_agent_trace_sampler::ErrorSamplerMode::AlwaysKeep,
-                    // AlwaysKeep derives its disabled flag from `target_tps <= 0.0`,
-                    // so the boolean maps onto any positive value vs. zero. The
-                    // magnitude is unused until RateLimited is wired up, which is
-                    // when DD_APM_ERROR_TPS becomes meaningful and gets exposed.
-                    target_tps: if config.ext.apm_error_sampler_enabled {
-                        1.0
-                    } else {
-                        0.0
-                    },
-                    extra_sample_rate: 1.0,
-                },
-            ),
-        )),
+        error_sampler: trace_processor::new_error_sampler(config.ext.apm_error_sampler_enabled),
     });
 
     let (span_dedup_service, span_dedup_handle) = span_dedup_service::DedupService::new();

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -1225,6 +1225,14 @@ fn start_trace_agent(
 
     let trace_processor = Arc::new(trace_processor::ServerlessTraceProcessor {
         obfuscation_config: Arc::new(obfuscation_config),
+        error_sampler: Arc::new(std::sync::Mutex::new(
+            datadog_agent_trace_sampler::ErrorsSampler::new(
+                datadog_agent_trace_sampler::ErrorSamplerConfig {
+                    target_tps: config.ext.apm_error_tps,
+                    extra_sample_rate: config.ext.apm_extra_sample_rate,
+                },
+            ),
+        )),
     });
 
     let (span_dedup_service, span_dedup_handle) = span_dedup_service::DedupService::new();

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -1226,15 +1226,9 @@ fn start_trace_agent(
     // The Agent's error sampler knob has no effect here: the extension's
     // sampler is a plain on/off switch, not a TPS budget.
     if env::var("DD_APM_ERROR_TPS").is_ok_and(|v| !v.trim().is_empty()) {
-        if config.ext.serverless_error_sampler_enabled {
-            warn!(
-                "DD_APM_ERROR_TPS is not supported by the Lambda extension; error trace rescue is on/off only and is already enabled"
-            );
-        } else {
-            warn!(
-                "DD_APM_ERROR_TPS is not supported by the Lambda extension; set DD_SERVERLESS_ERROR_SAMPLER_ENABLED=true to rescue errored traces"
-            );
-        }
+        warn!(
+            "DD_APM_ERROR_TPS is not supported by the Lambda extension; error trace rescue is an on/off switch controlled by DD_SERVERLESS_ERROR_SAMPLER_ENABLED"
+        );
     }
 
     let trace_processor = Arc::new(trace_processor::ServerlessTraceProcessor {

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -1223,9 +1223,19 @@ fn start_trace_agent(
         ..Default::default()
     };
 
+    // The Agent's error sampler knob has no effect here: the extension's
+    // sampler is a plain on/off switch, not a TPS budget.
+    if env::var("DD_APM_ERROR_TPS").is_ok() {
+        warn!(
+            "DD_APM_ERROR_TPS is not supported by the Lambda extension; set DD_SERVERLESS_ERROR_SAMPLER_ENABLED=true to rescue errored traces"
+        );
+    }
+
     let trace_processor = Arc::new(trace_processor::ServerlessTraceProcessor {
         obfuscation_config: Arc::new(obfuscation_config),
-        error_sampler: trace_processor::new_error_sampler(config.ext.apm_error_sampler_enabled),
+        error_sampler: trace_processor::new_error_sampler(
+            config.ext.serverless_error_sampler_enabled,
+        ),
     });
 
     let (span_dedup_service, span_dedup_handle) = span_dedup_service::DedupService::new();

--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -1233,8 +1233,16 @@ fn start_trace_agent(
                     // freeze/thaw breaks the RateLimited mode's 30s wall-clock
                     // window, so AlwaysKeep is the right default. See APMSVLS-469.
                     mode: datadog_agent_trace_sampler::ErrorSamplerMode::AlwaysKeep,
-                    target_tps: config.ext.apm_error_tps,
-                    extra_sample_rate: config.ext.apm_extra_sample_rate,
+                    // AlwaysKeep derives its disabled flag from `target_tps <= 0.0`,
+                    // so the boolean maps onto any positive value vs. zero. The
+                    // magnitude is unused until RateLimited is wired up, which is
+                    // when DD_APM_ERROR_TPS becomes meaningful and gets exposed.
+                    target_tps: if config.ext.apm_error_sampler_enabled {
+                        1.0
+                    } else {
+                        0.0
+                    },
+                    extra_sample_rate: 1.0,
                 },
             ),
         )),

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -376,7 +376,6 @@ impl LambdaConfig {
 #[cfg_attr(coverage_nightly, coverage(off))] // Test modules skew coverage metrics
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
-#[allow(clippy::float_cmp)] // exact, representable config values (10.0, 1.0, ...) parsed deterministically
 mod lambda_config_tests {
     use datadog_agent_config::{Config as UpstreamConfig, flush_strategy::PeriodicStrategy};
     use figment::Jail;

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -73,10 +73,19 @@ pub struct LambdaConfig {
     /// agent-side error sampler when the extension computes stats. Matches the
     /// Go trace agent's `apm_config.errors_per_second`. Default 10.0; `0`
     /// disables the sampler (no rescue).
+    ///
+    /// Note: the sampler currently runs in `AlwaysKeep` mode (hardcoded in
+    /// `main.rs`), where this value acts only as an on/off switch — `0` (or
+    /// negative) disables rescue, any positive value rescues every errored
+    /// chunk without a rate cap. The traces/sec budget is only enforced in
+    /// `RateLimited` mode. See APMSVLS-469.
     pub apm_error_tps: f64,
     /// `DD_APM_EXTRA_SAMPLE_RATE` — extra raw sampling rate applied on top of
     /// the computed error-sampler rate. Matches the Go trace agent's
     /// `apm_config.extra_sample_rate`. Default 1.0.
+    ///
+    /// Note: only meaningful in `RateLimited` mode; inert while the sampler is
+    /// hardcoded to `AlwaysKeep`. See APMSVLS-469.
     pub apm_extra_sample_rate: f64,
 
     pub span_dedup_timeout: Option<Duration>,

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -69,24 +69,18 @@ pub struct LambdaConfig {
     pub capture_lambda_payload_max_depth: u32,
     pub lambda_extension_compute_stats: bool,
 
-    /// `DD_APM_ERROR_TPS` — target error traces per second rescued by the
-    /// agent-side error sampler when the extension computes stats. Matches the
-    /// Go trace agent's `apm_config.errors_per_second`. Default 10.0; `0`
-    /// disables the sampler (no rescue).
+    /// `DD_APM_ERROR_SAMPLER_ENABLED` — whether the agent-side error sampler
+    /// rescues errored trace chunks that would otherwise be dropped, on the
+    /// `lambda_extension_compute_stats` path.
     ///
-    /// Note: the sampler currently runs in `AlwaysKeep` mode (hardcoded in
-    /// `main.rs`), where this value acts only as an on/off switch — `0` (or
-    /// negative) disables rescue, any positive value rescues every errored
-    /// chunk without a rate cap. The traces/sec budget is only enforced in
-    /// `RateLimited` mode. See APMSVLS-469.
-    pub apm_error_tps: f64,
-    /// `DD_APM_EXTRA_SAMPLE_RATE` — extra raw sampling rate applied on top of
-    /// the computed error-sampler rate. Matches the Go trace agent's
-    /// `apm_config.extra_sample_rate`. Default 1.0.
-    ///
-    /// Note: only meaningful in `RateLimited` mode; inert while the sampler is
-    /// hardcoded to `AlwaysKeep`. See APMSVLS-469.
-    pub apm_extra_sample_rate: f64,
+    /// Defaults to `false` while the feature rolls out as opt-in; the plan is
+    /// to flip the default to `true` once it has soaked. The sampler runs in
+    /// `AlwaysKeep` mode (hardcoded in `main.rs`), so this is a plain on/off
+    /// switch: enabled rescues every errored chunk. The Go agent's
+    /// rate-limiting knobs (`apm_config.errors_per_second` /
+    /// `extra_sample_rate`) are intentionally not exposed yet — they only have
+    /// meaning in `RateLimited` mode and will be added with it. See APMSVLS-469.
+    pub apm_error_sampler_enabled: bool,
 
     pub span_dedup_timeout: Option<Duration>,
     pub api_key_secret_reload_interval: Option<Duration>,
@@ -154,8 +148,7 @@ impl Default for LambdaConfig {
             capture_lambda_payload: false,
             capture_lambda_payload_max_depth: 10,
             lambda_extension_compute_stats: false,
-            apm_error_tps: 10.0,
-            apm_extra_sample_rate: 1.0,
+            apm_error_sampler_enabled: false,
             span_dedup_timeout: None,
             api_key_secret_reload_interval: None,
             serverless_appsec_enabled: false,
@@ -221,14 +214,10 @@ pub struct LambdaConfigSource {
     #[serde(deserialize_with = "deser_opt_bool")]
     pub lambda_extension_compute_stats: Option<bool>,
 
-    /// `DD_APM_ERROR_TPS` — error sampler target traces/sec. Flat env/YAML key
-    /// (`apm_error_tps`), unlike the Go agent's nested `apm_config.errors_per_second`.
-    #[serde(deserialize_with = "deser_opt_lossless")]
-    pub apm_error_tps: Option<f64>,
-    /// `DD_APM_EXTRA_SAMPLE_RATE` — error sampler extra sample rate. Flat
-    /// env/YAML key (`apm_extra_sample_rate`).
-    #[serde(deserialize_with = "deser_opt_lossless")]
-    pub apm_extra_sample_rate: Option<f64>,
+    /// `DD_APM_ERROR_SAMPLER_ENABLED` — toggles the agent-side error sampler.
+    /// Flat env/YAML key (`apm_error_sampler_enabled`).
+    #[serde(deserialize_with = "deser_opt_bool")]
+    pub apm_error_sampler_enabled: Option<bool>,
 
     #[serde(deserialize_with = "deser_dur_secs_ignore_zero")]
     pub span_dedup_timeout: Option<Duration>,
@@ -311,8 +300,7 @@ impl DatadogConfigExtension for LambdaConfig {
                 capture_lambda_payload,
                 capture_lambda_payload_max_depth,
                 lambda_extension_compute_stats,
-                apm_error_tps,
-                apm_extra_sample_rate,
+                apm_error_sampler_enabled,
                 serverless_appsec_enabled,
                 appsec_waf_timeout,
                 api_security_enabled,
@@ -734,37 +722,30 @@ mod lambda_config_tests {
         assert!(!config.ext.dsm_consume_enabled);
     }
 
-    // ---- error sampler (apm_error_tps / apm_extra_sample_rate) ----
+    // ---- error sampler (apm_error_sampler_enabled) ----
 
     #[test]
-    fn apm_error_tps_defaults_to_ten() {
+    fn apm_error_sampler_enabled_defaults_to_false() {
         let config = load(|_| Ok(()));
-        assert_eq!(config.ext.apm_error_tps, 10.0);
-        assert_eq!(config.ext.apm_extra_sample_rate, 1.0);
+        assert!(!config.ext.apm_error_sampler_enabled);
     }
 
     #[test]
-    fn apm_error_tps_from_env() {
+    fn apm_error_sampler_enabled_from_env() {
         let config = load(|jail| {
-            jail.set_env("DD_APM_ERROR_TPS", "25");
-            jail.set_env("DD_APM_EXTRA_SAMPLE_RATE", "0.5");
+            jail.set_env("DD_APM_ERROR_SAMPLER_ENABLED", "true");
             Ok(())
         });
-        assert_eq!(config.ext.apm_error_tps, 25.0);
-        assert_eq!(config.ext.apm_extra_sample_rate, 0.5);
+        assert!(config.ext.apm_error_sampler_enabled);
     }
 
     #[test]
-    fn apm_error_tps_from_yaml() {
+    fn apm_error_sampler_enabled_from_yaml() {
         let config = load(|jail| {
-            jail.create_file(
-                "datadog.yaml",
-                "apm_error_tps: 0\napm_extra_sample_rate: 2\n",
-            )?;
+            jail.create_file("datadog.yaml", "apm_error_sampler_enabled: true\n")?;
             Ok(())
         });
-        assert_eq!(config.ext.apm_error_tps, 0.0);
-        assert_eq!(config.ext.apm_extra_sample_rate, 2.0);
+        assert!(config.ext.apm_error_sampler_enabled);
     }
 
     // ---- Duration fields ----

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -68,6 +68,17 @@ pub struct LambdaConfig {
     pub capture_lambda_payload: bool,
     pub capture_lambda_payload_max_depth: u32,
     pub lambda_extension_compute_stats: bool,
+
+    /// `DD_APM_ERROR_TPS` — target error traces per second rescued by the
+    /// agent-side error sampler when the extension computes stats. Matches the
+    /// Go trace agent's `apm_config.errors_per_second`. Default 10.0; `0`
+    /// disables the sampler (no rescue).
+    pub apm_error_tps: f64,
+    /// `DD_APM_EXTRA_SAMPLE_RATE` — extra raw sampling rate applied on top of
+    /// the computed error-sampler rate. Matches the Go trace agent's
+    /// `apm_config.extra_sample_rate`. Default 1.0.
+    pub apm_extra_sample_rate: f64,
+
     pub span_dedup_timeout: Option<Duration>,
     pub api_key_secret_reload_interval: Option<Duration>,
     pub serverless_appsec_enabled: bool,
@@ -134,6 +145,8 @@ impl Default for LambdaConfig {
             capture_lambda_payload: false,
             capture_lambda_payload_max_depth: 10,
             lambda_extension_compute_stats: false,
+            apm_error_tps: 10.0,
+            apm_extra_sample_rate: 1.0,
             span_dedup_timeout: None,
             api_key_secret_reload_interval: None,
             serverless_appsec_enabled: false,
@@ -198,6 +211,15 @@ pub struct LambdaConfigSource {
     /// APM trace stats locally instead of letting the backend do it.
     #[serde(deserialize_with = "deser_opt_bool")]
     pub lambda_extension_compute_stats: Option<bool>,
+
+    /// `DD_APM_ERROR_TPS` — error sampler target traces/sec. Flat env/YAML key
+    /// (`apm_error_tps`), unlike the Go agent's nested `apm_config.errors_per_second`.
+    #[serde(deserialize_with = "deser_opt_lossless")]
+    pub apm_error_tps: Option<f64>,
+    /// `DD_APM_EXTRA_SAMPLE_RATE` — error sampler extra sample rate. Flat
+    /// env/YAML key (`apm_extra_sample_rate`).
+    #[serde(deserialize_with = "deser_opt_lossless")]
+    pub apm_extra_sample_rate: Option<f64>,
 
     #[serde(deserialize_with = "deser_dur_secs_ignore_zero")]
     pub span_dedup_timeout: Option<Duration>,
@@ -280,6 +302,8 @@ impl DatadogConfigExtension for LambdaConfig {
                 capture_lambda_payload,
                 capture_lambda_payload_max_depth,
                 lambda_extension_compute_stats,
+                apm_error_tps,
+                apm_extra_sample_rate,
                 serverless_appsec_enabled,
                 appsec_waf_timeout,
                 api_security_enabled,
@@ -355,6 +379,7 @@ impl LambdaConfig {
 #[cfg_attr(coverage_nightly, coverage(off))] // Test modules skew coverage metrics
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
+#[allow(clippy::float_cmp)] // exact, representable config values (10.0, 1.0, ...) parsed deterministically
 mod lambda_config_tests {
     use datadog_agent_config::{Config as UpstreamConfig, flush_strategy::PeriodicStrategy};
     use figment::Jail;
@@ -698,6 +723,39 @@ mod lambda_config_tests {
     fn dsm_consume_enabled_defaults_false() {
         let config = load(|_| Ok(()));
         assert!(!config.ext.dsm_consume_enabled);
+    }
+
+    // ---- error sampler (apm_error_tps / apm_extra_sample_rate) ----
+
+    #[test]
+    fn apm_error_tps_defaults_to_ten() {
+        let config = load(|_| Ok(()));
+        assert_eq!(config.ext.apm_error_tps, 10.0);
+        assert_eq!(config.ext.apm_extra_sample_rate, 1.0);
+    }
+
+    #[test]
+    fn apm_error_tps_from_env() {
+        let config = load(|jail| {
+            jail.set_env("DD_APM_ERROR_TPS", "25");
+            jail.set_env("DD_APM_EXTRA_SAMPLE_RATE", "0.5");
+            Ok(())
+        });
+        assert_eq!(config.ext.apm_error_tps, 25.0);
+        assert_eq!(config.ext.apm_extra_sample_rate, 0.5);
+    }
+
+    #[test]
+    fn apm_error_tps_from_yaml() {
+        let config = load(|jail| {
+            jail.create_file(
+                "datadog.yaml",
+                "apm_error_tps: 0\napm_extra_sample_rate: 2\n",
+            )?;
+            Ok(())
+        });
+        assert_eq!(config.ext.apm_error_tps, 0.0);
+        assert_eq!(config.ext.apm_extra_sample_rate, 2.0);
     }
 
     // ---- Duration fields ----

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -69,11 +69,14 @@ pub struct LambdaConfig {
     pub capture_lambda_payload_max_depth: u32,
     pub lambda_extension_compute_stats: bool,
 
-    /// `DD_APM_ERROR_SAMPLER_ENABLED`: rescue errored trace chunks that would
+    /// `DD_SERVERLESS_ERROR_SAMPLER_ENABLED`: rescue errored trace chunks that would
     /// otherwise be dropped, on the `lambda_extension_compute_stats` path. The
-    /// sampler runs in `AlwaysKeep` mode, so this is a plain on/off switch:
-    /// enabled rescues every errored chunk. See APMSVLS-469.
-    pub apm_error_sampler_enabled: bool,
+    /// sampler runs in `AlwaysKeep` mode, so this is a plain on/off switch with
+    /// no volume ceiling: enabled rescues every errored chunk, whatever the
+    /// tracer's sampling rate. A function that errors on most invocations under
+    /// `DD_TRACE_SAMPLE_RATE=0.01` will ingest close to every trace, not 1%.
+    /// See APMSVLS-469.
+    pub serverless_error_sampler_enabled: bool,
 
     pub span_dedup_timeout: Option<Duration>,
     pub api_key_secret_reload_interval: Option<Duration>,
@@ -141,7 +144,7 @@ impl Default for LambdaConfig {
             capture_lambda_payload: false,
             capture_lambda_payload_max_depth: 10,
             lambda_extension_compute_stats: false,
-            apm_error_sampler_enabled: false,
+            serverless_error_sampler_enabled: false,
             span_dedup_timeout: None,
             api_key_secret_reload_interval: None,
             serverless_appsec_enabled: false,
@@ -208,7 +211,7 @@ pub struct LambdaConfigSource {
     pub lambda_extension_compute_stats: Option<bool>,
 
     #[serde(deserialize_with = "deser_opt_bool")]
-    pub apm_error_sampler_enabled: Option<bool>,
+    pub serverless_error_sampler_enabled: Option<bool>,
 
     #[serde(deserialize_with = "deser_dur_secs_ignore_zero")]
     pub span_dedup_timeout: Option<Duration>,
@@ -291,7 +294,7 @@ impl DatadogConfigExtension for LambdaConfig {
                 capture_lambda_payload,
                 capture_lambda_payload_max_depth,
                 lambda_extension_compute_stats,
-                apm_error_sampler_enabled,
+                serverless_error_sampler_enabled,
                 serverless_appsec_enabled,
                 appsec_waf_timeout,
                 api_security_enabled,
@@ -712,30 +715,30 @@ mod lambda_config_tests {
         assert!(!config.ext.dsm_consume_enabled);
     }
 
-    // ---- error sampler (apm_error_sampler_enabled) ----
+    // ---- error sampler (serverless_error_sampler_enabled) ----
 
     #[test]
-    fn apm_error_sampler_enabled_defaults_to_false() {
+    fn serverless_error_sampler_enabled_defaults_to_false() {
         let config = load(|_| Ok(()));
-        assert!(!config.ext.apm_error_sampler_enabled);
+        assert!(!config.ext.serverless_error_sampler_enabled);
     }
 
     #[test]
-    fn apm_error_sampler_enabled_from_env() {
+    fn serverless_error_sampler_enabled_from_env() {
         let config = load(|jail| {
-            jail.set_env("DD_APM_ERROR_SAMPLER_ENABLED", "true");
+            jail.set_env("DD_SERVERLESS_ERROR_SAMPLER_ENABLED", "true");
             Ok(())
         });
-        assert!(config.ext.apm_error_sampler_enabled);
+        assert!(config.ext.serverless_error_sampler_enabled);
     }
 
     #[test]
-    fn apm_error_sampler_enabled_from_yaml() {
+    fn serverless_error_sampler_enabled_from_yaml() {
         let config = load(|jail| {
-            jail.create_file("datadog.yaml", "apm_error_sampler_enabled: true\n")?;
+            jail.create_file("datadog.yaml", "serverless_error_sampler_enabled: true\n")?;
             Ok(())
         });
-        assert!(config.ext.apm_error_sampler_enabled);
+        assert!(config.ext.serverless_error_sampler_enabled);
     }
 
     // ---- Duration fields ----

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -69,17 +69,10 @@ pub struct LambdaConfig {
     pub capture_lambda_payload_max_depth: u32,
     pub lambda_extension_compute_stats: bool,
 
-    /// `DD_APM_ERROR_SAMPLER_ENABLED` — whether the agent-side error sampler
-    /// rescues errored trace chunks that would otherwise be dropped, on the
-    /// `lambda_extension_compute_stats` path.
-    ///
-    /// Defaults to `false` while the feature rolls out as opt-in; the plan is
-    /// to flip the default to `true` once it has soaked. The sampler runs in
-    /// `AlwaysKeep` mode (hardcoded in `main.rs`), so this is a plain on/off
-    /// switch: enabled rescues every errored chunk. The Go agent's
-    /// rate-limiting knobs (`apm_config.errors_per_second` /
-    /// `extra_sample_rate`) are intentionally not exposed yet — they only have
-    /// meaning in `RateLimited` mode and will be added with it. See APMSVLS-469.
+    /// `DD_APM_ERROR_SAMPLER_ENABLED`: rescue errored trace chunks that would
+    /// otherwise be dropped, on the `lambda_extension_compute_stats` path. The
+    /// sampler runs in `AlwaysKeep` mode, so this is a plain on/off switch:
+    /// enabled rescues every errored chunk. See APMSVLS-469.
     pub apm_error_sampler_enabled: bool,
 
     pub span_dedup_timeout: Option<Duration>,
@@ -214,8 +207,6 @@ pub struct LambdaConfigSource {
     #[serde(deserialize_with = "deser_opt_bool")]
     pub lambda_extension_compute_stats: Option<bool>,
 
-    /// `DD_APM_ERROR_SAMPLER_ENABLED` — toggles the agent-side error sampler.
-    /// Flat env/YAML key (`apm_error_sampler_enabled`).
     #[serde(deserialize_with = "deser_opt_bool")]
     pub apm_error_sampler_enabled: Option<bool>,
 

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -2293,7 +2293,7 @@ mod tests {
                         appsec: None,
                         processor: Arc::new(trace_processor::ServerlessTraceProcessor {
                             obfuscation_config: Arc::new(ObfuscationConfig::new().expect("Failed to create ObfuscationConfig")),
-                            error_sampler: trace_processor::default_error_sampler(),
+                            error_sampler: trace_processor::enabled_error_sampler(),
                         }),
                         trace_tx: tokio::sync::mpsc::channel(1).0,
                         stats_generator: Arc::new(StatsGenerator::new(stats_concentrator_handle)),
@@ -2404,7 +2404,7 @@ mod tests {
                 obfuscation_config: Arc::new(
                     ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
                 ),
-                error_sampler: trace_processor::default_error_sampler(),
+                error_sampler: trace_processor::enabled_error_sampler(),
             }),
             trace_tx: tokio::sync::mpsc::channel(1).0,
             stats_generator: Arc::new(StatsGenerator::new(stats_concentrator_handle)),
@@ -3043,7 +3043,7 @@ mod tests {
                 obfuscation_config: Arc::new(
                     ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
                 ),
-                error_sampler: trace_processor::default_error_sampler(),
+                error_sampler: trace_processor::enabled_error_sampler(),
             }),
             trace_tx: tokio::sync::mpsc::channel(1).0,
             stats_generator: Arc::new(StatsGenerator::new(stats_concentrator_handle)),
@@ -3625,7 +3625,7 @@ mod tests {
                 obfuscation_config: Arc::new(
                     ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
                 ),
-                error_sampler: trace_processor::default_error_sampler(),
+                error_sampler: trace_processor::enabled_error_sampler(),
             }),
             trace_tx,
             stats_generator: Arc::new(StatsGenerator::new(stats_concentrator_handle)),

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -2293,6 +2293,7 @@ mod tests {
                         appsec: None,
                         processor: Arc::new(trace_processor::ServerlessTraceProcessor {
                             obfuscation_config: Arc::new(ObfuscationConfig::new().expect("Failed to create ObfuscationConfig")),
+                            error_sampler: trace_processor::default_error_sampler(),
                         }),
                         trace_tx: tokio::sync::mpsc::channel(1).0,
                         stats_generator: Arc::new(StatsGenerator::new(stats_concentrator_handle)),
@@ -2403,6 +2404,7 @@ mod tests {
                 obfuscation_config: Arc::new(
                     ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
                 ),
+                error_sampler: trace_processor::default_error_sampler(),
             }),
             trace_tx: tokio::sync::mpsc::channel(1).0,
             stats_generator: Arc::new(StatsGenerator::new(stats_concentrator_handle)),
@@ -3041,6 +3043,7 @@ mod tests {
                 obfuscation_config: Arc::new(
                     ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
                 ),
+                error_sampler: trace_processor::default_error_sampler(),
             }),
             trace_tx: tokio::sync::mpsc::channel(1).0,
             stats_generator: Arc::new(StatsGenerator::new(stats_concentrator_handle)),
@@ -3622,6 +3625,7 @@ mod tests {
                 obfuscation_config: Arc::new(
                     ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
                 ),
+                error_sampler: trace_processor::default_error_sampler(),
             }),
             trace_tx,
             stats_generator: Arc::new(StatsGenerator::new(stats_concentrator_handle)),

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -64,7 +64,7 @@ impl StatsComputedBy {
 pub struct ServerlessTraceProcessor {
     pub obfuscation_config: Arc<obfuscation_config::ObfuscationConfig>,
     /// Agent-side error sampler. On the `lambda_extension_compute_stats` path,
-    /// errored chunks that would be dropped (priority <= 0) get a second look
+    /// errored chunks that would be dropped (`AutoDrop`) get a second look
     /// and are rescued up to `apm_error_tps` traces/sec. Shared across
     /// invocations (std Mutex, not tokio: consulted from the synchronous
     /// `process_traces`) so its rolling-window rate limiter accumulates.
@@ -73,7 +73,7 @@ pub struct ServerlessTraceProcessor {
 
 impl ServerlessTraceProcessor {
     /// Consult the error sampler for a chunk that would otherwise be dropped
-    /// (priority <= 0). Returns `true` to keep (rescue) the chunk. Only errored
+    /// (`AutoDrop`). Returns `true` to keep (rescue) the chunk. Only errored
     /// traces are candidates; on a keep, stamps `_dd.errors_sr` on the root span.
     fn rescue_error_chunk(&self, chunk: &mut pb::TraceChunk, env: &str, now_secs: i64) -> bool {
         let Ok(root_idx) = trace_utils::get_root_span_index(&chunk.spans) else {
@@ -503,8 +503,8 @@ impl TraceProcessor for ServerlessTraceProcessor {
         // Remove sampled-out chunks so they won't be sent to Datadog.
         // Sampled-out chunks are preserved in payloads_for_stats above so their
         // stats are still counted. SamplerPriority::None (-128) means no explicit priority
-        // was set and the trace is kept; drop priorities are SamplerPriority::AutoDrop (0)
-        // and UserDrop (-1, not represented in SamplerPriority).
+        // was set and the trace is kept. Only SamplerPriority::AutoDrop (0) chunks are
+        // rescue candidates; negative priorities are explicit drops and are honored.
         if config.ext.lambda_extension_compute_stats
             && let TracerPayloadCollection::V07(ref mut tracer_payloads) = payload
         {
@@ -521,8 +521,13 @@ impl TraceProcessor for ServerlessTraceProcessor {
                     if chunk.priority > 0 || chunk.priority == SamplerPriority::None as i32 {
                         return true;
                     }
-                    // Otherwise this chunk would be dropped; give errored ones a
-                    // second look via the error sampler (rescue within budget).
+                    // A negative priority is an explicit drop (a tracer sampling rule
+                    // or MANUAL_DROP): honor it and never rescue, as the Agent does.
+                    if chunk.priority < 0 {
+                        return false;
+                    }
+                    // AutoDrop (0): give errored chunks a second look via the error
+                    // sampler (rescue within budget).
                     self.rescue_error_chunk(chunk, env, now_secs)
                 });
             }
@@ -1356,8 +1361,8 @@ mod tests {
     }
 
     /// On the compute-stats path, the error sampler rescues errored chunks that
-    /// would otherwise be dropped (priority <= 0), stamping `_dd.errors_sr`,
-    /// while non-errored P0 chunks are still dropped.
+    /// would otherwise be dropped (`AutoDrop`), stamping `_dd.errors_sr`, while
+    /// non-errored P0 chunks and explicit user drops are still dropped.
     #[test]
     fn test_error_sampler_rescues_errored_p0_chunks() {
         use libdd_trace_obfuscation::obfuscation_config::ObfuscationConfig;
@@ -1412,11 +1417,12 @@ mod tests {
         };
 
         // trace 1: kept normally (priority 1). trace 2: errored P0 (rescued).
-        // trace 3: non-errored P0 (dropped).
+        // trace 3: non-errored P0 (dropped). trace 4: errored user drop (dropped).
         let traces = vec![
             vec![make_span(1, 1.0, 0)],
             vec![make_span(2, 0.0, 1)],
             vec![make_span(3, 0.0, 0)],
+            vec![make_span(4, -1.0, 1)],
         ];
 
         let (payload_info, _stats) =
@@ -1438,6 +1444,7 @@ mod tests {
         assert!(kept.contains(&1), "priority-1 trace kept");
         assert!(kept.contains(&2), "errored P0 trace rescued");
         assert!(!kept.contains(&3), "non-errored P0 trace dropped");
+        assert!(!kept.contains(&4), "errored user-drop trace not rescued");
 
         let rescued_root = backend_payloads
             .iter()

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -66,12 +66,11 @@ pub struct ServerlessTraceProcessor {
     /// Agent-side error sampler. On the `lambda_extension_compute_stats` path,
     /// errored chunks that would be dropped (`AutoDrop`) get a second look and
     /// may be rescued. In the current `AlwaysKeep` mode every errored chunk is
-    /// rescued (`apm_error_tps` only gates on/off); the `apm_error_tps`
-    /// traces/sec budget applies in `RateLimited` mode. Shared across
-    /// invocations (std Mutex, not tokio: consulted from the synchronous
-    /// `process_traces`) so `RateLimited`'s rolling-window rate limiter
-    /// accumulates. `AlwaysKeep` holds no state, so the lock is uncontended
-    /// bookkeeping there.
+    /// rescued, gated only by `apm_error_sampler_enabled`; a traces/sec budget
+    /// applies in `RateLimited` mode. Shared across invocations (std Mutex, not
+    /// tokio: consulted from the synchronous `process_traces`) so
+    /// `RateLimited`'s rolling-window rate limiter accumulates. `AlwaysKeep`
+    /// holds no state, so the lock is uncontended bookkeeping there.
     pub error_sampler: Arc<std::sync::Mutex<ErrorsSampler>>,
 }
 

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -15,7 +15,9 @@ use crate::traces::{
     LAMBDA_RUNTIME_URL_PREFIX, LAMBDA_STATSD_URL_PREFIX,
 };
 use async_trait::async_trait;
-use datadog_agent_trace_sampler::{ErrorsSampler, SampleDecision, SpanView, TraceView};
+use datadog_agent_trace_sampler::{
+    ErrorSamplerConfig, ErrorSamplerMode, ErrorsSampler, SampleDecision, SpanView, TraceView,
+};
 use libdd_common::Endpoint;
 use libdd_trace_obfuscation::obfuscate::obfuscate_span;
 use libdd_trace_obfuscation::obfuscation_config;
@@ -74,7 +76,95 @@ pub struct ServerlessTraceProcessor {
     pub error_sampler: Arc<std::sync::Mutex<ErrorsSampler>>,
 }
 
+/// Borrow-only view of a span for the error sampler.
+fn span_view(span: &Span) -> SpanView<'_> {
+    SpanView {
+        service: &span.service,
+        name: &span.name,
+        resource: &span.resource,
+        error: span.error != 0,
+        http_status_code: span.meta.get("http.status_code").map(String::as_str),
+        error_type: span.meta.get("error.type").map(String::as_str),
+    }
+}
+
+/// Builds the error sampler as the extension ships it, enabled or disabled by
+/// `apm_error_sampler_enabled`. Shared by `main` and the tests so tests
+/// exercise the shipping configuration.
+///
+/// The mode is hardcoded for now (config wiring via `DD_APM_ERROR_SAMPLER_MODE`
+/// is deferred): Lambda's per-invocation trace volume is low and freeze/thaw
+/// breaks the `RateLimited` mode's 30s wall-clock window, so `AlwaysKeep` is
+/// the right default. See APMSVLS-469.
+#[must_use]
+pub fn new_error_sampler(enabled: bool) -> Arc<std::sync::Mutex<ErrorsSampler>> {
+    Arc::new(std::sync::Mutex::new(ErrorsSampler::new(
+        ErrorSamplerConfig {
+            mode: ErrorSamplerMode::AlwaysKeep,
+            // AlwaysKeep derives its disabled flag from `target_tps <= 0.0`, so
+            // the boolean maps onto any positive value vs. zero. The magnitude
+            // is unused until RateLimited is wired up, which is when
+            // DD_APM_ERROR_TPS becomes meaningful and gets exposed.
+            target_tps: if enabled { 1.0 } else { 0.0 },
+            extra_sample_rate: 1.0,
+        },
+    )))
+}
+
 impl ServerlessTraceProcessor {
+    /// Removes sampled-out chunks so they won't be sent to Datadog, then drops
+    /// any payload left without chunks. `SamplerPriority::None` (-128) means no
+    /// explicit priority was set and the trace is kept. Only
+    /// `SamplerPriority::AutoDrop` (0) chunks are rescue candidates; negative
+    /// priorities are explicit drops and are honored.
+    fn drop_sampled_out_chunks(&self, tracer_payloads: &mut Vec<pb::TracerPayload>) {
+        // Ask the sampler itself whether it is disabled, rather than
+        // re-deriving that from config: one lock here instead of per chunk,
+        // and no second definition of "disabled" to keep in sync.
+        let rescue_enabled = !self
+            .error_sampler
+            .lock()
+            .expect("error sampler poisoned")
+            .is_disabled();
+        // Only RateLimited's rolling window reads the clock, and only rescue
+        // candidates reach it.
+        let now_secs: i64 = if rescue_enabled {
+            std::time::UNIX_EPOCH
+                .elapsed()
+                .unwrap_or_default()
+                .as_secs()
+                .try_into()
+                .unwrap_or_default()
+        } else {
+            0
+        };
+        for tp in tracer_payloads.iter_mut() {
+            // The sampler keys its per-signature rate limits on the env the
+            // tracer reported for this payload, as the Agent does.
+            let env = tp.env.as_str();
+            tp.chunks.retain_mut(|chunk| {
+                // Explicit keeps and "no priority set" pass through unchanged.
+                if chunk.priority > 0 || chunk.priority == SamplerPriority::None as i32 {
+                    return true;
+                }
+                // A negative priority is an explicit drop (a tracer sampling rule
+                // or MANUAL_DROP): honor it and never rescue, as the Agent does.
+                if chunk.priority < 0 {
+                    return false;
+                }
+                // A disabled sampler drops every chunk; skip building views
+                // for a decision that is already known.
+                if !rescue_enabled {
+                    return false;
+                }
+                // AutoDrop (0): give errored chunks a second look via the error
+                // sampler (rescue within budget).
+                self.rescue_error_chunk(chunk, env, now_secs)
+            });
+        }
+        tracer_payloads.retain(|tp| !tp.chunks.is_empty());
+    }
+
     /// Consult the error sampler for a chunk that would otherwise be dropped
     /// (`AutoDrop`). Returns `true` to keep (rescue) the chunk. Only errored
     /// traces are candidates; on a keep, stamps `_dd.errors_sr` on the root span.
@@ -92,33 +182,27 @@ impl ServerlessTraceProcessor {
         // Build the borrow-only views in a scope so they (and their immutable
         // borrow of chunk.spans) drop before the `_dd.errors_sr` mutation below.
         let decision = {
-            let views: Vec<SpanView> = chunk
-                .spans
-                .iter()
-                .map(|s| SpanView {
-                    service: &s.service,
-                    name: &s.name,
-                    resource: &s.resource,
-                    error: s.error != 0,
-                    http_status_code: s.meta.get("http.status_code").map(String::as_str),
-                    error_type: s.meta.get("error.type").map(String::as_str),
-                })
-                .collect();
+            let mut sampler = self.error_sampler.lock().expect("error sampler poisoned");
             let root = &chunk.spans[root_idx];
+            // AlwaysKeep ignores the spans apart from a bounds check on
+            // root_index, so only the root view is built there. RateLimited
+            // needs every span to compute the trace signature.
+            let root_view;
+            let all_views;
+            let (spans, root_index) = if matches!(*sampler, ErrorsSampler::AlwaysKeep { .. }) {
+                root_view = [span_view(root)];
+                (&root_view[..], 0)
+            } else {
+                all_views = chunk.spans.iter().map(span_view).collect::<Vec<SpanView>>();
+                (&all_views[..], root_idx)
+            };
             let trace = TraceView {
                 env,
                 trace_id: root.trace_id,
-                root_index: root_idx,
+                root_index,
                 root_global_sample_rate: root.metrics.get("_sample_rate").copied().unwrap_or(1.0),
-                spans: &views,
+                spans,
             };
-            // Recover through poisoning: the sampler holds only rolling-window
-            // counters, so a partially updated bucket is far cheaper than
-            // disabling error rescue for the rest of the sandbox's life.
-            let mut sampler = self
-                .error_sampler
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
             sampler.sample(now_secs, &trace)
         };
 
@@ -507,53 +591,12 @@ impl TraceProcessor for ServerlessTraceProcessor {
             }
         };
 
-        // Remove sampled-out chunks so they won't be sent to Datadog.
-        // Sampled-out chunks are preserved in payloads_for_stats above so their
-        // stats are still counted. SamplerPriority::None (-128) means no explicit priority
-        // was set and the trace is kept. Only SamplerPriority::AutoDrop (0) chunks are
-        // rescue candidates; negative priorities are explicit drops and are honored.
+        // Sampled-out chunks are preserved in payloads_for_stats above, so their
+        // stats are still counted after they are removed here.
         if config.ext.lambda_extension_compute_stats
             && let TracerPayloadCollection::V07(ref mut tracer_payloads) = payload
         {
-            let now_secs: i64 = std::time::UNIX_EPOCH
-                .elapsed()
-                .expect("unable to poll clock, unrecoverable")
-                .as_secs()
-                .try_into()
-                .unwrap_or_default();
-            // Ask the sampler itself whether it is disabled, rather than
-            // re-deriving that from config: one lock here instead of per chunk,
-            // and no second definition of "disabled" to keep in sync.
-            let rescue_enabled = !self
-                .error_sampler
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .is_disabled();
-            for tp in tracer_payloads.iter_mut() {
-                // The sampler keys its per-signature rate limits on the env the
-                // tracer reported for this payload, as the Agent does.
-                let env = tp.env.as_str();
-                tp.chunks.retain_mut(|chunk| {
-                    // Explicit keeps and "no priority set" pass through unchanged.
-                    if chunk.priority > 0 || chunk.priority == SamplerPriority::None as i32 {
-                        return true;
-                    }
-                    // A negative priority is an explicit drop (a tracer sampling rule
-                    // or MANUAL_DROP): honor it and never rescue, as the Agent does.
-                    if chunk.priority < 0 {
-                        return false;
-                    }
-                    // A disabled sampler drops every chunk; skip building views
-                    // for a decision that is already known.
-                    if !rescue_enabled {
-                        return false;
-                    }
-                    // AutoDrop (0): give errored chunks a second look via the error
-                    // sampler (rescue within budget).
-                    self.rescue_error_chunk(chunk, env, now_secs)
-                });
-            }
-            tracer_payloads.retain(|tp| !tp.chunks.is_empty());
+            self.drop_sampled_out_chunks(tracer_payloads);
             if tracer_payloads.is_empty() {
                 return (None, payloads_for_stats);
             }
@@ -702,14 +745,12 @@ impl SendingTraceProcessor {
     }
 }
 
-/// Default error sampler for constructing `ServerlessTraceProcessor` in tests
+/// Enabled error sampler for constructing `ServerlessTraceProcessor` in tests
 /// (sampler behavior itself is unit-tested in the `datadog-agent-trace-sampler`
 /// crate; these call sites just need a value).
 #[cfg(test)]
 pub(crate) fn default_error_sampler() -> Arc<std::sync::Mutex<ErrorsSampler>> {
-    Arc::new(std::sync::Mutex::new(ErrorsSampler::new(
-        datadog_agent_trace_sampler::ErrorSamplerConfig::default(),
-    )))
+    new_error_sampler(true)
 }
 
 #[cfg(test)]
@@ -1557,6 +1598,68 @@ mod tests {
         assert!(
             root.metrics.contains_key("_dd.errors_sr"),
             "_dd.errors_sr stamped on rescued root"
+        );
+    }
+
+    /// With the error sampler disabled (the shipping default,
+    /// `apm_error_sampler_enabled: false`), errored P0 chunks are dropped as
+    /// before: no rescue, no `_dd.errors_sr`.
+    #[test]
+    fn test_disabled_error_sampler_drops_errored_p0_chunks() {
+        use libdd_trace_obfuscation::obfuscation_config::ObfuscationConfig;
+
+        let config = Arc::new(Config {
+            apm_dd_url: "https://trace.agent.datadoghq.com".to_string(),
+            ext: crate::config::LambdaConfig {
+                lambda_extension_compute_stats: true,
+                ..Default::default()
+            },
+            ..Config::default()
+        });
+        let tags_provider = Arc::new(Provider::new(
+            config.clone(),
+            "lambda".to_string(),
+            &std::collections::HashMap::from([(
+                "function_arn".to_string(),
+                "test-arn".to_string(),
+            )]),
+        ));
+        let processor = ServerlessTraceProcessor {
+            obfuscation_config: Arc::new(
+                ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
+            ),
+            error_sampler: new_error_sampler(false),
+        };
+
+        let header_tags = tracer_header_tags::TracerHeaderTags {
+            lang: "rust",
+            lang_version: "1.0",
+            lang_interpreter: "",
+            lang_vendor: "",
+            tracer_version: "1.0",
+            container_id: "",
+            generic: tracer_header_tags::TracerGenericTags::default(),
+        };
+
+        let mut metrics = HashMap::new();
+        metrics.insert("_sampling_priority_v1".to_string(), 0.0);
+        let traces = vec![vec![pb::Span {
+            trace_id: 1,
+            span_id: 1,
+            parent_id: 0,
+            error: 1,
+            metrics,
+            service: "svc".to_string(),
+            name: "op".to_string(),
+            resource: "res".to_string(),
+            ..Default::default()
+        }]];
+
+        let (payload_info, _stats) =
+            processor.process_traces(config, tags_provider, header_tags, traces, 0, None);
+        assert!(
+            payload_info.is_none(),
+            "errored P0 trace must stay dropped when the error sampler is disabled"
         );
     }
 

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -66,8 +66,8 @@ impl StatsComputedBy {
 pub struct ServerlessTraceProcessor {
     pub obfuscation_config: Arc<obfuscation_config::ObfuscationConfig>,
     /// Rescues errored `AutoDrop` chunks on the `lambda_extension_compute_stats`
-    /// path. Shared across invocations so `RateLimited`'s rolling-window rate
-    /// limiter accumulates; a std Mutex rather than tokio because
+    /// path. Shared across invocations so a stateful mode (`RateLimited`) would
+    /// keep its rolling window; a std Mutex rather than tokio because
     /// `process_traces` is synchronous.
     pub error_sampler: Arc<std::sync::Mutex<ErrorsSampler>>,
 }
@@ -110,10 +110,10 @@ impl ServerlessTraceProcessor {
     /// `SamplerPriority::AutoDrop` (0) chunks are rescue candidates; negative
     /// priorities are explicit drops and are honored.
     fn drop_sampled_out_chunks(&self, tracer_payloads: &mut Vec<pb::TracerPayload>) {
-        // Hoisted out of the loop: one lock instead of one per chunk.
-        // Recover through poisoning: the sampler holds only rolling-window
-        // counters, so a partially updated bucket is far cheaper than disabling
-        // error rescue for the rest of the sandbox's life.
+        // Read once up front so non-errored and explicitly-dropped chunks never
+        // touch the lock. Recover through poisoning: the sampler holds only
+        // rolling-window counters, so a partially updated bucket is far cheaper
+        // than disabling error rescue for the rest of the sandbox's life.
         let rescue_enabled = !self
             .error_sampler
             .lock()
@@ -157,44 +157,34 @@ impl ServerlessTraceProcessor {
     /// (`AutoDrop`). Returns `true` to keep (rescue) the chunk. Only errored
     /// traces are candidates; on a keep, stamps `_dd.errors_sr` on the root span.
     fn rescue_error_chunk(&self, chunk: &mut pb::TraceChunk, env: &str, now_secs: i64) -> bool {
-        let Ok(root_idx) = trace_utils::get_root_span_index(&chunk.spans) else {
-            return false; // no identifiable root span
-        };
         // Only errored traces are rescue candidates (matches the Go agent, which
         // only routes error traces through the ErrorTPS ScoreSampler). An error
-        // anywhere in the chunk counts, not just on the root span.
+        // anywhere in the chunk counts, not just on the root span. Checked before
+        // the root-span search because non-errored chunks are the common case on
+        // this path.
         if !chunk.spans.iter().any(|s| s.error != 0) {
             return false;
         }
+        let Ok(root_idx) = trace_utils::get_root_span_index(&chunk.spans) else {
+            return false; // no identifiable root span
+        };
 
         // Scoped so the views release their borrow of chunk.spans before the
         // `_dd.errors_sr` mutation below.
         let decision = {
-            let mut sampler = self
-                .error_sampler
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
             let root = &chunk.spans[root_idx];
-            // AlwaysKeep only bounds-checks root_index, so building the root
-            // view alone is enough. RateLimited needs every span to compute
-            // the trace signature.
-            let root_view;
-            let all_views;
-            let (spans, root_index) = if matches!(*sampler, ErrorsSampler::AlwaysKeep { .. }) {
-                root_view = [span_view(root)];
-                (&root_view[..], 0)
-            } else {
-                all_views = chunk.spans.iter().map(span_view).collect::<Vec<SpanView>>();
-                (&all_views[..], root_idx)
-            };
+            let views = chunk.spans.iter().map(span_view).collect::<Vec<SpanView>>();
             let trace = TraceView {
                 env,
                 trace_id: root.trace_id,
-                root_index,
+                root_index: root_idx,
                 root_global_sample_rate: root.metrics.get("_sample_rate").copied().unwrap_or(1.0),
-                spans,
+                spans: &views,
             };
-            sampler.sample(now_secs, &trace)
+            self.error_sampler
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .sample(now_secs, &trace)
         };
 
         match decision {

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -737,7 +737,7 @@ impl SendingTraceProcessor {
 
 /// Enabled error sampler for constructing `ServerlessTraceProcessor` in tests.
 #[cfg(test)]
-pub(crate) fn default_error_sampler() -> Arc<std::sync::Mutex<ErrorsSampler>> {
+pub(crate) fn enabled_error_sampler() -> Arc<std::sync::Mutex<ErrorsSampler>> {
     new_error_sampler(true)
 }
 
@@ -863,7 +863,7 @@ mod tests {
             obfuscation_config: Arc::new(
                 ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
             ),
-            error_sampler: default_error_sampler(),
+            error_sampler: enabled_error_sampler(),
         };
         let config = create_test_config();
         let tags_provider = create_tags_provider(config.clone());
@@ -1342,7 +1342,7 @@ mod tests {
             obfuscation_config: Arc::new(
                 ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
             ),
-            error_sampler: default_error_sampler(),
+            error_sampler: enabled_error_sampler(),
         };
 
         let header_tags = tracer_header_tags::TracerHeaderTags {
@@ -1438,7 +1438,7 @@ mod tests {
             obfuscation_config: Arc::new(
                 ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
             ),
-            error_sampler: default_error_sampler(),
+            error_sampler: enabled_error_sampler(),
         };
 
         let header_tags = tracer_header_tags::TracerHeaderTags {
@@ -1535,7 +1535,7 @@ mod tests {
             obfuscation_config: Arc::new(
                 ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
             ),
-            error_sampler: default_error_sampler(),
+            error_sampler: enabled_error_sampler(),
         };
 
         let header_tags = tracer_header_tags::TracerHeaderTags {
@@ -1676,7 +1676,7 @@ mod tests {
             obfuscation_config: Arc::new(
                 ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
             ),
-            error_sampler: default_error_sampler(),
+            error_sampler: enabled_error_sampler(),
         };
         let header_tags = tracer_header_tags::TracerHeaderTags {
             lang: "rust",
@@ -1755,7 +1755,7 @@ mod tests {
             obfuscation_config: Arc::new(
                 ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
             ),
-            error_sampler: default_error_sampler(),
+            error_sampler: enabled_error_sampler(),
         };
         let header_tags = tracer_header_tags::TracerHeaderTags {
             lang: "rust",
@@ -1861,7 +1861,7 @@ mod tests {
             obfuscation_config: Arc::new(
                 ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
             ),
-            error_sampler: default_error_sampler(),
+            error_sampler: enabled_error_sampler(),
         };
         let header_tags = tracer_header_tags::TracerHeaderTags {
             lang: "rust",
@@ -2269,7 +2269,7 @@ mod tests {
                     obfuscation_config: Arc::new(
                         ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
                     ),
-                    error_sampler: default_error_sampler(),
+                    error_sampler: enabled_error_sampler(),
                 }),
                 trace_tx,
                 stats_generator: Arc::new(StatsGenerator::new(concentrator_handle.clone())),

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -508,7 +508,6 @@ impl TraceProcessor for ServerlessTraceProcessor {
         if config.ext.lambda_extension_compute_stats
             && let TracerPayloadCollection::V07(ref mut tracer_payloads) = payload
         {
-            let env = config.env.as_deref().unwrap_or_default();
             let now_secs: i64 = std::time::UNIX_EPOCH
                 .elapsed()
                 .expect("unable to poll clock, unrecoverable")
@@ -516,6 +515,9 @@ impl TraceProcessor for ServerlessTraceProcessor {
                 .try_into()
                 .unwrap_or_default();
             for tp in tracer_payloads.iter_mut() {
+                // The sampler keys its per-signature rate limits on the env the
+                // tracer reported for this payload, as the Agent does.
+                let env = tp.env.as_str();
                 tp.chunks.retain_mut(|chunk| {
                     // Explicit keeps and "no priority set" pass through unchanged.
                     if chunk.priority > 0 || chunk.priority == SamplerPriority::None as i32 {

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -64,10 +64,14 @@ impl StatsComputedBy {
 pub struct ServerlessTraceProcessor {
     pub obfuscation_config: Arc<obfuscation_config::ObfuscationConfig>,
     /// Agent-side error sampler. On the `lambda_extension_compute_stats` path,
-    /// errored chunks that would be dropped (`AutoDrop`) get a second look
-    /// and are rescued up to `apm_error_tps` traces/sec. Shared across
+    /// errored chunks that would be dropped (`AutoDrop`) get a second look and
+    /// may be rescued. In the current `AlwaysKeep` mode every errored chunk is
+    /// rescued (`apm_error_tps` only gates on/off); the `apm_error_tps`
+    /// traces/sec budget applies in `RateLimited` mode. Shared across
     /// invocations (std Mutex, not tokio: consulted from the synchronous
-    /// `process_traces`) so its rolling-window rate limiter accumulates.
+    /// `process_traces`) so `RateLimited`'s rolling-window rate limiter
+    /// accumulates. `AlwaysKeep` holds no state, so the lock is uncontended
+    /// bookkeeping there.
     pub error_sampler: Arc<std::sync::Mutex<ErrorsSampler>>,
 }
 

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -85,10 +85,11 @@ fn span_view(span: &Span) -> SpanView<'_> {
 }
 
 /// Builds the error sampler as the extension ships it, enabled or disabled by
-/// `apm_error_sampler_enabled`.
+/// `serverless_error_sampler_enabled`.
 ///
 /// The mode is hardcoded to `AlwaysKeep`: Lambda's per-invocation trace volume
-/// is low, and freeze/thaw breaks `RateLimited`'s 30s wall-clock window.
+/// is low, and freeze/thaw breaks `RateLimited`'s 30s wall-clock window. There
+/// is therefore no rate ceiling when enabled: every errored chunk is rescued.
 #[must_use]
 pub fn new_error_sampler(enabled: bool) -> Arc<std::sync::Mutex<ErrorsSampler>> {
     Arc::new(std::sync::Mutex::new(ErrorsSampler::new(

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -110,10 +110,13 @@ impl ServerlessTraceProcessor {
     /// priorities are explicit drops and are honored.
     fn drop_sampled_out_chunks(&self, tracer_payloads: &mut Vec<pb::TracerPayload>) {
         // Hoisted out of the loop: one lock instead of one per chunk.
+        // Recover through poisoning: the sampler holds only rolling-window
+        // counters, so a partially updated bucket is far cheaper than disabling
+        // error rescue for the rest of the sandbox's life.
         let rescue_enabled = !self
             .error_sampler
             .lock()
-            .expect("error sampler poisoned")
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .is_disabled();
         // Only RateLimited's rolling window reads the clock, and only rescue
         // candidates reach it.
@@ -166,7 +169,10 @@ impl ServerlessTraceProcessor {
         // Scoped so the views release their borrow of chunk.spans before the
         // `_dd.errors_sr` mutation below.
         let decision = {
-            let mut sampler = self.error_sampler.lock().expect("error sampler poisoned");
+            let mut sampler = self
+                .error_sampler
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             let root = &chunk.spans[root_idx];
             // AlwaysKeep only bounds-checks root_index, so building the root
             // view alone is enough. RateLimited needs every span to compute

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -532,8 +532,9 @@ impl TraceProcessor for ServerlessTraceProcessor {
                     if chunk.priority < 0 {
                         return false;
                     }
-                    // AutoDrop (0): give errored chunks a second look via the error
-                    // sampler (rescue within budget).
+                    if config.ext.apm_error_tps <= 0.0 {
+                        return false;
+                    }
                     self.rescue_error_chunk(chunk, env, now_secs)
                 });
             }

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -518,6 +518,14 @@ impl TraceProcessor for ServerlessTraceProcessor {
                 .as_secs()
                 .try_into()
                 .unwrap_or_default();
+            // Ask the sampler itself whether it is disabled, rather than
+            // re-deriving that from config: one lock here instead of per chunk,
+            // and no second definition of "disabled" to keep in sync.
+            let rescue_enabled = !self
+                .error_sampler
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .is_disabled();
             for tp in tracer_payloads.iter_mut() {
                 // The sampler keys its per-signature rate limits on the env the
                 // tracer reported for this payload, as the Agent does.
@@ -532,9 +540,13 @@ impl TraceProcessor for ServerlessTraceProcessor {
                     if chunk.priority < 0 {
                         return false;
                     }
-                    if config.ext.apm_error_tps <= 0.0 {
+                    // A disabled sampler drops every chunk; skip building views
+                    // for a decision that is already known.
+                    if !rescue_enabled {
                         return false;
                     }
+                    // AutoDrop (0): give errored chunks a second look via the error
+                    // sampler (rescue within budget).
                     self.rescue_error_chunk(chunk, env, now_secs)
                 });
             }

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -1641,6 +1641,105 @@ mod tests {
         );
     }
 
+    /// With the error sampler disabled, an errored P0 chunk dropped from the
+    /// backend payload must still appear in the stats collection, so its stats
+    /// are counted.
+    #[test]
+    fn test_disabled_error_sampler_keeps_dropped_errored_p0_chunk_in_stats() {
+        use libdd_trace_obfuscation::obfuscation_config::ObfuscationConfig;
+
+        let config = Arc::new(Config {
+            apm_dd_url: "https://trace.agent.datadoghq.com".to_string(),
+            ext: crate::config::LambdaConfig {
+                lambda_extension_compute_stats: true,
+                ..Default::default()
+            },
+            ..Config::default()
+        });
+        let tags_provider = Arc::new(Provider::new(
+            config.clone(),
+            "lambda".to_string(),
+            &std::collections::HashMap::from([(
+                "function_arn".to_string(),
+                "test-arn".to_string(),
+            )]),
+        ));
+        let processor = ServerlessTraceProcessor {
+            obfuscation_config: Arc::new(
+                ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
+            ),
+            error_sampler: new_error_sampler(false),
+        };
+
+        let header_tags = tracer_header_tags::TracerHeaderTags {
+            lang: "rust",
+            lang_version: "1.0",
+            lang_interpreter: "",
+            lang_vendor: "",
+            tracer_version: "1.0",
+            container_id: "",
+            generic: tracer_header_tags::TracerGenericTags::default(),
+        };
+
+        let make_span = |trace_id: u64, priority: f64, error: i32| -> pb::Span {
+            let mut metrics = HashMap::new();
+            metrics.insert("_sampling_priority_v1".to_string(), priority);
+            pb::Span {
+                trace_id,
+                span_id: trace_id,
+                parent_id: 0,
+                error,
+                metrics,
+                service: "svc".to_string(),
+                name: "op".to_string(),
+                resource: "res".to_string(),
+                ..Default::default()
+            }
+        };
+
+        // trace 1: kept normally (priority 1). trace 2: errored P0, dropped
+        // because the error sampler is disabled.
+        let traces = vec![vec![make_span(1, 1.0, 0)], vec![make_span(2, 0.0, 1)]];
+
+        let (payload_info, stats_collection) =
+            processor.process_traces(config, tags_provider, header_tags, traces, 0, None);
+        let payload_info = payload_info.expect("kept trace must produce a backend payload");
+
+        // Stats collection must include both traces, including the dropped errored P0.
+        let TracerPayloadCollection::V07(ref stats_payloads) = stats_collection else {
+            panic!("expected V07");
+        };
+        let stats_trace_ids: Vec<u64> = stats_payloads
+            .iter()
+            .flat_map(|tp| tp.chunks.iter())
+            .flat_map(|c| c.spans.iter())
+            .map(|s| s.trace_id)
+            .collect();
+        assert_eq!(stats_trace_ids.len(), 2, "stats must include all traces");
+        assert!(
+            stats_trace_ids.contains(&2),
+            "dropped errored P0 trace must still be counted in stats"
+        );
+
+        // Backend payload must only contain the kept trace.
+        let backend_send_data = payload_info.builder.build();
+        let TracerPayloadCollection::V07(backend_payloads) = backend_send_data.get_payloads()
+        else {
+            panic!("expected V07");
+        };
+        let backend_trace_ids: Vec<u64> = backend_payloads
+            .iter()
+            .flat_map(|tp| tp.chunks.iter())
+            .flat_map(|c| c.spans.iter())
+            .map(|s| s.trace_id)
+            .collect();
+        assert_eq!(
+            backend_trace_ids,
+            vec![1],
+            "backend payload must exclude the dropped errored P0 trace"
+        );
+    }
+
     /// Verifies that `process_traces` returns `None` for the backend payload when all
     /// traces are sampled out and `lambda_extension_compute_stats` is true.
     #[test]

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -109,10 +109,14 @@ impl ServerlessTraceProcessor {
                 root_global_sample_rate: root.metrics.get("_sample_rate").copied().unwrap_or(1.0),
                 spans: &views,
             };
-            match self.error_sampler.lock() {
-                Ok(mut sampler) => sampler.sample(now_secs, &trace),
-                Err(_) => return false, // poisoned lock: fail safe to the drop
-            }
+            // Recover through poisoning: the sampler holds only rolling-window
+            // counters, so a partially updated bucket is far cheaper than
+            // disabling error rescue for the rest of the sandbox's life.
+            let mut sampler = self
+                .error_sampler
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            sampler.sample(now_secs, &trace)
         };
 
         match decision {

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -80,8 +80,9 @@ impl ServerlessTraceProcessor {
             return false; // can't identify a root span; drop as before
         };
         // Only errored traces are rescue candidates (matches the Go agent, which
-        // only routes error traces through the ErrorTPS ScoreSampler).
-        if chunk.spans.get(root_idx).map_or(0, |s| s.error) == 0 {
+        // only routes error traces through the ErrorTPS ScoreSampler). An error
+        // anywhere in the chunk counts, not just on the root span.
+        if !chunk.spans.iter().any(|s| s.error != 0) {
             return false;
         }
 
@@ -1446,6 +1447,86 @@ mod tests {
             .expect("rescued trace present");
         assert!(
             rescued_root.metrics.contains_key("_dd.errors_sr"),
+            "_dd.errors_sr stamped on rescued root"
+        );
+    }
+
+    /// An error on a child span (root not errored) still makes the chunk a rescue
+    /// candidate, matching the Go agent's `traceContainsError`.
+    #[test]
+    fn test_error_sampler_rescues_chunk_with_errored_child_span() {
+        use libdd_trace_obfuscation::obfuscation_config::ObfuscationConfig;
+
+        let config = Arc::new(Config {
+            apm_dd_url: "https://trace.agent.datadoghq.com".to_string(),
+            ext: crate::config::LambdaConfig {
+                lambda_extension_compute_stats: true,
+                ..Default::default()
+            },
+            ..Config::default()
+        });
+        let tags_provider = Arc::new(Provider::new(
+            config.clone(),
+            "lambda".to_string(),
+            &std::collections::HashMap::from([(
+                "function_arn".to_string(),
+                "test-arn".to_string(),
+            )]),
+        ));
+        let processor = ServerlessTraceProcessor {
+            obfuscation_config: Arc::new(
+                ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
+            ),
+            error_sampler: default_error_sampler(),
+        };
+
+        let header_tags = tracer_header_tags::TracerHeaderTags {
+            lang: "rust",
+            lang_version: "1.0",
+            lang_interpreter: "",
+            lang_vendor: "",
+            tracer_version: "1.0",
+            container_id: "",
+            generic: tracer_header_tags::TracerGenericTags::default(),
+        };
+
+        let make_span = |span_id: u64, parent_id: u64, error: i32| -> pb::Span {
+            let mut metrics = HashMap::new();
+            metrics.insert("_sampling_priority_v1".to_string(), 0.0);
+            pb::Span {
+                trace_id: 1,
+                span_id,
+                parent_id,
+                error,
+                metrics,
+                service: "svc".to_string(),
+                name: "op".to_string(),
+                resource: "res".to_string(),
+                ..Default::default()
+            }
+        };
+
+        // P0 trace whose root is fine but whose child failed (e.g. a caught
+        // downstream call): still an error trace, so it must be rescued.
+        let traces = vec![vec![make_span(1, 0, 0), make_span(2, 1, 1)]];
+
+        let (payload_info, _stats) =
+            processor.process_traces(config, tags_provider, header_tags, traces, 0, None);
+        let payload_info = payload_info.expect("errored-child P0 trace rescued");
+        let backend_send_data = payload_info.builder.build();
+        let TracerPayloadCollection::V07(backend_payloads) = backend_send_data.get_payloads()
+        else {
+            panic!("expected V07");
+        };
+
+        let root = backend_payloads
+            .iter()
+            .flat_map(|tp| tp.chunks.iter())
+            .flat_map(|c| c.spans.iter())
+            .find(|s| s.span_id == 1)
+            .expect("rescued trace present");
+        assert!(
+            root.metrics.contains_key("_dd.errors_sr"),
             "_dd.errors_sr stamped on rescued root"
         );
     }

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -65,14 +65,10 @@ impl StatsComputedBy {
 #[allow(clippy::module_name_repetitions)]
 pub struct ServerlessTraceProcessor {
     pub obfuscation_config: Arc<obfuscation_config::ObfuscationConfig>,
-    /// Agent-side error sampler. On the `lambda_extension_compute_stats` path,
-    /// errored chunks that would be dropped (`AutoDrop`) get a second look and
-    /// may be rescued. In the current `AlwaysKeep` mode every errored chunk is
-    /// rescued, gated only by `apm_error_sampler_enabled`; a traces/sec budget
-    /// applies in `RateLimited` mode. Shared across invocations (std Mutex, not
-    /// tokio: consulted from the synchronous `process_traces`) so
-    /// `RateLimited`'s rolling-window rate limiter accumulates. `AlwaysKeep`
-    /// holds no state, so the lock is uncontended bookkeeping there.
+    /// Rescues errored `AutoDrop` chunks on the `lambda_extension_compute_stats`
+    /// path. Shared across invocations so `RateLimited`'s rolling-window rate
+    /// limiter accumulates; a std Mutex rather than tokio because
+    /// `process_traces` is synchronous.
     pub error_sampler: Arc<std::sync::Mutex<ErrorsSampler>>,
 }
 
@@ -89,22 +85,17 @@ fn span_view(span: &Span) -> SpanView<'_> {
 }
 
 /// Builds the error sampler as the extension ships it, enabled or disabled by
-/// `apm_error_sampler_enabled`. Shared by `main` and the tests so tests
-/// exercise the shipping configuration.
+/// `apm_error_sampler_enabled`.
 ///
-/// The mode is hardcoded for now (config wiring via `DD_APM_ERROR_SAMPLER_MODE`
-/// is deferred): Lambda's per-invocation trace volume is low and freeze/thaw
-/// breaks the `RateLimited` mode's 30s wall-clock window, so `AlwaysKeep` is
-/// the right default. See APMSVLS-469.
+/// The mode is hardcoded to `AlwaysKeep`: Lambda's per-invocation trace volume
+/// is low, and freeze/thaw breaks `RateLimited`'s 30s wall-clock window.
 #[must_use]
 pub fn new_error_sampler(enabled: bool) -> Arc<std::sync::Mutex<ErrorsSampler>> {
     Arc::new(std::sync::Mutex::new(ErrorsSampler::new(
         ErrorSamplerConfig {
             mode: ErrorSamplerMode::AlwaysKeep,
-            // AlwaysKeep derives its disabled flag from `target_tps <= 0.0`, so
-            // the boolean maps onto any positive value vs. zero. The magnitude
-            // is unused until RateLimited is wired up, which is when
-            // DD_APM_ERROR_TPS becomes meaningful and gets exposed.
+            // `is_disabled()` is `target_tps <= 0.0`; the magnitude only
+            // matters in RateLimited mode.
             target_tps: if enabled { 1.0 } else { 0.0 },
             extra_sample_rate: 1.0,
         },
@@ -118,9 +109,7 @@ impl ServerlessTraceProcessor {
     /// `SamplerPriority::AutoDrop` (0) chunks are rescue candidates; negative
     /// priorities are explicit drops and are honored.
     fn drop_sampled_out_chunks(&self, tracer_payloads: &mut Vec<pb::TracerPayload>) {
-        // Ask the sampler itself whether it is disabled, rather than
-        // re-deriving that from config: one lock here instead of per chunk,
-        // and no second definition of "disabled" to keep in sync.
+        // Hoisted out of the loop: one lock instead of one per chunk.
         let rescue_enabled = !self
             .error_sampler
             .lock()
@@ -143,7 +132,6 @@ impl ServerlessTraceProcessor {
             // tracer reported for this payload, as the Agent does.
             let env = tp.env.as_str();
             tp.chunks.retain_mut(|chunk| {
-                // Explicit keeps and "no priority set" pass through unchanged.
                 if chunk.priority > 0 || chunk.priority == SamplerPriority::None as i32 {
                     return true;
                 }
@@ -152,13 +140,9 @@ impl ServerlessTraceProcessor {
                 if chunk.priority < 0 {
                     return false;
                 }
-                // A disabled sampler drops every chunk; skip building views
-                // for a decision that is already known.
                 if !rescue_enabled {
                     return false;
                 }
-                // AutoDrop (0): give errored chunks a second look via the error
-                // sampler (rescue within budget).
                 self.rescue_error_chunk(chunk, env, now_secs)
             });
         }
@@ -170,7 +154,7 @@ impl ServerlessTraceProcessor {
     /// traces are candidates; on a keep, stamps `_dd.errors_sr` on the root span.
     fn rescue_error_chunk(&self, chunk: &mut pb::TraceChunk, env: &str, now_secs: i64) -> bool {
         let Ok(root_idx) = trace_utils::get_root_span_index(&chunk.spans) else {
-            return false; // can't identify a root span; drop as before
+            return false; // no identifiable root span
         };
         // Only errored traces are rescue candidates (matches the Go agent, which
         // only routes error traces through the ErrorTPS ScoreSampler). An error
@@ -179,14 +163,14 @@ impl ServerlessTraceProcessor {
             return false;
         }
 
-        // Build the borrow-only views in a scope so they (and their immutable
-        // borrow of chunk.spans) drop before the `_dd.errors_sr` mutation below.
+        // Scoped so the views release their borrow of chunk.spans before the
+        // `_dd.errors_sr` mutation below.
         let decision = {
             let mut sampler = self.error_sampler.lock().expect("error sampler poisoned");
             let root = &chunk.spans[root_idx];
-            // AlwaysKeep ignores the spans apart from a bounds check on
-            // root_index, so only the root view is built there. RateLimited
-            // needs every span to compute the trace signature.
+            // AlwaysKeep only bounds-checks root_index, so building the root
+            // view alone is enough. RateLimited needs every span to compute
+            // the trace signature.
             let root_view;
             let all_views;
             let (spans, root_index) = if matches!(*sampler, ErrorsSampler::AlwaysKeep { .. }) {
@@ -745,9 +729,7 @@ impl SendingTraceProcessor {
     }
 }
 
-/// Enabled error sampler for constructing `ServerlessTraceProcessor` in tests
-/// (sampler behavior itself is unit-tested in the `datadog-agent-trace-sampler`
-/// crate; these call sites just need a value).
+/// Enabled error sampler for constructing `ServerlessTraceProcessor` in tests.
 #[cfg(test)]
 pub(crate) fn default_error_sampler() -> Arc<std::sync::Mutex<ErrorsSampler>> {
     new_error_sampler(true)
@@ -1601,9 +1583,8 @@ mod tests {
         );
     }
 
-    /// With the error sampler disabled (the shipping default,
-    /// `apm_error_sampler_enabled: false`), errored P0 chunks are dropped as
-    /// before: no rescue, no `_dd.errors_sr`.
+    /// With the error sampler disabled (the shipping default), errored P0
+    /// chunks are dropped: no rescue, no `_dd.errors_sr`.
     #[test]
     fn test_disabled_error_sampler_drops_errored_p0_chunks() {
         use libdd_trace_obfuscation::obfuscation_config::ObfuscationConfig;

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -15,6 +15,7 @@ use crate::traces::{
     LAMBDA_RUNTIME_URL_PREFIX, LAMBDA_STATSD_URL_PREFIX,
 };
 use async_trait::async_trait;
+use datadog_agent_trace_sampler::{ErrorsSampler, SampleDecision, SpanView, TraceView};
 use libdd_common::Endpoint;
 use libdd_trace_obfuscation::obfuscate::obfuscate_span;
 use libdd_trace_obfuscation::obfuscation_config;
@@ -62,6 +63,67 @@ impl StatsComputedBy {
 #[allow(clippy::module_name_repetitions)]
 pub struct ServerlessTraceProcessor {
     pub obfuscation_config: Arc<obfuscation_config::ObfuscationConfig>,
+    /// Agent-side error sampler. On the `lambda_extension_compute_stats` path,
+    /// errored chunks that would be dropped (priority <= 0) get a second look
+    /// and are rescued up to `apm_error_tps` traces/sec. Shared across
+    /// invocations (std Mutex, not tokio: consulted from the synchronous
+    /// `process_traces`) so its rolling-window rate limiter accumulates.
+    pub error_sampler: Arc<std::sync::Mutex<ErrorsSampler>>,
+}
+
+impl ServerlessTraceProcessor {
+    /// Consult the error sampler for a chunk that would otherwise be dropped
+    /// (priority <= 0). Returns `true` to keep (rescue) the chunk. Only errored
+    /// traces are candidates; on a keep, stamps `_dd.errors_sr` on the root span.
+    fn rescue_error_chunk(&self, chunk: &mut pb::TraceChunk, env: &str, now_secs: i64) -> bool {
+        let Ok(root_idx) = trace_utils::get_root_span_index(&chunk.spans) else {
+            return false; // can't identify a root span; drop as before
+        };
+        // Only errored traces are rescue candidates (matches the Go agent, which
+        // only routes error traces through the ErrorTPS ScoreSampler).
+        if chunk.spans.get(root_idx).map_or(0, |s| s.error) == 0 {
+            return false;
+        }
+
+        // Build the borrow-only views in a scope so they (and their immutable
+        // borrow of chunk.spans) drop before the `_dd.errors_sr` mutation below.
+        let decision = {
+            let views: Vec<SpanView> = chunk
+                .spans
+                .iter()
+                .map(|s| SpanView {
+                    service: &s.service,
+                    name: &s.name,
+                    resource: &s.resource,
+                    error: s.error != 0,
+                    http_status_code: s.meta.get("http.status_code").map(String::as_str),
+                    error_type: s.meta.get("error.type").map(String::as_str),
+                })
+                .collect();
+            let root = &chunk.spans[root_idx];
+            let trace = TraceView {
+                env,
+                trace_id: root.trace_id,
+                root_index: root_idx,
+                root_global_sample_rate: root.metrics.get("_sample_rate").copied().unwrap_or(1.0),
+                spans: &views,
+            };
+            match self.error_sampler.lock() {
+                Ok(mut sampler) => sampler.sample(now_secs, &trace),
+                Err(_) => return false, // poisoned lock: fail safe to the drop
+            }
+        };
+
+        match decision {
+            SampleDecision::Keep { errors_sr } => {
+                if let Some(root) = chunk.spans.get_mut(root_idx) {
+                    root.metrics.insert("_dd.errors_sr".to_string(), errors_sr);
+                }
+                true
+            }
+            SampleDecision::Drop => false,
+        }
+    }
 }
 
 struct ChunkProcessor {
@@ -445,9 +507,22 @@ impl TraceProcessor for ServerlessTraceProcessor {
         if config.ext.lambda_extension_compute_stats
             && let TracerPayloadCollection::V07(ref mut tracer_payloads) = payload
         {
+            let env = config.env.as_deref().unwrap_or_default();
+            let now_secs: i64 = std::time::UNIX_EPOCH
+                .elapsed()
+                .expect("unable to poll clock, unrecoverable")
+                .as_secs()
+                .try_into()
+                .unwrap_or_default();
             for tp in tracer_payloads.iter_mut() {
-                tp.chunks.retain(|chunk| {
-                    chunk.priority > 0 || chunk.priority == SamplerPriority::None as i32
+                tp.chunks.retain_mut(|chunk| {
+                    // Explicit keeps and "no priority set" pass through unchanged.
+                    if chunk.priority > 0 || chunk.priority == SamplerPriority::None as i32 {
+                        return true;
+                    }
+                    // Otherwise this chunk would be dropped; give errored ones a
+                    // second look via the error sampler (rescue within budget).
+                    self.rescue_error_chunk(chunk, env, now_secs)
                 });
             }
             tracer_payloads.retain(|tp| !tp.chunks.is_empty());
@@ -599,6 +674,16 @@ impl SendingTraceProcessor {
     }
 }
 
+/// Default error sampler for constructing `ServerlessTraceProcessor` in tests
+/// (sampler behavior itself is unit-tested in the `datadog-agent-trace-sampler`
+/// crate; these call sites just need a value).
+#[cfg(test)]
+pub(crate) fn default_error_sampler() -> Arc<std::sync::Mutex<ErrorsSampler>> {
+    Arc::new(std::sync::Mutex::new(ErrorsSampler::new(
+        datadog_agent_trace_sampler::ErrorSamplerConfig::default(),
+    )))
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -721,6 +806,7 @@ mod tests {
             obfuscation_config: Arc::new(
                 ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
             ),
+            error_sampler: default_error_sampler(),
         };
         let config = create_test_config();
         let tags_provider = create_tags_provider(config.clone());
@@ -1199,6 +1285,7 @@ mod tests {
             obfuscation_config: Arc::new(
                 ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
             ),
+            error_sampler: default_error_sampler(),
         };
 
         let header_tags = tracer_header_tags::TracerHeaderTags {
@@ -1267,6 +1354,102 @@ mod tests {
         );
     }
 
+    /// On the compute-stats path, the error sampler rescues errored chunks that
+    /// would otherwise be dropped (priority <= 0), stamping `_dd.errors_sr`,
+    /// while non-errored P0 chunks are still dropped.
+    #[test]
+    fn test_error_sampler_rescues_errored_p0_chunks() {
+        use libdd_trace_obfuscation::obfuscation_config::ObfuscationConfig;
+
+        let config = Arc::new(Config {
+            apm_dd_url: "https://trace.agent.datadoghq.com".to_string(),
+            ext: crate::config::LambdaConfig {
+                lambda_extension_compute_stats: true,
+                ..Default::default()
+            },
+            ..Config::default()
+        });
+        let tags_provider = Arc::new(Provider::new(
+            config.clone(),
+            "lambda".to_string(),
+            &std::collections::HashMap::from([(
+                "function_arn".to_string(),
+                "test-arn".to_string(),
+            )]),
+        ));
+        let processor = ServerlessTraceProcessor {
+            obfuscation_config: Arc::new(
+                ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
+            ),
+            error_sampler: default_error_sampler(),
+        };
+
+        let header_tags = tracer_header_tags::TracerHeaderTags {
+            lang: "rust",
+            lang_version: "1.0",
+            lang_interpreter: "",
+            lang_vendor: "",
+            tracer_version: "1.0",
+            container_id: "",
+            generic: tracer_header_tags::TracerGenericTags::default(),
+        };
+
+        let make_span = |trace_id: u64, priority: f64, error: i32| -> pb::Span {
+            let mut metrics = HashMap::new();
+            metrics.insert("_sampling_priority_v1".to_string(), priority);
+            pb::Span {
+                trace_id,
+                span_id: trace_id,
+                parent_id: 0,
+                error,
+                metrics,
+                service: "svc".to_string(),
+                name: "op".to_string(),
+                resource: "res".to_string(),
+                ..Default::default()
+            }
+        };
+
+        // trace 1: kept normally (priority 1). trace 2: errored P0 (rescued).
+        // trace 3: non-errored P0 (dropped).
+        let traces = vec![
+            vec![make_span(1, 1.0, 0)],
+            vec![make_span(2, 0.0, 1)],
+            vec![make_span(3, 0.0, 0)],
+        ];
+
+        let (payload_info, _stats) =
+            processor.process_traces(config, tags_provider, header_tags, traces, 0, None);
+        let payload_info = payload_info.expect("expected Some payload");
+        let backend_send_data = payload_info.builder.build();
+        let TracerPayloadCollection::V07(backend_payloads) = backend_send_data.get_payloads()
+        else {
+            panic!("expected V07");
+        };
+
+        let kept: Vec<u64> = backend_payloads
+            .iter()
+            .flat_map(|tp| tp.chunks.iter())
+            .flat_map(|c| c.spans.iter())
+            .map(|s| s.trace_id)
+            .collect();
+        assert_eq!(kept.len(), 2, "kept normal trace + rescued errored trace");
+        assert!(kept.contains(&1), "priority-1 trace kept");
+        assert!(kept.contains(&2), "errored P0 trace rescued");
+        assert!(!kept.contains(&3), "non-errored P0 trace dropped");
+
+        let rescued_root = backend_payloads
+            .iter()
+            .flat_map(|tp| tp.chunks.iter())
+            .flat_map(|c| c.spans.iter())
+            .find(|s| s.trace_id == 2)
+            .expect("rescued trace present");
+        assert!(
+            rescued_root.metrics.contains_key("_dd.errors_sr"),
+            "_dd.errors_sr stamped on rescued root"
+        );
+    }
+
     /// Verifies that `process_traces` returns `None` for the backend payload when all
     /// traces are sampled out and `lambda_extension_compute_stats` is true.
     #[test]
@@ -1293,6 +1476,7 @@ mod tests {
             obfuscation_config: Arc::new(
                 ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
             ),
+            error_sampler: default_error_sampler(),
         };
         let header_tags = tracer_header_tags::TracerHeaderTags {
             lang: "rust",
@@ -1371,6 +1555,7 @@ mod tests {
             obfuscation_config: Arc::new(
                 ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
             ),
+            error_sampler: default_error_sampler(),
         };
         let header_tags = tracer_header_tags::TracerHeaderTags {
             lang: "rust",
@@ -1476,6 +1661,7 @@ mod tests {
             obfuscation_config: Arc::new(
                 ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
             ),
+            error_sampler: default_error_sampler(),
         };
         let header_tags = tracer_header_tags::TracerHeaderTags {
             lang: "rust",
@@ -1883,6 +2069,7 @@ mod tests {
                     obfuscation_config: Arc::new(
                         ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
                     ),
+                    error_sampler: default_error_sampler(),
                 }),
                 trace_tx,
                 stats_generator: Arc::new(StatsGenerator::new(concentrator_handle.clone())),

--- a/bottlecap/tests/apm_integration_test.rs
+++ b/bottlecap/tests/apm_integration_test.rs
@@ -31,7 +31,9 @@ use bottlecap::traces::stats_generator::StatsGenerator;
 use bottlecap::traces::trace_aggregator::SendDataBuilderInfo;
 use bottlecap::traces::trace_aggregator_service::AggregatorService;
 use bottlecap::traces::trace_flusher::TraceFlusher;
-use bottlecap::traces::trace_processor::{SendingTraceProcessor, ServerlessTraceProcessor};
+use bottlecap::traces::trace_processor::{
+    SendingTraceProcessor, ServerlessTraceProcessor, new_error_sampler,
+};
 use dogstatsd::api_key::ApiKeyFactory;
 use libdd_common::Endpoint;
 use libdd_trace_obfuscation::obfuscation_config::ObfuscationConfig;
@@ -363,11 +365,7 @@ async fn run_processor_pipeline_with_traces(
             obfuscation_config: Arc::new(
                 ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
             ),
-            error_sampler: Arc::new(std::sync::Mutex::new(
-                datadog_agent_trace_sampler::ErrorsSampler::new(
-                    datadog_agent_trace_sampler::ErrorSamplerConfig::default(),
-                ),
-            )),
+            error_sampler: new_error_sampler(true),
         }),
         trace_tx,
         stats_generator: Arc::new(StatsGenerator::new(concentrator_handle.clone())),

--- a/bottlecap/tests/apm_integration_test.rs
+++ b/bottlecap/tests/apm_integration_test.rs
@@ -484,6 +484,67 @@ fn captured_compute_stats(traces: &[pb::AgentPayload]) -> Option<String> {
     span.meta.get(COMPUTE_STATS_KEY).cloned()
 }
 
+/// An errored P0 trace is rescued and reaches the intake, while a non-errored P0 trace is dropped.
+#[tokio::test]
+async fn e2e_error_sampler_rescues_only_errored_p0_traces() {
+    let make_span = |trace_id: u64, error: i32| {
+        let mut span = pb::Span {
+            service: "fake-intake-trace-service".to_string(),
+            name: "web.request".to_string(),
+            resource: "GET /fake".to_string(),
+            trace_id,
+            span_id: trace_id,
+            parent_id: 0,
+            start: STATS_SPAN_START_NS,
+            duration: 5_000_000,
+            error,
+            r#type: "web".to_string(),
+            ..pb::Span::default()
+        };
+        span.metrics
+            .insert("_sampling_priority_v1".to_string(), 0.0);
+        span
+    };
+
+    let rescued_trace_id = 1;
+    let dropped_trace_id = 2;
+    let outcome = run_processor_pipeline_with_traces(
+        true,
+        false,
+        vec![
+            vec![make_span(rescued_trace_id, 1)],
+            vec![make_span(dropped_trace_id, 0)],
+        ],
+    )
+    .await;
+
+    let captured_spans: Vec<&pb::Span> = outcome
+        .traces
+        .iter()
+        .flat_map(|payload| &payload.tracer_payloads)
+        .flat_map(|payload| &payload.chunks)
+        .flat_map(|chunk| &chunk.spans)
+        .collect();
+    assert_eq!(
+        captured_spans.len(),
+        1,
+        "only the rescued trace reaches intake"
+    );
+
+    let rescued_span = captured_spans[0];
+    assert_eq!(rescued_span.trace_id, rescued_trace_id);
+    assert!(
+        rescued_span.metrics.contains_key("_dd.errors_sr"),
+        "the rescued root span must carry its error sampling rate",
+    );
+    assert!(
+        captured_spans
+            .iter()
+            .all(|span| span.trace_id != dropped_trace_id),
+        "the non-errored P0 trace must not reach intake",
+    );
+}
+
 /// T3.1: `client_computed_stats=true` → captured span meta has `_dd.compute_stats` absent.
 #[tokio::test]
 async fn e2e_client_computed_stats_leaves_compute_stats_absent() {

--- a/bottlecap/tests/apm_integration_test.rs
+++ b/bottlecap/tests/apm_integration_test.rs
@@ -363,6 +363,11 @@ async fn run_processor_pipeline_with_traces(
             obfuscation_config: Arc::new(
                 ObfuscationConfig::new().expect("Failed to create ObfuscationConfig"),
             ),
+            error_sampler: Arc::new(std::sync::Mutex::new(
+                datadog_agent_trace_sampler::ErrorsSampler::new(
+                    datadog_agent_trace_sampler::ErrorSamplerConfig::default(),
+                ),
+            )),
         }),
         trace_tx,
         stats_generator: Arc::new(StatsGenerator::new(concentrator_handle.clone())),


### PR DESCRIPTION
Stacked PRs:
- DataDog/serverless-components#141
- #1332
- #1320 👈🏽 **This PR**

### TL;DR

Rescues errored traces that automatic sampling drops on the `lambda_extension_compute_stats` path, so errors stay visible even under aggressive sampling. Ships disabled behind `DD_SERVERLESS_ERROR_SAMPLER_ENABLED`, using the `AlwaysKeep` mode of the new `datadog-agent-trace-sampler` crate (DataDog/serverless-components#141).

----

## Overview

On the `lambda_extension_compute_stats` path, the extension drops every P0 (priority <= 0) trace after computing its stats, so an errored trace the tracer sampled away is invisible in the UI even though its stats are counted. This adds an agent-side error sampler that rescues those traces and stamps `_dd.errors_sr` on the root span, matching the Go trace agent's `ScoreSampler` / `ErrorTPS` behavior.

Candidates, matching the Go agent:

- An error on **any** span (not just the root) qualifies the trace.
- Only **automatic** drops are candidates, explicit drops (a sampling rule or `MANUAL_DROP`) are always honored.
- Non-errored P0 traces are still dropped; stats still count everything.
- Rate limits are keyed per-env, so services don't share one budget.

The sampling logic lives in the dependency-free `datadog-agent-trace-sampler` crate (DataDog/serverless-components#141): primitives in (`SpanView`/`TraceView`), a `SampleDecision` out, no protobuf `Span` type, so consumers pinning different libdatadog revisions can share it.

### Configuration

| Variable | Default | Notes |
|---|---|---|
| `DD_SERVERLESS_ERROR_SAMPLER_ENABLED` | `false` | Rescue errored traces that automatic sampling dropped. |

Flat key (`serverless_error_sampler_enabled`), unlike the Go agent's nested `apm_config.*`. The `DD_SERVERLESS_` prefix matches the extension's other settings (`DD_SERVERLESS_LOGS_ENABLED`, `DD_SERVERLESS_FLUSH_STRATEGY`, `DD_SERVERLESS_APPSEC_ENABLED`) and lets the serverless compatibility layer adopt the same name later.

**Enabling this has no volume ceiling.** The crate offers two strategies; this PR ships `AlwaysKeep` (rescue *every* errored auto-dropped trace), since Lambda's per-invocation volume is low and freeze/thaw breaks `RateLimited`'s 30s window. So a function that errors on most invocations under `DD_TRACE_SAMPLE_RATE=0.01` goes from ingesting ~1% of its traces to ~100% of them. `RateLimited` (a traces/sec budget à la the Go agent's `errors_per_second`) stays unwired, along with `DD_APM_ERROR_TPS`/`DD_APM_EXTRA_SAMPLE_RATE`; because `DD_APM_ERROR_TPS` is the setting Agent docs point at, the extension now logs a warning at startup when it is set, naming the setting that does work.

When disabled, the rescue path, including the clock read, is skipped entirely, so behavior is unchanged from before this PR. When enabled, a failed clock read falls back to `0` instead of aborting the extension, and a panic while the sampler's lock is held recovers through the poison instead of disabling rescue for the rest of the sandbox's life.

### Blocked on

~DataDog/serverless-components#141: the four pins in `bottlecap/Cargo.toml` point at its branch rev (`54e570a`) and need repinning to `main` once merged.~ Update: DataDog/serverless-components#141 is merged

## Testing

Unit tests in `traces/trace_processor.rs`:

- `test_error_sampler_rescues_errored_p0_chunks` — errored auto-dropped chunk is rescued and stamped; non-errored stays dropped; explicit user drop is never rescued.
- `test_error_sampler_rescues_chunk_with_errored_child_span` — a healthy root with an errored child is still rescued.
- `test_disabled_error_sampler_drops_errored_p0_chunks` — shipping default (disabled) still drops errored P0 traces.
- `test_disabled_error_sampler_keeps_dropped_errored_p0_chunk_in_stats` — with the sampler disabled, a dropped errored P0 chunk is absent from the backend payload but still present in the stats collection.

Also: config tests for `serverless_error_sampler_enabled`'s default, env var, and YAML key; prod and tests share one constructor (`new_error_sampler`) so tests exercise the shipping config.

Fake-intake integration test in `apm_integration_test.rs`:

- `e2e_error_sampler_rescues_only_errored_p0_traces` routes errored and non-errored P0 traces through the processor and trace flusher. It verifies that only the errored trace reaches the intake and that its root span carries `_dd.errors_sr`.

🤖
