### PR TITLE
fix(deps): bump h2 to 0.4.18 to fix RUSTSEC-2026-0258

### DIFF
--- a/bottlecap/Cargo.lock
+++ b/bottlecap/Cargo.lock
@@ -1340,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Overview

The **Audit** check (`cargo-audit`) is failing on `main`: [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258) — `h2` accepts and queues empty DATA frames without limit, which can lead to unbounded memory usage or a panic on length overflow. Low severity, patched in `h2` 0.4.16.

This bumps `h2` 0.4.13 → 0.4.18 in `bottlecap/Cargo.lock`. Lockfile-only; no source changes.

Notes on the diff:
- `LICENSE-3rdparty.csv` is unchanged. `h2` is already listed there (the CSV carries no versions) and no crates were added or removed, so `dd-rust-license-tool write` produces no change for this bump.
- The diff is restricted to the two `h2` lines. Running `cargo update -p h2` locally also re-resolved six unrelated `windows-sys` entries downward (0.61.2 → 0.52.0/0.60.2); that churn was reverted, and `cargo metadata --locked` confirms the lockfile is still self-consistent.

## Testing

- `cargo audit` locally on the updated lockfile: 0 vulnerabilities. The 9 remaining `unmaintained`/`unsound` warnings are pre-existing on `main` and are not what fails the check (the job failed on "Critical vulnerabilities were found").
- `cargo metadata --locked` succeeds, i.e. the hand-edited lockfile needs no further resolution.
- No Rust source changed, so `cargo clippy` / `cargo fmt` were not re-run; CI covers the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)