### PR TITLE
chore(deps): update `libdatadog` to `72fa8685` and `serverless-components` to `9daae40`

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -507,13 +507,13 @@ dependencies = [
  "indexmap",
  "itertools 0.14.0",
  "lazy_static",
- "libdd-capabilities",
- "libdd-common",
- "libdd-trace-normalization",
- "libdd-trace-obfuscation",
- "libdd-trace-protobuf",
- "libdd-trace-stats",
- "libdd-trace-utils",
+ "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-common 5.1.0",
+ "libdd-trace-normalization 3.0.0",
+ "libdd-trace-obfuscation 5.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-trace-protobuf 4.0.0",
+ "libdd-trace-stats 6.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-trace-utils 9.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
  "libddwaf",
  "log",
  "mime",
@@ -810,13 +810,13 @@ dependencies = [
 [[package]]
 name = "datadog-agent-config"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=d0c7f44191445e20d309734675d5e8b91d2a5d51#d0c7f44191445e20d309734675d5e8b91d2a5d51"
+source = "git+https://github.com/DataDog/serverless-components?rev=9daae40afa87f52fad1489f4d7cfd4a579037d2d#9daae40afa87f52fad1489f4d7cfd4a579037d2d"
 dependencies = [
  "datadog-opentelemetry",
  "dogstatsd",
  "figment",
- "libdd-trace-obfuscation",
- "libdd-trace-utils",
+ "libdd-trace-obfuscation 5.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-trace-utils 9.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
  "log",
  "serde",
  "serde-aux",
@@ -828,7 +828,7 @@ dependencies = [
 [[package]]
 name = "datadog-fips"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=d0c7f44191445e20d309734675d5e8b91d2a5d51#d0c7f44191445e20d309734675d5e8b91d2a5d51"
+source = "git+https://github.com/DataDog/serverless-components?rev=9daae40afa87f52fad1489f4d7cfd4a579037d2d#9daae40afa87f52fad1489f4d7cfd4a579037d2d"
 dependencies = [
  "reqwest",
  "rustls",
@@ -851,15 +851,15 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "libc",
- "libdd-capabilities-impl",
- "libdd-common",
+ "libdd-capabilities-impl 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-common 5.2.0",
  "libdd-data-pipeline",
  "libdd-library-config",
  "libdd-sampling",
- "libdd-shared-runtime",
- "libdd-telemetry",
- "libdd-tinybytes",
- "libdd-trace-utils",
+ "libdd-shared-runtime 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-telemetry 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-tinybytes 1.1.2",
+ "libdd-trace-utils 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru",
  "opentelemetry 0.32.0",
  "opentelemetry-semantic-conventions 0.32.1",
@@ -977,7 +977,7 @@ dependencies = [
 [[package]]
 name = "dogstatsd"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components?rev=d0c7f44191445e20d309734675d5e8b91d2a5d51#d0c7f44191445e20d309734675d5e8b91d2a5d51"
+source = "git+https://github.com/DataDog/serverless-components?rev=9daae40afa87f52fad1489f4d7cfd4a579037d2d#9daae40afa87f52fad1489f4d7cfd4a579037d2d"
 dependencies = [
  "datadog-protos",
  "ddsketch-agent",
@@ -1961,7 +1961,8 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 [[package]]
 name = "libdd-capabilities"
 version = "2.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a946c29c5fe7cc2adec7a66a35f7cfc138ba75c988d09a7a99c12de7d3b9a7"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1970,22 +1971,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "libdd-capabilities"
+version = "2.1.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.4.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "libdd-capabilities-impl"
 version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e948ad5c65d8598fd3889762ea4767b9a521ebfb2f7b72f6e52162aa4d7f353"
 dependencies = [
  "bytes",
  "http 1.4.0",
  "http-body-util",
- "libdd-capabilities",
- "libdd-common",
+ "libdd-capabilities 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-common 5.2.0",
+ "tokio",
+]
+
+[[package]]
+name = "libdd-capabilities-impl"
+version = "3.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "http 1.4.0",
+ "http-body-util",
+ "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-common 5.1.0",
  "tokio",
 ]
 
 [[package]]
 name = "libdd-common"
 version = "5.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2018,9 +2047,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "libdd-common"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350fb68fd76193dceecbadd8add17732f5f2ca0b0c7806d62da0bd110af53410"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "cc",
+ "const_format",
+ "futures",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "libc",
+ "nix 0.29.0",
+ "pin-project",
+ "regex",
+ "serde",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "tokio",
+ "tower-service",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "libdd-data-pipeline"
 version = "7.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433f9bfe60850c0638a273dfb2bd873f5abc12c9983ce74ebffe055a7a3c21c9"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2030,19 +2091,19 @@ dependencies = [
  "getrandom 0.2.17",
  "http 1.4.0",
  "http-body-util",
- "libdd-capabilities",
- "libdd-capabilities-impl",
- "libdd-common",
- "libdd-ddsketch",
- "libdd-dogstatsd-client",
- "libdd-shared-runtime",
- "libdd-telemetry",
- "libdd-tinybytes",
- "libdd-trace-normalization",
- "libdd-trace-obfuscation",
- "libdd-trace-protobuf",
- "libdd-trace-stats",
- "libdd-trace-utils",
+ "libdd-capabilities 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-capabilities-impl 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-common 5.2.0",
+ "libdd-ddsketch 1.1.1",
+ "libdd-dogstatsd-client 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-shared-runtime 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-telemetry 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-tinybytes 1.1.2",
+ "libdd-trace-normalization 3.0.1",
+ "libdd-trace-obfuscation 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-trace-protobuf 4.0.1",
+ "libdd-trace-stats 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-trace-utils 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -2056,7 +2117,16 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
+dependencies = [
+ "prost 0.14.3",
+]
+
+[[package]]
+name = "libdd-ddsketch"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "827db9addada0e19a8371241e54fe4f27e9101c5a1dc30a13cf42dea5220e3f0"
 dependencies = [
  "prost 0.14.3",
 ]
@@ -2064,12 +2134,26 @@ dependencies = [
 [[package]]
 name = "libdd-dogstatsd-client"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c29c7bd569824c4d8ffe7171bb77e6b69c2161517ed75436ff458b40d41a663d"
 dependencies = [
  "anyhow",
  "cadence",
  "http 1.4.0",
- "libdd-common",
+ "libdd-common 5.2.0",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "libdd-dogstatsd-client"
+version = "4.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
+dependencies = [
+ "anyhow",
+ "cadence",
+ "http 1.4.0",
+ "libdd-common 5.1.0",
  "serde",
  "tracing",
 ]
@@ -2077,11 +2161,12 @@ dependencies = [
 [[package]]
 name = "libdd-library-config"
 version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab46ec324c1b916ca06c4a369da171a08eb9f112620e6f6f004860e589892715"
 dependencies = [
  "anyhow",
  "libc",
- "libdd-trace-protobuf",
+ "libdd-trace-protobuf 4.0.1",
  "memfd",
  "prost 0.14.3",
  "rand 0.8.6",
@@ -2094,9 +2179,10 @@ dependencies = [
 [[package]]
 name = "libdd-sampling"
 version = "5.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6c34dd818feb6a2c1de996017d2f8e3190615c62fa5513f3b9559bce727dfb"
 dependencies = [
- "libdd-common",
+ "libdd-common 5.2.0",
  "lru",
  "serde",
  "serde_json",
@@ -2105,14 +2191,32 @@ dependencies = [
 [[package]]
 name = "libdd-shared-runtime"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab1ad16a0bfcf1ce826e2314c162b04daf4324c71da5a28583ea40e76be8772"
 dependencies = [
  "async-trait",
  "futures",
  "futures-util",
- "libdd-capabilities",
- "libdd-capabilities-impl",
- "libdd-common",
+ "libdd-capabilities 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-capabilities-impl 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-common 5.2.0",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "libdd-shared-runtime"
+version = "2.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-util",
+ "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-capabilities-impl 3.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-common 5.1.0",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2122,7 +2226,8 @@ dependencies = [
 [[package]]
 name = "libdd-telemetry"
 version = "6.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c791d810acbe99b0c7fc4285824f4e27a4b2b9137d4aec8a5df220ca55b34942"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2133,9 +2238,9 @@ dependencies = [
  "http 1.4.0",
  "http-body-util",
  "libc",
- "libdd-common",
- "libdd-ddsketch",
- "libdd-shared-runtime",
+ "libdd-common 5.2.0",
+ "libdd-ddsketch 1.1.1",
+ "libdd-shared-runtime 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_json",
  "sys-info",
@@ -2147,9 +2252,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "libdd-telemetry"
+version = "6.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "getrandom 0.2.17",
+ "hashbrown 0.15.5",
+ "http 1.4.0",
+ "libc",
+ "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-common 5.1.0",
+ "libdd-ddsketch 1.1.0",
+ "libdd-shared-runtime 2.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "serde",
+ "serde_json",
+ "sys-info",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "web-time",
+ "winver",
+]
+
+[[package]]
 name = "libdd-tinybytes"
 version = "1.1.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "libdd-tinybytes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d3e6ade71c21b86ab81fa8d905f9f26733336f1a904bb826b9ac1972b3c8289"
 dependencies = [
  "serde",
 ]
@@ -2157,22 +2300,49 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
 dependencies = [
  "anyhow",
- "libdd-trace-protobuf",
+ "libdd-trace-protobuf 4.0.0",
+]
+
+[[package]]
+name = "libdd-trace-normalization"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a643220a54228ef837631b5036f34fc13fc8ee2e307a74ac011232c062393fc5"
+dependencies = [
+ "anyhow",
+ "libdd-trace-protobuf 4.0.1",
 ]
 
 [[package]]
 name = "libdd-trace-obfuscation"
 version = "5.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d313153f515b9dd31a483bc7e4d432ecb76e53dd33f67f4eeaa415319372b68d"
 dependencies = [
  "anyhow",
  "fluent-uri",
- "libdd-common",
- "libdd-trace-protobuf",
- "libdd-trace-utils",
+ "libdd-common 5.2.0",
+ "libdd-trace-protobuf 4.0.1",
+ "libdd-trace-utils 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "libdd-trace-obfuscation"
+version = "5.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
+dependencies = [
+ "anyhow",
+ "fluent-uri",
+ "libdd-common 5.1.0",
+ "libdd-trace-protobuf 4.0.0",
+ "libdd-trace-utils 9.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
  "log",
  "percent-encoding",
  "serde",
@@ -2182,7 +2352,18 @@ dependencies = [
 [[package]]
 name = "libdd-trace-protobuf"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
+dependencies = [
+ "prost 0.14.3",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "libdd-trace-protobuf"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b1bc3bd67115bec00669d84a29b7b52ef1d61f36dfb49b273b2fee3346bf18f"
 dependencies = [
  "prost 0.14.3",
  "serde",
@@ -2192,24 +2373,24 @@ dependencies = [
 [[package]]
 name = "libdd-trace-stats"
 version = "6.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23a575e3ecccfbbbd1612ddb1cb8b08e0c12ae0a62052ef995f05d93976a55b"
 dependencies = [
  "anyhow",
  "arc-swap",
  "async-trait",
- "futures",
  "hashbrown 0.15.5",
  "http 1.4.0",
- "libdd-capabilities",
- "libdd-capabilities-impl",
- "libdd-common",
- "libdd-ddsketch",
- "libdd-dogstatsd-client",
- "libdd-shared-runtime",
- "libdd-telemetry",
- "libdd-trace-obfuscation",
- "libdd-trace-protobuf",
- "libdd-trace-utils",
+ "libdd-capabilities 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-capabilities-impl 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-common 5.2.0",
+ "libdd-ddsketch 1.1.1",
+ "libdd-dogstatsd-client 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-shared-runtime 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-telemetry 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-trace-obfuscation 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-trace-protobuf 4.0.1",
+ "libdd-trace-utils 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde",
  "serde",
  "tokio",
@@ -2218,9 +2399,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "libdd-trace-stats"
+version = "6.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "async-trait",
+ "futures",
+ "hashbrown 0.15.5",
+ "http 1.4.0",
+ "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-capabilities-impl 3.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-common 5.1.0",
+ "libdd-ddsketch 1.1.0",
+ "libdd-dogstatsd-client 4.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-shared-runtime 2.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-telemetry 6.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-trace-obfuscation 5.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-trace-protobuf 4.0.0",
+ "libdd-trace-utils 9.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "rmp-serde",
+ "serde",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
 name = "libdd-trace-utils"
 version = "9.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=85ce322a1dcb1eda7df9bcc021223b2d1a236783#85ce322a1dcb1eda7df9bcc021223b2d1a236783"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2529075e0b7494767011c027750951f302b3ee8a5f5d15ab7a6e95e88a755182"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "getrandom 0.2.17",
+ "hex",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "indexmap",
+ "libdd-capabilities 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-capabilities-impl 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdd-common 5.2.0",
+ "libdd-tinybytes 1.1.2",
+ "libdd-trace-normalization 3.0.1",
+ "libdd-trace-protobuf 4.0.1",
+ "prost 0.14.3",
+ "rand 0.8.6",
+ "rmp",
+ "rmp-serde",
+ "rmpv",
+ "rustc-hash",
+ "serde",
+ "serde-transcode",
+ "serde_json",
+ "thin-vec",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "libdd-trace-utils"
+version = "9.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe#72fa86854c823361b7d234545f1a2f2d21f944fe"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2233,12 +2479,13 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "indexmap",
- "libdd-capabilities",
- "libdd-capabilities-impl",
- "libdd-common",
- "libdd-tinybytes",
- "libdd-trace-normalization",
- "libdd-trace-protobuf",
+ "itoa",
+ "libdd-capabilities 2.1.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-capabilities-impl 3.0.0 (git+https://github.com/DataDog/libdatadog?rev=72fa86854c823361b7d234545f1a2f2d21f944fe)",
+ "libdd-common 5.1.0",
+ "libdd-tinybytes 1.1.1",
+ "libdd-trace-normalization 3.0.0",
+ "libdd-trace-protobuf 4.0.0",
  "prost 0.14.3",
  "rand 0.8.6",
  "rmp",

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -78,6 +78,12 @@ indexmap = {version = "2.11.0", default-features = false}
 # be found in the clippy.toml file adjacent to this Cargo.toml.
 datadog-protos = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "f863626dbfe3c59bb390985fa6530b0621c2a0a2"}
 ddsketch-agent = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "f863626dbfe3c59bb390985fa6530b0621c2a0a2"}
+# dd-trace-rs (datadog-opentelemetry) resolves libdd-* from crates.io, so ~11 of these
+# crates are compiled twice. A `[patch.crates-io]` section used to collapse them, but it
+# cannot be restored while this rev's versions trail the published ones (libdd-common 5.1.0
+# here vs the ^5.2.0 that published libdd-data-pipeline requires) and while the rev carries
+# an unreleased breaking libdd-telemetry change under an unchanged version. Re-check with
+# `cargo tree --duplicates | grep ^libdd-` when bumping either side.
 libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "72fa86854c823361b7d234545f1a2f2d21f944fe" }
 libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "72fa86854c823361b7d234545f1a2f2d21f944fe", default-features = false }
 libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "72fa86854c823361b7d234545f1a2f2d21f944fe" }

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -78,17 +78,17 @@ indexmap = {version = "2.11.0", default-features = false}
 # be found in the clippy.toml file adjacent to this Cargo.toml.
 datadog-protos = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "f863626dbfe3c59bb390985fa6530b0621c2a0a2"}
 ddsketch-agent = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "f863626dbfe3c59bb390985fa6530b0621c2a0a2"}
-libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783", default-features = false }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783", default-features = false, features = ["mini_agent"] }
-libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783", default-features = false }
-libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783", default-features = false }
+libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "72fa86854c823361b7d234545f1a2f2d21f944fe" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "72fa86854c823361b7d234545f1a2f2d21f944fe", default-features = false }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "72fa86854c823361b7d234545f1a2f2d21f944fe" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "72fa86854c823361b7d234545f1a2f2d21f944fe", default-features = false, features = ["mini_agent"] }
+libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog", rev = "72fa86854c823361b7d234545f1a2f2d21f944fe" }
+libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "72fa86854c823361b7d234545f1a2f2d21f944fe", default-features = false }
+libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "72fa86854c823361b7d234545f1a2f2d21f944fe", default-features = false }
 datadog-opentelemetry = { git = "https://github.com/DataDog/dd-trace-rs", rev = "50bfea8755b75e448a80ac04d53fa7edd414eefe", default-features = false, features = ["_unstable_propagation"] }
-dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "d0c7f44191445e20d309734675d5e8b91d2a5d51", default-features = false }
-datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "d0c7f44191445e20d309734675d5e8b91d2a5d51", default-features = false }
-datadog-agent-config = { git = "https://github.com/DataDog/serverless-components", rev = "d0c7f44191445e20d309734675d5e8b91d2a5d51", default-features = false }
+dogstatsd = { git = "https://github.com/DataDog/serverless-components", rev = "9daae40afa87f52fad1489f4d7cfd4a579037d2d", default-features = false }
+datadog-fips = { git = "https://github.com/DataDog/serverless-components", rev = "9daae40afa87f52fad1489f4d7cfd4a579037d2d", default-features = false }
+datadog-agent-config = { git = "https://github.com/DataDog/serverless-components", rev = "9daae40afa87f52fad1489f4d7cfd4a579037d2d", default-features = false }
 libddwaf = { version = "1.28.1", git = "https://github.com/DataDog/libddwaf-rust", rev = "d1534a158d976bd4f747bf9fcc58e0712d2d17fc", default-features = false, features = ["serde"] }
 
 [dev-dependencies]
@@ -173,26 +173,3 @@ fips = [
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage,coverage_nightly)'] }
-
-# datadog-opentelemetry (dd-trace-rs) depends on these libdatadog crates via
-# crates.io, while we depend on them directly via a git rev. Without this,
-# both copies get compiled. Pointing the crates.io versions at the same git
-# rev pinned above collapses them back to one. Verify with
-# `cargo tree --duplicates | grep ^libdd-` after bumping either side.
-[patch.crates-io]
-libdd-capabilities = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
-libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
-libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
-libdd-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
-libdd-dogstatsd-client = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
-libdd-sampling = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
-libdd-shared-runtime = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
-libdd-telemetry = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
-libdd-tinybytes = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
-libdd-trace-normalization = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
-libdd-trace-obfuscation = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
-libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "85ce322a1dcb1eda7df9bcc021223b2d1a236783" }

--- a/bottlecap/src/appsec/processor/context.rs
+++ b/bottlecap/src/appsec/processor/context.rs
@@ -5,7 +5,6 @@ use std::time::Duration;
 
 use bytes::{Buf, Bytes};
 use libdd_trace_protobuf::pb::Span;
-use libdd_trace_utils::tracer_header_tags;
 use libddwaf::object::{Keyed, WafMap, WafObject};
 use libddwaf::{Context as WafContext, Handle, RunError, RunOutput, RunResult, waf_map};
 use mime::Mime;
@@ -17,6 +16,7 @@ use crate::appsec::processor::{InvocationPayload, Processor};
 use crate::config::Config;
 use crate::tags::provider::Provider;
 use crate::traces::span_pointers::SpanPointer;
+use crate::traces::trace_aggregator::OwnedTracerHeaderTags;
 use crate::traces::trace_processor::SendingTraceProcessor;
 
 /// Holds inforamtion gathered about an invocation.
@@ -116,19 +116,7 @@ impl Context {
                 .send_processed_traces(
                     args.config,
                     args.tags_provider,
-                    tracer_header_tags::TracerHeaderTags {
-                        lang: &args.tracer_header_tags_lang,
-                        lang_version: &args.tracer_header_tags_lang_version,
-                        lang_interpreter: &args.tracer_header_tags_lang_interpreter,
-                        lang_vendor: &args.tracer_header_tags_lang_vendor,
-                        tracer_version: &args.tracer_header_tags_tracer_version,
-                        container_id: &args.tracer_header_tags_container_id,
-                        client_computed_top_level: args
-                            .tracer_header_tags_client_computed_top_level,
-                        client_computed_stats: args.tracer_header_tags_client_computed_stats,
-                        dropped_p0_traces: args.tracer_header_tags_dropped_p0_traces,
-                        dropped_p0_spans: args.tracer_header_tags_dropped_p0_spans,
-                    },
+                    args.header_tags.to_tracer_header_tags(),
                     vec![trace],
                     args.body_size,
                     args.span_pointers,
@@ -547,16 +535,7 @@ pub struct HoldArguments {
     pub body_size: usize,
     pub span_pointers: Option<Vec<SpanPointer>>,
 
-    pub tracer_header_tags_lang: String,
-    pub tracer_header_tags_lang_version: String,
-    pub tracer_header_tags_lang_interpreter: String,
-    pub tracer_header_tags_lang_vendor: String,
-    pub tracer_header_tags_tracer_version: String,
-    pub tracer_header_tags_container_id: String,
-    pub tracer_header_tags_client_computed_top_level: bool,
-    pub tracer_header_tags_client_computed_stats: bool,
-    pub tracer_header_tags_dropped_p0_traces: usize,
-    pub tracer_header_tags_dropped_p0_spans: usize,
+    pub header_tags: OwnedTracerHeaderTags,
 }
 
 /// Names of tags that can be emitted by the WAF.

--- a/bottlecap/src/appsec/processor/context.rs
+++ b/bottlecap/src/appsec/processor/context.rs
@@ -19,7 +19,7 @@ use crate::traces::span_pointers::SpanPointer;
 use crate::traces::trace_aggregator::OwnedTracerHeaderTags;
 use crate::traces::trace_processor::SendingTraceProcessor;
 
-/// Holds inforamtion gathered about an invocation.
+/// Holds information gathered about an invocation.
 #[must_use]
 pub struct Context {
     /// The request ID of the invocation.

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -889,10 +889,10 @@ impl Processor {
             lang_vendor: "",
             tracer_version: "",
             container_id: "",
-            client_computed_top_level: false,
-            client_computed_stats,
-            dropped_p0_traces: 0,
-            dropped_p0_spans: 0,
+            generic: tracer_header_tags::TracerGenericTags {
+                client_computed_stats,
+                ..Default::default()
+            },
         };
 
         if let Err(e) = trace_sender

--- a/bottlecap/src/otlp/agent.rs
+++ b/bottlecap/src/otlp/agent.rs
@@ -60,7 +60,7 @@ impl TracePipeline {
 
         let lambda_extension_compute_stats = self.config.ext.lambda_extension_compute_stats;
         // Capture before `tracer_header_tags` is moved into process_traces below.
-        let client_computed_stats = tracer_header_tags.client_computed_stats;
+        let client_computed_stats = tracer_header_tags.generic.client_computed_stats;
         let (send_data_builder, processed_traces) = self.trace_processor.process_traces(
             self.config.clone(),
             self.tags_provider.clone(),

--- a/bottlecap/src/traces/stats_concentrator_service.rs
+++ b/bottlecap/src/traces/stats_concentrator_service.rs
@@ -3,7 +3,7 @@ use tokio::sync::{mpsc, oneshot};
 use crate::config::Config;
 use libdd_trace_protobuf::pb;
 use libdd_trace_protobuf::pb::{ClientStatsPayload, TracerPayload};
-use libdd_trace_stats::span_concentrator::SpanConcentrator;
+use libdd_trace_stats::span_concentrator::{CardinalityLimitConfig, SpanConcentrator};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime};
@@ -186,10 +186,24 @@ impl StatsConcentratorService {
                 .iter()
                 .map(ToString::to_string)
                 .collect(),
-            // Disable the cardinality limit to match pre-existing (unbounded) behavior.
-            Some(usize::MAX),
-            // Bottlecap does not perform agent-side stats obfuscation.
-            None,
+            // Keep stats cardinality unbounded, matching bottlecap's behavior before
+            // libdatadog gained per-field cardinality limits. Passing `None` would opt
+            // into CardinalityLimitConfig::default(): 7000 whole-key, 1024 resource,
+            // 512 http endpoint, 512 peer tags, 100 additional tags, which would
+            // silently collapse high-cardinality Lambda stats into the
+            // `tracer_blocked_value` overflow bucket. Every field is pinned instead.
+            // Per-field limits are `usize::MAX - 1` rather than `usize::MAX` only
+            // because the constructor warns when whole_key_limit is not strictly
+            // greater than every per-field limit; both values are unreachable.
+            Some(CardinalityLimitConfig {
+                whole_key_limit: usize::MAX,
+                resource_limit: usize::MAX - 1,
+                http_endpoint_limit: usize::MAX - 1,
+                peer_tags_limit: usize::MAX - 1,
+                additional_tags_limit: usize::MAX - 1,
+            }),
+            // No additional stats tag keys: aggregate on the default key fields only.
+            Vec::new(),
         );
         let service: StatsConcentratorService = Self {
             concentrator,
@@ -221,8 +235,9 @@ impl StatsConcentratorService {
         response_tx: oneshot::Sender<Option<ClientStatsPayload>>,
     ) {
         let flush_result = self.concentrator.flush(SystemTime::now(), force_flush);
-        // Obfuscation is disabled (see `SpanConcentrator::new` above), so every bucket ends up
-        // in `unobfuscated_buckets`; combine both to stay correct if that ever changes. Start
+        // Obfuscation is excluded at the feature level: bottlecap's `libdd-trace-stats`
+        // dependency does not enable `stats-obfuscation`, so every bucket ends up in
+        // `unobfuscated_buckets`; combine both to stay correct if that ever changes. Start
         // from `unobfuscated_buckets` since it's normally the only non-empty one, avoiding a
         // reallocation to grow the (usually empty) `obfuscated_buckets` vec.
         let mut stats_buckets = flush_result.unobfuscated_buckets;
@@ -397,15 +412,18 @@ mod tests {
         );
     }
 
-    /// The concentrator is configured with no cardinality limit (`Some(usize::MAX)`), so
-    /// exceeding `libdd_trace_stats`' default limit of 7,000 distinct aggregation keys per
-    /// bucket must not collapse any of them into the `tracer_blocked_value` overflow key.
+    /// The concentrator is configured with all five `CardinalityLimitConfig` limits pinned to
+    /// effectively unbounded values, so exceeding `libdd_trace_stats`' defaults must not collapse
+    /// any aggregation keys into the `tracer_blocked_value` overflow key. This exercises two
+    /// limits at once: 7,001 distinct resources exceeds both the default `whole_key_limit`
+    /// (7,000) and `resource_limit` (1,024), so a regression back to `None` (which would opt
+    /// into `CardinalityLimitConfig::default()`) fails this test twice over.
     #[tokio::test]
     async fn test_no_cardinality_limit_applied() {
-        use libdd_trace_stats::span_concentrator::DEFAULT_MAX_ENTRIES_PER_BUCKET;
+        use libdd_trace_stats::span_concentrator::CardinalityLimitConfig;
 
         const OVERFLOW_KEY: &str = "tracer_blocked_value";
-        let span_count = DEFAULT_MAX_ENTRIES_PER_BUCKET + 1;
+        let span_count = CardinalityLimitConfig::default().whole_key_limit + 1;
 
         let config = Arc::new(Config::default());
         let (service, handle) = StatsConcentratorService::new(config);

--- a/bottlecap/src/traces/trace_agent.rs
+++ b/bottlecap/src/traces/trace_agent.rs
@@ -592,7 +592,10 @@ impl TraceAgent {
 
                 if span.resource == INVOCATION_SPAN_RESOURCE
                     && let Err(e) = invocation_processor_handle
-                        .add_tracer_span(span.clone(), tracer_header_tags.client_computed_stats)
+                        .add_tracer_span(
+                            span.clone(),
+                            tracer_header_tags.generic.client_computed_stats,
+                        )
                         .await
                 {
                     error!("Failed to add tracer span to processor: {}", e);
@@ -807,7 +810,10 @@ mod tests {
             );
         }
         let tags: TracerHeaderTags<'_> = (&headers).into();
-        (tags.client_computed_stats, tags.client_computed_top_level)
+        (
+            tags.generic.client_computed_stats,
+            tags.generic.client_computed_top_level,
+        )
     }
 
     fn parse_stats(value: Option<&str>) -> bool {

--- a/bottlecap/src/traces/trace_aggregator.rs
+++ b/bottlecap/src/traces/trace_aggregator.rs
@@ -1,5 +1,5 @@
 use libdd_trace_utils::send_data::SendDataBuilder;
-use libdd_trace_utils::trace_utils::TracerHeaderTags;
+use libdd_trace_utils::trace_utils::{TracerGenericTags, TracerHeaderTags};
 use std::collections::VecDeque;
 use tracing::debug;
 
@@ -16,10 +16,7 @@ pub struct OwnedTracerHeaderTags {
     pub lang_vendor: String,
     pub tracer_version: String,
     pub container_id: String,
-    pub client_computed_top_level: bool,
-    pub client_computed_stats: bool,
-    pub dropped_p0_traces: usize,
-    pub dropped_p0_spans: usize,
+    pub generic: TracerGenericTags,
 }
 
 impl From<TracerHeaderTags<'_>> for OwnedTracerHeaderTags {
@@ -31,10 +28,7 @@ impl From<TracerHeaderTags<'_>> for OwnedTracerHeaderTags {
             lang_vendor: tags.lang_vendor.to_string(),
             tracer_version: tags.tracer_version.to_string(),
             container_id: tags.container_id.to_string(),
-            client_computed_top_level: tags.client_computed_top_level,
-            client_computed_stats: tags.client_computed_stats,
-            dropped_p0_traces: tags.dropped_p0_traces,
-            dropped_p0_spans: tags.dropped_p0_spans,
+            generic: tags.generic,
         }
     }
 }
@@ -49,10 +43,7 @@ impl OwnedTracerHeaderTags {
             lang_vendor: &self.lang_vendor,
             tracer_version: &self.tracer_version,
             container_id: &self.container_id,
-            client_computed_top_level: self.client_computed_top_level,
-            client_computed_stats: self.client_computed_stats,
-            dropped_p0_traces: self.dropped_p0_traces,
-            dropped_p0_spans: self.dropped_p0_spans,
+            generic: self.generic,
         }
     }
 }
@@ -153,7 +144,8 @@ impl TraceAggregator {
 mod tests {
     use libdd_common::Endpoint;
     use libdd_trace_utils::{
-        trace_utils::TracerHeaderTags, tracer_payload::TracerPayloadCollection,
+        trace_utils::{TracerGenericTags, TracerHeaderTags},
+        tracer_payload::TracerPayloadCollection,
     };
 
     use super::*;
@@ -166,10 +158,11 @@ mod tests {
             lang_vendor: "lang_vendor",
             tracer_version: "tracer_version",
             container_id: "container_id",
-            client_computed_top_level: true,
-            client_computed_stats: true,
-            dropped_p0_traces: 0,
-            dropped_p0_spans: 0,
+            generic: TracerGenericTags {
+                client_computed_top_level: true,
+                client_computed_stats: true,
+                ..Default::default()
+            },
         }
     }
 

--- a/bottlecap/src/traces/trace_aggregator_service.rs
+++ b/bottlecap/src/traces/trace_aggregator_service.rs
@@ -107,7 +107,8 @@ mod tests {
     use crate::traces::trace_aggregator::OwnedTracerHeaderTags;
     use libdd_common::Endpoint;
     use libdd_trace_utils::{
-        send_data::SendDataBuilder, trace_utils::TracerHeaderTags,
+        send_data::SendDataBuilder,
+        trace_utils::{TracerGenericTags, TracerHeaderTags},
         tracer_payload::TracerPayloadCollection,
     };
 
@@ -126,10 +127,11 @@ mod tests {
             lang_vendor: "lang_vendor",
             tracer_version: "tracer_version",
             container_id: "container_id",
-            client_computed_top_level: true,
-            client_computed_stats: true,
-            dropped_p0_traces: 0,
-            dropped_p0_spans: 0,
+            generic: TracerGenericTags {
+                client_computed_top_level: true,
+                client_computed_stats: true,
+                ..Default::default()
+            },
         };
         let size = 1;
         let owned_tags = OwnedTracerHeaderTags::from(tracer_header_tags.clone());

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -530,22 +530,32 @@ impl SendingTraceProcessor {
                 };
 
                 let (finalized, ctx) = appsec.process_span(span);
-                if  finalized {
+                if finalized {
                     Some(trace)
-                } else if let Some(ctx) = ctx{
-                    debug!("TRACE_PROCESSOR | Holding trace for App & API Protection additional data");
-                    ctx.hold_trace(trace, SendingTraceProcessor{ appsec:  None, processor: self.processor.clone(), trace_tx: self.trace_tx.clone(), stats_generator: self.stats_generator.clone() }, HoldArguments{
-                        config:Arc::clone(&config),
-                        tags_provider:Arc::clone(&tags_provider),
+                } else if let Some(ctx) = ctx {
+                    debug!(
+                        "TRACE_PROCESSOR | Holding trace for App & API Protection additional data"
+                    );
+                    let sender = SendingTraceProcessor {
+                        appsec: None,
+                        processor: self.processor.clone(),
+                        trace_tx: self.trace_tx.clone(),
+                        stats_generator: self.stats_generator.clone(),
+                    };
+                    let args = HoldArguments {
+                        config: Arc::clone(&config),
+                        tags_provider: Arc::clone(&tags_provider),
                         body_size,
-                        span_pointers:span_pointers.clone(),
+                        span_pointers: span_pointers.clone(),
                         header_tags: OwnedTracerHeaderTags::from(header_tags.clone()),
-                    });
+                    };
+                    ctx.hold_trace(trace, sender, args);
                     None
                 } else {
                     Some(trace)
                 }
-            }).collect()
+            })
+            .collect()
         } else {
             traces
         };

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -539,16 +539,7 @@ impl SendingTraceProcessor {
                         tags_provider:Arc::clone(&tags_provider),
                         body_size,
                         span_pointers:span_pointers.clone(),
-                        tracer_header_tags_lang: header_tags.lang.to_string(),
-                        tracer_header_tags_lang_version: header_tags.lang_version.to_string(),
-                        tracer_header_tags_lang_interpreter: header_tags.lang_interpreter.to_string(),
-                        tracer_header_tags_lang_vendor: header_tags.lang_vendor.to_string(),
-                        tracer_header_tags_tracer_version: header_tags.tracer_version.to_string(),
-                        tracer_header_tags_container_id: header_tags.container_id.to_string(),
-                        tracer_header_tags_client_computed_top_level: header_tags.client_computed_top_level,
-                        tracer_header_tags_client_computed_stats: header_tags.client_computed_stats,
-                        tracer_header_tags_dropped_p0_traces: header_tags.dropped_p0_traces,
-                        tracer_header_tags_dropped_p0_spans: header_tags.dropped_p0_spans,
+                        header_tags: OwnedTracerHeaderTags::from(header_tags.clone()),
                     });
                     None
                 } else {

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -536,11 +536,11 @@ impl SendingTraceProcessor {
                     debug!(
                         "TRACE_PROCESSOR | Holding trace for App & API Protection additional data"
                     );
+                    // Same sender, minus the App & API Protection processor, so the held
+                    // trace is not re-held when it is flushed.
                     let sender = SendingTraceProcessor {
                         appsec: None,
-                        processor: self.processor.clone(),
-                        trace_tx: self.trace_tx.clone(),
-                        stats_generator: self.stats_generator.clone(),
+                        ..self.clone()
                     };
                     let args = HoldArguments {
                         config: Arc::clone(&config),

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -399,7 +399,7 @@ impl TraceProcessor for ServerlessTraceProcessor {
                 obfuscation_config: self.obfuscation_config.clone(),
                 tags_provider: tags_provider.clone(),
                 span_pointers,
-                client_computed_stats: header_tags.client_computed_stats,
+                client_computed_stats: header_tags.generic.client_computed_stats,
             },
             true, // send agentless since we are the agent
         )
@@ -556,7 +556,7 @@ impl SendingTraceProcessor {
         }
 
         // Capture before `header_tags` is moved into process_traces below.
-        let client_computed_stats = header_tags.client_computed_stats;
+        let client_computed_stats = header_tags.generic.client_computed_stats;
 
         let (payload, processed_traces) = self.processor.process_traces(
             config.clone(),
@@ -704,10 +704,7 @@ mod tests {
             lang_vendor: "vendor",
             tracer_version: "4.0.0",
             container_id: "33",
-            client_computed_top_level: false,
-            client_computed_stats: false,
-            dropped_p0_traces: 0,
-            dropped_p0_spans: 0,
+            generic: tracer_header_tags::TracerGenericTags::default(),
         };
 
         let trace_processor = ServerlessTraceProcessor {
@@ -1201,10 +1198,7 @@ mod tests {
             lang_vendor: "",
             tracer_version: "1.0",
             container_id: "",
-            client_computed_top_level: false,
-            client_computed_stats: false,
-            dropped_p0_traces: 0,
-            dropped_p0_spans: 0,
+            generic: tracer_header_tags::TracerGenericTags::default(),
         };
 
         let make_span = |trace_id: u64, priority: Option<f64>| -> pb::Span {
@@ -1297,10 +1291,7 @@ mod tests {
             lang_vendor: "",
             tracer_version: "1.0",
             container_id: "",
-            client_computed_top_level: false,
-            client_computed_stats: false,
-            dropped_p0_traces: 0,
-            dropped_p0_spans: 0,
+            generic: tracer_header_tags::TracerGenericTags::default(),
         };
 
         let make_dropped_span = |trace_id: u64| -> pb::Span {
@@ -1378,10 +1369,7 @@ mod tests {
             lang_vendor: "",
             tracer_version: "1.0",
             container_id: "",
-            client_computed_top_level: false,
-            client_computed_stats: false,
-            dropped_p0_traces: 0,
-            dropped_p0_spans: 0,
+            generic: tracer_header_tags::TracerGenericTags::default(),
         };
 
         let make_span = |trace_id: u64, priority: f64| -> pb::Span {
@@ -1486,10 +1474,7 @@ mod tests {
             lang_vendor: "",
             tracer_version: "1.0",
             container_id: "",
-            client_computed_top_level: false,
-            client_computed_stats: false,
-            dropped_p0_traces: 0,
-            dropped_p0_spans: 0,
+            generic: tracer_header_tags::TracerGenericTags::default(),
         };
 
         let span = pb::Span {
@@ -1903,10 +1888,10 @@ mod tests {
                 lang_vendor: "vendor",
                 tracer_version: "4.0.0",
                 container_id: "33",
-                client_computed_top_level: false,
-                client_computed_stats,
-                dropped_p0_traces: 0,
-                dropped_p0_spans: 0,
+                generic: tracer_header_tags::TracerGenericTags {
+                    client_computed_stats,
+                    ..Default::default()
+                },
             };
 
             sender

--- a/bottlecap/tests/apm_integration_test.rs
+++ b/bottlecap/tests/apm_integration_test.rs
@@ -36,7 +36,7 @@ use libdd_common::Endpoint;
 use libdd_trace_obfuscation::obfuscation_config::ObfuscationConfig;
 use libdd_trace_protobuf::pb;
 use libdd_trace_utils::send_data::SendDataBuilder;
-use libdd_trace_utils::trace_utils::TracerHeaderTags;
+use libdd_trace_utils::trace_utils::{TracerGenericTags, TracerHeaderTags};
 use libdd_trace_utils::tracer_payload::TracerPayloadCollection;
 use tokio::sync::Mutex;
 
@@ -55,10 +55,11 @@ fn header_tags() -> TracerHeaderTags<'static> {
         lang_vendor: "datadog",
         tracer_version: "test",
         container_id: "",
-        client_computed_top_level: true,
-        client_computed_stats: true,
-        dropped_p0_traces: 0,
-        dropped_p0_spans: 0,
+        generic: TracerGenericTags {
+            client_computed_top_level: true,
+            client_computed_stats: true,
+            ..Default::default()
+        },
     }
 }
 
@@ -289,7 +290,10 @@ async fn trace_payload_roundtrip_through_fake_intake() {
 
 fn header_tags_with(client_computed_stats: bool) -> TracerHeaderTags<'static> {
     TracerHeaderTags {
-        client_computed_stats,
+        generic: TracerGenericTags {
+            client_computed_stats,
+            ..header_tags().generic
+        },
         ..header_tags()
     }
 }


### PR DESCRIPTION
Stacked PRs:
- DataDog/serverless-components#141
  - #1332 👈🏽 **This PR**
    - #1338
      - #1336
    - #1320

## Overview

Tactical dependency bump, **behavior-preserving**: every changed call site is adapted to the
new APIs without altering runtime behavior. In particular the new
`override_cardinality_limits` parameter is pinned to reproduce bottlecap's pre-bump
aggregation exactly (see commit 2); adopting libdatadog's default cardinality limits is a
customer-visible change and is deferred to the follow-up PR. Two queued features are blocked
behind the same dependency move:

- [**APMSVLS-469**](https://datadoghq.atlassian.net/browse/APMSVLS-469) (bottlecap error sampler, #1320) — pins the pre-merge branch rev `54e570ae`
  of the shared `datadog-agent-trace-sampler` crate, which happens to sit on the same
  libdatadog rev bottlecap uses today. Repinning to merged `main` (`9daae40`) pulls in
  libdatadog `72fa8685` via `datadog-agent-config` and hard-fails to compile against
  bottlecap's current libdatadog `85ce322a`.
- [**APMSVLS-485**](https://datadoghq.atlassian.net/browse/APMSVLS-485) (span-derived primary tags, #1336) — needs libdatadog ≥ `72fa8685` for
  `additional_metric_tag_keys` + `CardinalityLimitConfig`.

This PR does only the bump; both features become pure wiring afterwards.

| Pin | From | To |
|---|---|---|
| libdatadog (7 direct deps) | `85ce322a` | `72fa8685` |
| serverless-components (3 deps) | `d0c7f44` | `9daae40` |
| `dd-trace-rs` | `50bfea87` | unchanged |
| `[patch.crates-io]` (16 entries) | present | **deleted** |

Both rev bumps must land together: SCL `d0c7f44`'s `datadog-agent-config` pinned libdatadog
`85ce322a`, so bumping only one side leaves two `ReplaceRule` types structurally identical
but resolved as distinct crate instances, which rustc rejects with `E0308`.

`[patch.crates-io]` is deleted rather than repointed: rev `72fa8685` carries an unreleased
breaking `libdd-telemetry` change under an unchanged crate version ([libdatadog #2172](https://github.com/DataDog/libdatadog/pull/2172)), so
patching `datadog-opentelemetry` v0.5.0's transitive `libdd-telemetry` against it fails
`E0107`/`E0433`. Letting the tracer resolve `libdd-*` from `crates.io` — the arrangement
`serverless-components` already uses — avoids that, at the cost of 11 duplicated `libdd-*`
crates in the dependency graph. As a side effect, bottlecap's own `libdd-trace-stats` no
longer enables `stats-obfuscation` (that feature arrived only via the now-deleted patch's
crate-id unification), so `SpanConcentrator::new` drops its obfuscation argument entirely
(arity 6, not 7) rather than gaining a new parameter.

`dd-trace-rs` is intentionally **not** bumped: v0.5.1 raises `libdd-sampling` to 6.0.0, which
`72fa8685` does not carry. That belongs to a future `crates.io` migration.

### Commits

1. **refactor(traces): pass tracer header tags to the App & API Protection hold path as one
   struct** — pure no-op cleanup on the old rev. `HoldArguments` flattened all 10
   `TracerHeaderTags` fields with a `tracer_header_tags_` prefix; collapses them into the
   `OwnedTracerHeaderTags` struct that already exists for this purpose. Makes the bump
   commit's appsec diff zero.
2. **chore(deps): update libdatadog to 72fa8685 and serverless-components to 9daae40** — the
   bump itself:
   - `TracerHeaderTags` split (libdatadog #2279): `client_computed_stats`,
     `client_computed_top_level`, `dropped_p0_traces`, `dropped_p0_spans` moved into a nested
     `TracerGenericTags`. Mechanical follow-through at every construction site and the field
     reads that touched them directly.
   - `SpanConcentrator::new` signature: 5th param changed from
     `override_max_entries_per_bucket: Option<usize>` to
     `override_cardinality_limits: Option<CardinalityLimitConfig>`, plus a new 6th
     `additional_metric_tag_keys: Vec<String>` param. All five limits are pinned to
     effectively-unbounded values so bottlecap's pre-existing unbounded aggregation is
     preserved bit-for-bit; passing `None` would silently opt into
     `CardinalityLimitConfig::default()`. Per-field limits are `usize::MAX - 1` rather than
     `usize::MAX` only because the constructor warns when `whole_key_limit` is not strictly
     greater than every per-field limit; both values are unreachable.
     `additional_metric_tag_keys` is `Vec::new()` — no change to the aggregation dimensions.
   - `[patch.crates-io]` removed (see above).
3. **refactor(traces): simplify App & API Protection held-trace sender** — build the
   held-trace sender by spreading the existing processor rather than copying each field, so
   it does not silently need updating when `SendingTraceProcessor` gains one. Also documents
   in `Cargo.toml` why the `libdd-*` crates are no longer deduplicated, and how to re-check
   (`cargo tree --duplicates | grep ^libdd-`) when bumping either side. Repointing the patch
   at only the non-`libdd-telemetry` crates was tested and does **not** dedupe: this rev's
   `libdd-common` is 5.1.0 while published `libdd-data-pipeline` 7.0.0 requires `^5.2.0`, so
   the patch simply goes unused for the registry consumers.

### Size impact (amd64)

Built via `ARCHITECTURE=amd64 FIPS=false ./scripts/build_bottlecap_layer.sh` on `main`
(`fbf128dc`) and on this branch.

| | Baseline (`85ce322a`) | Post-bump (`72fa8685`) | Delta |
|---|---|---|---|
| Layer zip | 4,716,191 B | 4,734,152 B | +17,961 B (+0.38%) |
| Unpacked binary | 11,526,720 B | 11,571,776 B | +45,056 B (+0.39%) |
| `libdd-*` duplicates (`cargo tree --duplicates`) | 0 | 11 | +11 |

Both figures land far under the GitLab CI caps for amd64 (27 MB compressed / 54 MB
uncompressed). The release profile (`opt-level = "z"`, LTO, `codegen-units = 1`,
`strip = true`) absorbs nearly all of the size cost of the 11 newly-duplicated `libdd-*`
crates.

### Downstream handoff (not part of this PR)

- `lpimentel/add-trace-error-sampler` (#1320): rebase onto `main`, repin its four
  serverless-components deps `54e570ae` → `9daae40`. Conflicts will concentrate in
  `Cargo.toml`/`Cargo.lock` plus any `TracerHeaderTags` literals its commits added.
- Follow-up PR (APMSVLS-485, to be opened off this branch): adopt libdatadog's default
  cardinality limits — 7000 whole-key, 1024 resource, 512 http endpoint, 512 peer tags, 100
  additional tags — plus reporting when keys collapse. That is where the customer-visible
  change lives, so it is reviewed on its own rather than buried in a `chore(deps)` PR.
- `lpimentel/span-derived-primary-tags` (#1336): rebases onto that follow-up PR.

## Testing

- `cargo check --workspace --all-targets` — clean, no warnings
- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --features default -- -D warnings` — clean
- `cargo clippy --workspace --all-targets --no-default-features --features fips -- -D warnings`
  — clean (highest-risk check: patch-block deletion changes TLS feature flow)
- `cargo nextest run --workspace` — clean
- `cargo nextest run --workspace -E 'test(cardinality)'` —
  `test_no_cardinality_limit_applied` feeds 7,001 distinct resources (exceeding both the
  default `whole_key_limit` of 7,000 and `resource_limit` of 1,024) and asserts that **no**
  key collapses into `tracer_blocked_value`, so a regression back to `None` fails it twice
  over; passes
- `cargo audit` — 1 pre-existing vulnerability (`h2` 0.4.13, RUSTSEC-2026-0258), unchanged by
  this PR and present on `main` before this branch; 9 unmaintained/unsound warnings, all
  non-blocking in CI's `rustsec/audit-check` job
- `dd-rust-license-tool check` — already up to date, no `LICENSE-3rdparty.csv` changes needed
  (crate name-keyed, so the git/crates.io copies of each `libdd-*` crate collapse to one row)
- `./scripts/verify_tls_root_features.sh` — OK, reqwest root sources correct for both default
  and FIPS builds




