### PR TITLE
[SVLS-9625] chore(ci): trigger a rebuild and re-sign of the CI image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,9 +8,6 @@ variables:
   PIPELINE_LAYER_SUFFIX:
     description: "Suffix to be appended to the layer name (default empty)."
     value: ""
-  REBUILD_CI_IMAGE:
-    description: "Set to 'true' to rebuild and re-sign the CI image without a .gitlab/Dockerfile change."
-    value: ""
 
 stages:
   - prepare
@@ -22,10 +19,6 @@ ci image:
   image: registry.ddbuild.io/images/docker:20.10
   tags: ["arch:arm64"]
   rules:
-    # Signatures live on the image digest, so re-signing means rebuilding and
-    # pushing. Without this knob that requires a no-op Dockerfile commit.
-    - if: '$REBUILD_CI_IMAGE == "true"'
-      when: on_success
     - if: '$CI_COMMIT_BRANCH == "main" && $CI_PIPELINE_SOURCE == "push"'
       changes:
         - .gitlab/Dockerfile

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,9 @@ variables:
   PIPELINE_LAYER_SUFFIX:
     description: "Suffix to be appended to the layer name (default empty)."
     value: ""
+  REBUILD_CI_IMAGE:
+    description: "Set to 'true' to rebuild and re-sign the CI image without a .gitlab/Dockerfile change."
+    value: ""
 
 stages:
   - prepare
@@ -19,6 +22,10 @@ ci image:
   image: registry.ddbuild.io/images/docker:20.10
   tags: ["arch:arm64"]
   rules:
+    # Signatures live on the image digest, so re-signing means rebuilding and
+    # pushing. Without this knob that requires a no-op Dockerfile commit.
+    - if: '$REBUILD_CI_IMAGE == "true"'
+      when: on_success
     - if: '$CI_COMMIT_BRANCH == "main" && $CI_PIPELINE_SOURCE == "push"'
       changes:
         - .gitlab/Dockerfile

--- a/.gitlab/Dockerfile
+++ b/.gitlab/Dockerfile
@@ -26,5 +26,3 @@ ENV PATH=$PATH:/root/.cargo/bin/
 ENV LIBCLANG_PATH=/usr/lib/x86_64-linux-gnu
 
 RUN rustup component add rust-src --toolchain stable
-
-


### PR DESCRIPTION
## Problem

CI jobs are failing to start because `registry.ddbuild.io/ci/datadog-lambda-extension:latest` is unsigned and image-integrity enforcement blocks the pull:

```
verifier containerd-image-verifier rejected image: signature manifest not found
```

`ddsign` signing was added to the `ci image` job in #1065 (2026-03-05), but the job only runs when a push to `main` changes `.gitlab/Dockerfile` — and the last such change was 2025-12-03. So the job has never run with signing enabled.

## This PR
Deletes the trailing blank lines from `.gitlab/Dockerfile`: a no-op for the image content, but enough to make that rule match on merge and rebuild, sign, and push `:latest`.

## Testing

Ran the `ci image` job against a throwaway tag to confirm signing works before relying on it ([job 1939023452](https://gitlab.ddbuild.io/DataDog/datadog-lambda-extension/-/jobs/1939023452)): the build pushed, and `ddsign sign` reported `"signatureIsNew": true`. So `DDSIGN_ID_TOKEN` and the signer allowlist are set up correctly — the job simply never ran.

The merge itself can't be rehearsed from a branch. After merge, confirm the `ci image` job ran and that `integration-suite: [oom]` / `[lmi-oom]` start cleanly.

## Resources
Slack discussion: https://dd.slack.com/archives/C027P1CK07N/p1785767085015909

🤖 Generated with [Claude Code](https://claude.com/claude-code)
