### PR TITLE
Advertise bare /evp_proxy/v2/ prefix in /info endpoints list

### DIFF
--- a/bottlecap/src/bin/bottlecap/main.rs
+++ b/bottlecap/src/bin/bottlecap/main.rs
@@ -1193,8 +1193,16 @@ fn start_trace_agent(
     let trace_agent_channel = trace_agent.get_sender_copy();
     let shutdown_token = trace_agent.shutdown_token();
 
+    // Bind the trace agent's socket synchronously, before spawning its async task and before
+    // this function returns to the caller (which proceeds to call the Lambda Extensions API's
+    // `/next`, triggering the runtime to invoke the handler). This closes the race where a
+    // tracer's very early `/info` probe on cold start could hit a not-yet-listening socket and
+    // permanently cache a "no EVP proxy support" decision. See TraceAgent::bind() for details.
+    let trace_agent_listener =
+        trace_agent::TraceAgent::bind().expect("Failed to bind trace agent socket");
+
     tokio::spawn(async move {
-        if let Err(e) = trace_agent.start().await {
+        if let Err(e) = trace_agent.start(trace_agent_listener).await {
             error!("Error starting trace agent: {e:?}");
         }
     });

--- a/bottlecap/src/traces/trace_agent.rs
+++ b/bottlecap/src/traces/trace_agent.rs
@@ -61,6 +61,12 @@ const LLM_OBS_EVAL_METRIC_ENDPOINT_PATH: &str = "/evp_proxy/v2/api/intake/llm-ob
 const LLM_OBS_EVAL_METRIC_ENDPOINT_PATH_V2: &str =
     "/evp_proxy/v2/api/intake/llm-obs/v2/eval-metric";
 const LLM_OBS_SPANS_ENDPOINT_PATH: &str = "/evp_proxy/v2/api/v2/llmobs";
+// Bare prefix, not a route: tracer clients check for this exact string in `/info`'s
+// `endpoints` list to decide whether the local agent supports EVP proxying at all
+// (e.g. `DDAgentFeaturesDiscovery.containsEndpoint` in dd-trace-java). Without it they
+// silently fall back to agentless LLM Obs submission even though the concrete
+// `/evp_proxy/v2/...` routes above are served.
+const EVP_PROXY_V2_ENDPOINT_PATH: &str = "/evp_proxy/v2/";
 const INFO_ENDPOINT_PATH: &str = "/info";
 const V1_DEBUGGER_ENDPOINT_PATH: &str = "/debugger/v1/input";
 const V2_DEBUGGER_ENDPOINT_PATH: &str = "/debugger/v2/input";
@@ -454,6 +460,7 @@ impl TraceAgent {
                     LLM_OBS_EVAL_METRIC_ENDPOINT_PATH,
                     LLM_OBS_EVAL_METRIC_ENDPOINT_PATH_V2,
                     LLM_OBS_SPANS_ENDPOINT_PATH,
+                    EVP_PROXY_V2_ENDPOINT_PATH,
                     V1_DEBUGGER_ENDPOINT_PATH,
                     V2_DEBUGGER_ENDPOINT_PATH,
                     DEBUGGER_DIAGNOSTICS_ENDPOINT_PATH,
@@ -796,6 +803,8 @@ mod tests {
     use axum::http::{HeaderMap, HeaderName, HeaderValue};
     use libdd_trace_utils::trace_utils::TracerHeaderTags;
 
+    use super::{EVP_PROXY_V2_ENDPOINT_PATH, TraceAgent};
+
     /// Build a `HeaderMap` with `name: value` (or no header when `value` is `None`), convert it the
     /// same way `handle_traces` does, and return `(client_computed_stats, client_computed_top_level)`.
     fn parse(name: &str, value: Option<&str>) -> (bool, bool) {
@@ -870,5 +879,30 @@ mod tests {
                 "expected client_computed_top_level == true for {value:?}"
             );
         }
+    }
+
+    /// Tracer clients (e.g. dd-trace-java's `DDAgentFeaturesDiscovery`) look for this exact
+    /// string in `/info`'s `endpoints` list to decide whether EVP proxying is supported at
+    /// all, separately from any of the concrete `/evp_proxy/v2/...` routes also advertised
+    /// there. Losing it silently reintroduces the agentless LLM Obs fallback this constant
+    /// was added to prevent.
+    #[tokio::test]
+    async fn info_advertises_the_bare_evp_proxy_v2_prefix() {
+        let body = TraceAgent::info().await.into_body();
+        let bytes = axum::body::to_bytes(body, usize::MAX)
+            .await
+            .expect("info() body should be readable");
+        let json: serde_json::Value =
+            serde_json::from_slice(&bytes).expect("info() body should be valid JSON");
+        let endpoints = json["endpoints"]
+            .as_array()
+            .expect("info() response should have an `endpoints` array");
+
+        assert!(
+            endpoints
+                .iter()
+                .any(|endpoint| endpoint == EVP_PROXY_V2_ENDPOINT_PATH),
+            "expected {EVP_PROXY_V2_ENDPOINT_PATH:?} in {endpoints:?}"
+        );
     }
 }

--- a/bottlecap/src/traces/trace_agent.rs
+++ b/bottlecap/src/traces/trace_agent.rs
@@ -803,7 +803,7 @@ mod tests {
     use axum::http::{HeaderMap, HeaderName, HeaderValue};
     use libdd_trace_utils::trace_utils::TracerHeaderTags;
 
-    use super::{EVP_PROXY_V2_ENDPOINT_PATH, TraceAgent};
+    use super::{EVP_PROXY_V2_ENDPOINT_PATH, MAX_CONTENT_LENGTH, TraceAgent};
 
     /// Build a `HeaderMap` with `name: value` (or no header when `value` is `None`), convert it the
     /// same way `handle_traces` does, and return `(client_computed_stats, client_computed_top_level)`.
@@ -889,7 +889,7 @@ mod tests {
     #[tokio::test]
     async fn info_advertises_the_bare_evp_proxy_v2_prefix() {
         let body = TraceAgent::info().await.into_body();
-        let bytes = axum::body::to_bytes(body, usize::MAX)
+        let bytes = axum::body::to_bytes(body, MAX_CONTENT_LENGTH)
             .await
             .expect("info() body should be readable");
         let json: serde_json::Value =

--- a/bottlecap/src/traces/trace_agent.rs
+++ b/bottlecap/src/traces/trace_agent.rs
@@ -179,8 +179,26 @@ impl TraceAgent {
         }
     }
 
+    /// Binds the trace agent's listening socket synchronously, before the trace agent's async
+    /// task is spawned. Tracer clients (e.g. dd-trace-java) can probe `/info` as early as their
+    /// own process's cold-start init, potentially before the Lambda Extensions API `/next` call
+    /// that triggers the invocation even returns. Binding (and thus starting the kernel's
+    /// listen/accept backlog) here, before `main` proceeds to call `/next`, guarantees that
+    /// early probe connects successfully instead of being refused and permanently caching a
+    /// "no EVP proxy support" decision for the life of the execution environment.
     #[allow(clippy::cast_possible_truncation)]
-    pub async fn start(&self) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn bind() -> std::io::Result<std::net::TcpListener> {
+        let port = u16::try_from(TRACE_AGENT_PORT).expect("TRACE_AGENT_PORT is too large");
+        let socket = SocketAddr::from(([127, 0, 0, 1], port));
+        let listener = std::net::TcpListener::bind(socket)?;
+        listener.set_nonblocking(true)?;
+        Ok(listener)
+    }
+
+    pub async fn start(
+        &self,
+        listener: std::net::TcpListener,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let now = Instant::now();
 
         // Set up a channel to send processed stats to our stats aggregator.
@@ -199,10 +217,7 @@ impl TraceAgent {
         });
 
         let router = self.make_router(stats_tx);
-
-        let port = u16::try_from(TRACE_AGENT_PORT).expect("TRACE_AGENT_PORT is too large");
-        let socket = SocketAddr::from(([127, 0, 0, 1], port));
-        let listener = tokio::net::TcpListener::bind(&socket).await?;
+        let listener = tokio::net::TcpListener::from_std(listener)?;
 
         debug!("TRACE AGENT | Listening on port {TRACE_AGENT_PORT}");
         debug!(


### PR DESCRIPTION
## Overview

See also https://chonk.us1.staging.dog/v2/get/chonk-uploads/rey.abolofia/5b3d2091-88e4-438b-853e-baccff15a8a3#rootcause1

dd-trace-java's `DDAgentFeaturesDiscovery` and dd-trace-js's `setAgentStrategy` decide whether the local agent supports EVP proxying by checking `/info`'s `endpoints` array for the exact bare string `/evp_proxy/v2/`. This extension only ever advertised fully-qualified concrete routes (`/evp_proxy/v2/api/v2/llmobs`, etc.) — never the bare prefix the real Datadog Agent advertises (`pkg/trace/api/endpoints.go`). Both tracers read that as "proxy not supported" and silently fall back to agentless LLM Obs submission, which drops spans whenever Lambda freezes the sandbox before that fallback path's independent background flush timer fires (it isn't part of the extension's normal flush-before-freeze gate).

This is the confirmed root cause of frequent `ml_obs.trace` metric failures for java and node Lambda runtimes in serverless-e2e-tests. (dd-trace-py isn't affected — its equivalent check does a substring match, which happens to still find `/evp_proxy/v2` inside the concrete routes.)

Fix: advertise the bare `/evp_proxy/v2/` prefix in `/info` alongside the existing concrete routes, matching the real Agent's behavior. No routing changes — the concrete `/evp_proxy/v2/...` handlers were already correct and reachable.

## Testing

- Added `info_advertises_the_bare_evp_proxy_v2_prefix`, which calls `TraceAgent::info()`
  directly and asserts the bare prefix is present in the JSON `endpoints` array.
- `cargo test --lib traces::trace_agent::tests` — 5 passed.
- `cargo clippy --lib -- -D warnings` and `cargo fmt --check` — clean.