### PR TITLE
[APMSVLS-485] feat(traces): span-derived primary tags

### DIFF
--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -107,15 +107,15 @@ pub struct LambdaConfig {
     /// present in the Lambda event payload (`DD_DSM_KAFKA_GROUP`).
     pub dsm_kafka_group: Option<String>,
 
-    /// `DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED` — gates `additional_metric_tags` and
+    /// `DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED`: gates `additional_metric_tags` and
     /// `additional_metric_tags_cardinality_limit` below, matching the Serverless
     /// Compatibility Layer (`datadog-trace-agent`).
     pub trace_experimental_features_enabled: bool,
-    /// `DD_TRACE_STATS_ADDITIONAL_TAGS` — comma-separated span `meta` keys included as
+    /// `DD_TRACE_STATS_ADDITIONAL_TAGS`: comma-separated span `meta` keys included as
     /// additional dimensions on trace stats aggregation (`ClientGroupedStats.additional_metric_tags`).
     /// Only honored when `trace_experimental_features_enabled` is true.
     pub additional_metric_tags: Vec<String>,
-    /// `DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT` — per-bucket cap on distinct
+    /// `DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT`: per-bucket cap on distinct
     /// `additional_metric_tags` value combinations; `None` uses libdatadog's default (100).
     /// Only honored when `trace_experimental_features_enabled` is true.
     pub additional_metric_tags_cardinality_limit: Option<usize>,
@@ -245,16 +245,16 @@ pub struct LambdaConfigSource {
     #[serde(deserialize_with = "deser_opt_str")]
     pub dsm_kafka_group: Option<String>,
 
-    /// `DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED` — see `LambdaConfig::trace_experimental_features_enabled`.
+    /// `DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED`: see `LambdaConfig::trace_experimental_features_enabled`.
     #[serde(deserialize_with = "deser_opt_bool")]
     pub trace_experimental_features_enabled: Option<bool>,
-    /// `DD_TRACE_STATS_ADDITIONAL_TAGS` — see `LambdaConfig::additional_metric_tags`.
+    /// `DD_TRACE_STATS_ADDITIONAL_TAGS`: see `LambdaConfig::additional_metric_tags`.
     /// Gated after all config sources merge by `apply_experimental_features_gate`. Field is
     /// named `trace_stats_additional_tags` (rather than `additional_metric_tags`) so it maps
     /// to the `DD_TRACE_STATS_ADDITIONAL_TAGS` env var via the field-name-to-env-var convention.
     #[serde(deserialize_with = "deser_csv")]
     pub trace_stats_additional_tags: Vec<String>,
-    /// `DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT` — see
+    /// `DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT`: see
     /// `LambdaConfig::additional_metric_tags_cardinality_limit`. Gated after all config sources
     /// merge by `apply_experimental_features_gate`. See
     /// `trace_stats_additional_tags` above for why the field name differs from the

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -28,7 +28,9 @@ pub type Config = datadog_agent_config::Config<LambdaConfig>;
 #[inline]
 #[must_use]
 pub fn get_config(config_directory: &Path) -> Config {
-    get_config_with_extension::<LambdaConfig>(config_directory)
+    let mut config = get_config_with_extension::<LambdaConfig>(config_directory);
+    config.ext.apply_experimental_features_gate();
+    config
 }
 // ---------------------------------------------------------------------------
 // LambdaConfig — bottlecap's `ConfigExtension` for the shared
@@ -318,19 +320,32 @@ impl DatadogConfigExtension for LambdaConfig {
                 .clone_from(&source.lambda_customer_metrics_exclude_tags);
         }
 
-        // additional_metric_tags / additional_metric_tags_cardinality_limit are only
-        // honored when trace_experimental_features_enabled is true, matching the Serverless
-        // Compatibility Layer (datadog-trace-agent). When the gate is off, always reset
-        // both to their defaults so a stale/misconfigured env var can't leak through.
-        if self.trace_experimental_features_enabled {
-            if !source.trace_stats_additional_tags.is_empty() {
-                self.additional_metric_tags
-                    .clone_from(&source.trace_stats_additional_tags);
-            }
-            if let Some(limit) = source.trace_stats_additional_tags_cardinality_limit {
-                self.additional_metric_tags_cardinality_limit = Some(limit);
-            }
-        } else {
+        // trace_stats_additional_tags (source) → additional_metric_tags (config), and likewise
+        // for the cardinality limit. Merged unconditionally here: `merge_from` runs once per
+        // config source (datadog.yaml, then env vars), so gating on
+        // `trace_experimental_features_enabled` at this point would discard a value read from
+        // datadog.yaml whenever the gate itself only arrives with the later env-var pass.
+        // `apply_experimental_features_gate` applies the gate once, after every source has
+        // merged.
+        if !source.trace_stats_additional_tags.is_empty() {
+            self.additional_metric_tags
+                .clone_from(&source.trace_stats_additional_tags);
+        }
+        if let Some(limit) = source.trace_stats_additional_tags_cardinality_limit {
+            self.additional_metric_tags_cardinality_limit = Some(limit);
+        }
+    }
+}
+
+impl LambdaConfig {
+    /// Drop `additional_metric_tags` / `additional_metric_tags_cardinality_limit` unless
+    /// `trace_experimental_features_enabled` is set, matching the Serverless Compatibility
+    /// Layer (`datadog-trace-agent`).
+    ///
+    /// Applied after all config sources have merged, not inside `merge_from`, so that the gate
+    /// and the values it gates can come from different sources in either order.
+    fn apply_experimental_features_gate(&mut self) {
+        if !self.trace_experimental_features_enabled {
             self.additional_metric_tags.clear();
             self.additional_metric_tags_cardinality_limit = None;
         }
@@ -341,9 +356,7 @@ impl DatadogConfigExtension for LambdaConfig {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod lambda_config_tests {
-    use datadog_agent_config::{
-        Config as UpstreamConfig, flush_strategy::PeriodicStrategy, get_config_with_extension,
-    };
+    use datadog_agent_config::{Config as UpstreamConfig, flush_strategy::PeriodicStrategy};
     use figment::Jail;
 
     use super::*;
@@ -355,7 +368,9 @@ mod lambda_config_tests {
         Jail::expect_with(|jail| {
             jail.clear_env();
             jail_setup(jail)?;
-            result = Some(get_config_with_extension::<LambdaConfig>(Path::new("")));
+            // `get_config`, not `get_config_with_extension`, so the post-merge
+            // `apply_experimental_features_gate` step is covered too.
+            result = Some(get_config(Path::new("")));
             Ok(())
         });
         result.unwrap()
@@ -916,6 +931,44 @@ mod lambda_config_tests {
             );
             Ok(())
         });
+        assert_eq!(config.ext.additional_metric_tags_cardinality_limit, None);
+    }
+
+    /// The gate and the values it gates may come from different config sources. Sources merge
+    /// one at a time (datadog.yaml first, then env vars), so gating during the merge would
+    /// drop the yaml values before the env-var pass ever enables the gate.
+    #[test]
+    fn additional_metric_tags_from_yaml_survive_an_env_only_experimental_gate() {
+        let config = load(|jail| {
+            jail.create_file(
+                "datadog.yaml",
+                "trace_stats_additional_tags: \"region,zone\"\n\
+                 trace_stats_additional_tags_cardinality_limit: 7\n",
+            )?;
+            jail.set_env("DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED", "true");
+            Ok(())
+        });
+        assert_eq!(
+            config.ext.additional_metric_tags,
+            vec!["region".to_string(), "zone".to_string()]
+        );
+        assert_eq!(config.ext.additional_metric_tags_cardinality_limit, Some(7));
+    }
+
+    /// The mirror of the above: an env-var gate of `false` must still win over yaml values.
+    #[test]
+    fn additional_metric_tags_from_yaml_dropped_when_env_disables_the_gate() {
+        let config = load(|jail| {
+            jail.create_file(
+                "datadog.yaml",
+                "trace_experimental_features_enabled: true\n\
+                 trace_stats_additional_tags: \"region,zone\"\n\
+                 trace_stats_additional_tags_cardinality_limit: 7\n",
+            )?;
+            jail.set_env("DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED", "false");
+            Ok(())
+        });
+        assert!(config.ext.additional_metric_tags.is_empty());
         assert_eq!(config.ext.additional_metric_tags_cardinality_limit, None);
     }
 }

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -104,6 +104,19 @@ pub struct LambdaConfig {
     /// Consumer group used for `MSK`/Kafka DSM consume checkpoints, which is not
     /// present in the Lambda event payload (`DD_DSM_KAFKA_GROUP`).
     pub dsm_kafka_group: Option<String>,
+
+    /// `DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED` — gates `additional_metric_tags` and
+    /// `additional_metric_tags_cardinality_limit` below, matching the Serverless
+    /// Compatibility Layer (`datadog-trace-agent`).
+    pub trace_experimental_features_enabled: bool,
+    /// `DD_TRACE_STATS_ADDITIONAL_TAGS` — comma-separated span `meta` keys included as
+    /// additional dimensions on trace stats aggregation (`ClientGroupedStats.additional_metric_tags`).
+    /// Only honored when `trace_experimental_features_enabled` is true.
+    pub additional_metric_tags: Vec<String>,
+    /// `DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT` — per-bucket cap on distinct
+    /// `additional_metric_tags` value combinations; `None` uses libdatadog's default (100).
+    /// Only honored when `trace_experimental_features_enabled` is true.
+    pub additional_metric_tags_cardinality_limit: Option<usize>,
 }
 
 impl Default for LambdaConfig {
@@ -132,6 +145,9 @@ impl Default for LambdaConfig {
             dsm_consume_enabled: false,
             dsm_exchange_name: None,
             dsm_kafka_group: None,
+            trace_experimental_features_enabled: false,
+            additional_metric_tags: Vec::new(),
+            additional_metric_tags_cardinality_limit: None,
         }
     }
 }
@@ -226,6 +242,23 @@ pub struct LambdaConfigSource {
     /// `DD_DSM_KAFKA_GROUP` — consumer group for MSK/Kafka DSM consume checkpoints.
     #[serde(deserialize_with = "deser_opt_str")]
     pub dsm_kafka_group: Option<String>,
+
+    /// `DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED` — see `LambdaConfig::trace_experimental_features_enabled`.
+    #[serde(deserialize_with = "deser_opt_bool")]
+    pub trace_experimental_features_enabled: Option<bool>,
+    /// `DD_TRACE_STATS_ADDITIONAL_TAGS` — see `LambdaConfig::additional_metric_tags`.
+    /// Gated on `trace_experimental_features_enabled` in `merge_from`, not here. Field is
+    /// named `trace_stats_additional_tags` (rather than `additional_metric_tags`) so it maps
+    /// to the `DD_TRACE_STATS_ADDITIONAL_TAGS` env var via the field-name-to-env-var convention.
+    #[serde(deserialize_with = "deser_csv")]
+    pub trace_stats_additional_tags: Vec<String>,
+    /// `DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT` — see
+    /// `LambdaConfig::additional_metric_tags_cardinality_limit`. Gated on
+    /// `trace_experimental_features_enabled` in `merge_from`, not here. See
+    /// `trace_stats_additional_tags` above for why the field name differs from the
+    /// `LambdaConfig` field it merges into.
+    #[serde(deserialize_with = "deser_opt_lossless")]
+    pub trace_stats_additional_tags_cardinality_limit: Option<usize>,
 }
 
 impl DatadogConfigExtension for LambdaConfig {
@@ -251,6 +284,7 @@ impl DatadogConfigExtension for LambdaConfig {
                 api_security_sample_delay,
                 trace_remove_integration_service_names_enabled,
                 lambda_durable_function_log_buffer_size,
+                trace_experimental_features_enabled,
             ],
             option: [span_dedup_timeout, api_key_secret_reload_interval, appsec_rules, dsm_exchange_name, dsm_kafka_group],
         );
@@ -282,6 +316,23 @@ impl DatadogConfigExtension for LambdaConfig {
         if !source.lambda_customer_metrics_exclude_tags.is_empty() {
             self.custom_metrics_exclude_tags
                 .clone_from(&source.lambda_customer_metrics_exclude_tags);
+        }
+
+        // additional_metric_tags / additional_metric_tags_cardinality_limit are only
+        // honored when trace_experimental_features_enabled is true, matching the Serverless
+        // Compatibility Layer (datadog-trace-agent). When the gate is off, always reset
+        // both to their defaults so a stale/misconfigured env var can't leak through.
+        if self.trace_experimental_features_enabled {
+            if !source.trace_stats_additional_tags.is_empty() {
+                self.additional_metric_tags
+                    .clone_from(&source.trace_stats_additional_tags);
+            }
+            if let Some(limit) = source.trace_stats_additional_tags_cardinality_limit {
+                self.additional_metric_tags_cardinality_limit = Some(limit);
+            }
+        } else {
+            self.additional_metric_tags.clear();
+            self.additional_metric_tags_cardinality_limit = None;
         }
     }
 }
@@ -806,5 +857,65 @@ mod lambda_config_tests {
         });
         // Default is true.
         assert!(config.ext.enhanced_metrics);
+    }
+
+    // ---- additional_metric_tags (span-derived primary tags), gated on
+    // trace_experimental_features_enabled, matching the Serverless Compatibility Layer
+    // (datadog-trace-agent) ----
+
+    #[test]
+    fn additional_metric_tags_ignored_when_experimental_features_disabled() {
+        let config = load(|jail| {
+            jail.set_env("DD_TRACE_STATS_ADDITIONAL_TAGS", "region,tenant_id");
+            Ok(())
+        });
+        assert!(!config.ext.trace_experimental_features_enabled);
+        assert!(config.ext.additional_metric_tags.is_empty());
+    }
+
+    #[test]
+    fn additional_metric_tags_from_env_when_trace_experimental_features_enabled() {
+        let config = load(|jail| {
+            jail.set_env("DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED", "true");
+            jail.set_env("DD_TRACE_STATS_ADDITIONAL_TAGS", "region, tenant_id");
+            Ok(())
+        });
+        assert!(config.ext.trace_experimental_features_enabled);
+        assert_eq!(
+            config.ext.additional_metric_tags,
+            vec!["region".to_string(), "tenant_id".to_string()]
+        );
+    }
+
+    #[test]
+    fn additional_metric_tags_cardinality_limit_ignored_when_experimental_features_disabled() {
+        let config = load(|jail| {
+            jail.set_env("DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT", "5");
+            Ok(())
+        });
+        assert_eq!(config.ext.additional_metric_tags_cardinality_limit, None);
+    }
+
+    #[test]
+    fn additional_metric_tags_cardinality_limit_from_env_when_experimental_gate_enabled() {
+        let config = load(|jail| {
+            jail.set_env("DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED", "true");
+            jail.set_env("DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT", "5");
+            Ok(())
+        });
+        assert_eq!(config.ext.additional_metric_tags_cardinality_limit, Some(5));
+    }
+
+    #[test]
+    fn additional_metric_tags_cardinality_limit_invalid_value_falls_back_to_none() {
+        let config = load(|jail| {
+            jail.set_env("DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED", "true");
+            jail.set_env(
+                "DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT",
+                "not-a-number",
+            );
+            Ok(())
+        });
+        assert_eq!(config.ext.additional_metric_tags_cardinality_limit, None);
     }
 }

--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -249,14 +249,14 @@ pub struct LambdaConfigSource {
     #[serde(deserialize_with = "deser_opt_bool")]
     pub trace_experimental_features_enabled: Option<bool>,
     /// `DD_TRACE_STATS_ADDITIONAL_TAGS` — see `LambdaConfig::additional_metric_tags`.
-    /// Gated on `trace_experimental_features_enabled` in `merge_from`, not here. Field is
+    /// Gated after all config sources merge by `apply_experimental_features_gate`. Field is
     /// named `trace_stats_additional_tags` (rather than `additional_metric_tags`) so it maps
     /// to the `DD_TRACE_STATS_ADDITIONAL_TAGS` env var via the field-name-to-env-var convention.
     #[serde(deserialize_with = "deser_csv")]
     pub trace_stats_additional_tags: Vec<String>,
     /// `DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT` — see
-    /// `LambdaConfig::additional_metric_tags_cardinality_limit`. Gated on
-    /// `trace_experimental_features_enabled` in `merge_from`, not here. See
+    /// `LambdaConfig::additional_metric_tags_cardinality_limit`. Gated after all config sources
+    /// merge by `apply_experimental_features_gate`. See
     /// `trace_stats_additional_tags` above for why the field name differs from the
     /// `LambdaConfig` field it merges into.
     #[serde(deserialize_with = "deser_opt_lossless")]

--- a/bottlecap/src/traces/stats_concentrator_service.rs
+++ b/bottlecap/src/traces/stats_concentrator_service.rs
@@ -184,6 +184,45 @@ fn is_sentinel_tag(tag: &str) -> bool {
     tag.split_once(':').map_or(tag, |(key, _)| key) == TRACER_BLOCKED_VALUE
 }
 
+/// Build the `CardinalityLimitConfig` override for a user-supplied
+/// `DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT`, or `None` to keep libdatadog's defaults.
+///
+/// libdatadog only warns about out-of-range limits, it still applies them, so validate here:
+/// `0` would collapse *every* additional tag into the `tracer_blocked_value` sentinel, and any
+/// value at or above `whole_key_limit` is inert because the whole-key limit collapses the key
+/// first. Both are almost certainly misconfigurations rather than intent.
+fn resolve_cardinality_limits(configured_limit: Option<usize>) -> Option<CardinalityLimitConfig> {
+    let defaults = CardinalityLimitConfig::default();
+    // `saturating_sub` keeps the clamp below the whole-key limit so it stays effective.
+    let max_effective_limit = defaults.whole_key_limit.saturating_sub(1);
+
+    let additional_tags_limit = match configured_limit? {
+        0 => {
+            warn!(
+                "DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT=0 would collapse all additional \
+                 metric tags into `tracer_blocked_value`; using the default of {} instead.",
+                defaults.additional_tags_limit
+            );
+            return None;
+        }
+        limit if limit > max_effective_limit => {
+            warn!(
+                "DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT={limit} is at or above the \
+                 whole-key cardinality limit ({}), which would make it ineffective; clamping to \
+                 {max_effective_limit}.",
+                defaults.whole_key_limit
+            );
+            max_effective_limit
+        }
+        limit => limit,
+    };
+
+    Some(CardinalityLimitConfig {
+        additional_tags_limit,
+        ..defaults
+    })
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum StatsError {
     #[error("Failed to send command to concentrator: {0}")]
@@ -296,17 +335,12 @@ impl StatsConcentratorService {
     pub fn new(config: Arc<Config>) -> (Self, StatsConcentratorHandle) {
         let (tx, rx) = mpsc::unbounded_channel();
         let handle = StatsConcentratorHandle::new(tx);
-        // Overriding `additional_tags_limit` from `DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT`
-        // is resolved here, once, so the limits the collapse warnings quote are the same values
-        // the concentrator enforces.
-        let cardinality_limits = config
-            .ext
-            .additional_metric_tags_cardinality_limit
-            .map(|additional_tags_limit| CardinalityLimitConfig {
-                additional_tags_limit,
-                ..Default::default()
-            })
-            .unwrap_or_default();
+        // Resolved once, here, so the limits the collapse warnings quote are the same values the
+        // concentrator enforces. `unwrap_or_default()` mirrors what libdatadog does with a `None`
+        // override.
+        let cardinality_limits =
+            resolve_cardinality_limits(config.ext.additional_metric_tags_cardinality_limit)
+                .unwrap_or_default();
         let additional_metric_tag_keys = config.ext.additional_metric_tags.clone();
         let possible_collapsed_fields =
             CollapsedFields::possible(!additional_metric_tag_keys.is_empty());
@@ -662,6 +696,38 @@ mod tests {
                 .iter()
                 .map(|s| &s.additional_metric_tags)
                 .collect::<Vec<_>>()
+        );
+    }
+
+    /// libdatadog only warns about out-of-range cardinality limits and still applies them, so
+    /// `resolve_cardinality_limits` has to reject the two misconfigurations that would silently
+    /// break stats: `0` (collapses every additional tag) and any value at or above the whole-key
+    /// limit (inert, because the whole-key limit collapses the key first).
+    #[test]
+    fn test_resolve_cardinality_limits() {
+        let defaults = CardinalityLimitConfig::default();
+
+        // Unset: keep libdatadog's defaults entirely.
+        assert_eq!(resolve_cardinality_limits(None), None);
+
+        // 0 would collapse everything, fall back to the defaults.
+        assert_eq!(resolve_cardinality_limits(Some(0)), None);
+
+        // In-range values are applied, leaving the other limits at their defaults.
+        let resolved = resolve_cardinality_limits(Some(5)).expect("expected an override");
+        assert_eq!(resolved.additional_tags_limit, 5);
+        assert_eq!(resolved.whole_key_limit, defaults.whole_key_limit);
+        assert_eq!(resolved.resource_limit, defaults.resource_limit);
+
+        // At or above the whole-key limit is clamped so it stays effective.
+        let clamped = resolve_cardinality_limits(Some(defaults.whole_key_limit))
+            .expect("expected an override");
+        assert_eq!(clamped.additional_tags_limit, defaults.whole_key_limit - 1);
+        let clamped_high =
+            resolve_cardinality_limits(Some(usize::MAX)).expect("expected an override");
+        assert_eq!(
+            clamped_high.additional_tags_limit,
+            defaults.whole_key_limit - 1
         );
     }
 

--- a/bottlecap/src/traces/stats_concentrator_service.rs
+++ b/bottlecap/src/traces/stats_concentrator_service.rs
@@ -259,7 +259,7 @@ fn resolve_cardinality_limits(configured_limit: Option<usize>) -> Option<Cardina
 ///
 /// libdatadog normalizes the requested keys (sort, dedup, truncate to its own private cap) and
 /// exposes the survivors via `SpanConcentrator::additional_metric_tag_keys()`, so `kept` is asked
-/// for rather than recomputed — no hand-copied cap and no mirrored normalization to drift out of
+/// for rather than recomputed: no hand-copied cap and no mirrored normalization to drift out of
 /// sync with upstream. Excess keys are dropped by alphabetical accident rather than by anything
 /// the user expressed, and libdatadog's own warning names the dropped keys but not the kept ones,
 /// the selection rule, or the env var, so restate all three here. Truncation itself is left to

--- a/bottlecap/src/traces/stats_concentrator_service.rs
+++ b/bottlecap/src/traces/stats_concentrator_service.rs
@@ -184,13 +184,6 @@ fn is_sentinel_tag(tag: &str) -> bool {
     tag.split_once(':').map_or(tag, |(key, _)| key) == TRACER_BLOCKED_VALUE
 }
 
-/// Maximum number of additional metric tag keys libdatadog will aggregate on.
-///
-/// TODO: mirrors `ADDITIONAL_METRIC_TAGS_MAX_KEYS` in libdatadog's
-/// `libdd-trace-stats/src/span_concentrator/mod.rs`, which is private. Hand-copied here only to
-/// warn about excess keys in bottlecap's own terms; libdatadog still owns the actual truncation.
-const MAX_ADDITIONAL_METRIC_TAG_KEYS: usize = 4;
-
 /// Build the `CardinalityLimitConfig` override for a user-supplied
 /// `DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT`, or `None` to keep libdatadog's defaults.
 ///
@@ -199,8 +192,8 @@ const MAX_ADDITIONAL_METRIC_TAG_KEYS: usize = 4;
 /// `0` is the dangerous one: libdatadog would collapse *every* additional tag into the
 /// `tracer_blocked_value` sentinel. Note the Go trace agent reads `0` as "no cap" instead, so a
 /// user carrying that setting over would otherwise silently lose every tag value. Falling back to
-/// the default keeps aggregation working; "unbounded" is deliberately not offered, since #1332
-/// bounded this precisely to cap concentrator memory in a memory-capped Lambda.
+/// the default keeps aggregation working; "unbounded" is deliberately not offered, since these
+/// limits exist precisely to cap concentrator memory inside a memory-capped Lambda.
 ///
 /// Values at or above `whole_key_limit` are clamped mainly to silence libdatadog's
 /// misconfiguration warning. Per-field limits are applied *before* the whole-key limit, so such a
@@ -242,39 +235,34 @@ fn resolve_cardinality_limits(configured_limit: Option<usize>) -> Option<Cardina
 
 /// Warn when `DD_TRACE_STATS_ADDITIONAL_TAGS` lists more keys than libdatadog will aggregate on.
 ///
-/// libdatadog sorts alphabetically and keeps only the first
-/// [`MAX_ADDITIONAL_METRIC_TAG_KEYS`], so excess keys are dropped by alphabetical accident
-/// rather than by anything the user expressed. Its own warning names the dropped keys but not
-/// the kept ones, the selection rule, or the env var, so restate all three here. Truncation
-/// itself is left to libdatadog; this only reports it.
-fn warn_on_excess_additional_metric_tag_keys(keys: &[String]) {
-    if let Some((kept, dropped)) = split_additional_metric_tag_keys(keys) {
-        warn!(
-            "DD_TRACE_STATS_ADDITIONAL_TAGS lists {} unique keys but at most {} are aggregated \
-             on. Keys are sorted alphabetically and the rest dropped, so stats will use {kept:?} \
-             and ignore {dropped:?}. Reduce the list to at most {} keys to choose explicitly.",
-            kept.len() + dropped.len(),
-            MAX_ADDITIONAL_METRIC_TAG_KEYS,
-            MAX_ADDITIONAL_METRIC_TAG_KEYS,
-        );
+/// libdatadog normalizes the requested keys (sort, dedup, truncate to its own private cap) and
+/// exposes the survivors via `SpanConcentrator::additional_metric_tag_keys()`, so `kept` is asked
+/// for rather than recomputed — no hand-copied cap and no mirrored normalization to drift out of
+/// sync with upstream. Excess keys are dropped by alphabetical accident rather than by anything
+/// the user expressed, and libdatadog's own warning names the dropped keys but not the kept ones,
+/// the selection rule, or the env var, so restate all three here. Truncation itself is left to
+/// libdatadog; this only reports it.
+fn warn_on_excess_additional_metric_tag_keys(requested: &[String], kept: &[String]) {
+    let mut dropped: Vec<&str> = requested
+        .iter()
+        .map(String::as_str)
+        .filter(|key| !kept.iter().any(|k| k == key))
+        .collect();
+    if dropped.is_empty() {
+        return;
     }
-}
+    // The request may repeat a dropped key; report each once, ordered as libdatadog sorts them.
+    dropped.sort_unstable();
+    dropped.dedup();
 
-/// Split `keys` into the keys libdatadog will keep and the ones it will drop, or `None` when the
-/// list is within [`MAX_ADDITIONAL_METRIC_TAG_KEYS`].
-///
-/// Mirrors libdatadog's `normalize_additional_metric_tag_keys` (sort, dedup, truncate) so the
-/// split reported matches the split it will actually apply.
-fn split_additional_metric_tag_keys(keys: &[String]) -> Option<(Vec<&str>, Vec<&str>)> {
-    let mut normalized: Vec<&str> = keys.iter().map(String::as_str).collect();
-    normalized.sort_unstable();
-    normalized.dedup();
-
-    if normalized.len() <= MAX_ADDITIONAL_METRIC_TAG_KEYS {
-        return None;
-    }
-    let dropped = normalized.split_off(MAX_ADDITIONAL_METRIC_TAG_KEYS);
-    Some((normalized, dropped))
+    warn!(
+        "DD_TRACE_STATS_ADDITIONAL_TAGS lists {} unique keys but at most {} are aggregated on. \
+         Keys are sorted alphabetically and the rest dropped, so stats will use {kept:?} and \
+         ignore {dropped:?}. Reduce the list to at most {} keys to choose explicitly.",
+        kept.len() + dropped.len(),
+        kept.len(),
+        kept.len(),
+    );
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -389,7 +377,6 @@ impl StatsConcentratorService {
     pub fn new(config: Arc<Config>) -> (Self, StatsConcentratorHandle) {
         let (tx, rx) = mpsc::unbounded_channel();
         let handle = StatsConcentratorHandle::new(tx);
-        warn_on_excess_additional_metric_tag_keys(&config.ext.additional_metric_tags);
         // Resolved once, here, so the limits the collapse warnings quote are the same values the
         // concentrator enforces. `unwrap_or_default()` mirrors what libdatadog does with a `None`
         // override.
@@ -425,6 +412,12 @@ impl StatsConcentratorService {
             // Span meta keys included as additional aggregation dimensions, from
             // DD_TRACE_STATS_ADDITIONAL_TAGS (only set when experimental_features_enabled).
             additional_metric_tag_keys,
+        );
+        // After construction, so the kept keys can be read back off the concentrator rather than
+        // predicted.
+        warn_on_excess_additional_metric_tag_keys(
+            &config.ext.additional_metric_tags,
+            concentrator.additional_metric_tag_keys(),
         );
         let service: StatsConcentratorService = Self {
             concentrator,
@@ -786,40 +779,54 @@ mod tests {
         );
     }
 
-    /// libdatadog silently keeps only the first `MAX_ADDITIONAL_METRIC_TAG_KEYS` keys after
-    /// sorting alphabetically, so which keys survive is an alphabetical accident rather than
-    /// anything the user expressed. Verify the split we report matches that rule.
+    /// The dropped keys are derived by diffing the request against what the concentrator actually
+    /// kept, so this asserts on libdatadog's real normalization rather than on a mirrored copy of
+    /// it: build a concentrator with the requested keys and check which survive.
+    ///
+    /// Which keys survive is an alphabetical accident rather than anything the user expressed,
+    /// which is the whole reason the warning exists.
     #[test]
-    fn test_split_additional_metric_tag_keys() {
-        let keys =
-            |keys: &[&str]| -> Vec<String> { keys.iter().map(ToString::to_string).collect() };
+    fn test_kept_and_dropped_additional_metric_tag_keys() {
+        let concentrator_keys = |requested: &[&str]| -> Vec<String> {
+            let concentrator = SpanConcentrator::new(
+                Duration::from_nanos(BUCKET_DURATION_NS),
+                SystemTime::now(),
+                Vec::new(),
+                Vec::new(),
+                None,
+                requested.iter().map(ToString::to_string).collect(),
+            );
+            concentrator.additional_metric_tag_keys().to_vec()
+        };
 
-        // Within the cap: nothing is dropped.
-        assert_eq!(split_additional_metric_tag_keys(&[]), None);
+        // Within the cap: everything is kept, so nothing is dropped.
+        assert!(concentrator_keys(&[]).is_empty());
         assert_eq!(
-            split_additional_metric_tag_keys(&keys(&["region", "shard", "zone", "tenant_id"])),
-            None
+            concentrator_keys(&["region", "shard", "zone", "tenant_id"]),
+            vec!["region", "shard", "tenant_id", "zone"],
+            "Within the cap every key is kept, sorted."
         );
 
-        // Duplicates collapse first, so this stays within the cap.
+        // Duplicates collapse, so this stays within the cap.
         assert_eq!(
-            split_additional_metric_tag_keys(&keys(&["region", "region", "shard"])),
-            None
+            concentrator_keys(&["region", "region", "shard"]),
+            vec!["region", "shard"]
         );
 
         // Over the cap: alphabetical order decides, so `zone` loses despite being listed first.
+        let requested = ["zone", "tenant_id", "region", "shard", "customer"];
+        let kept = concentrator_keys(&requested);
+        assert_eq!(kept, vec!["customer", "region", "shard", "tenant_id"]);
+
+        let dropped: Vec<&str> = requested
+            .iter()
+            .copied()
+            .filter(|key| !kept.iter().any(|k| k == key))
+            .collect();
         assert_eq!(
-            split_additional_metric_tag_keys(&keys(&[
-                "zone",
-                "tenant_id",
-                "region",
-                "shard",
-                "customer"
-            ])),
-            Some((
-                vec!["customer", "region", "shard", "tenant_id"],
-                vec!["zone"]
-            ))
+            dropped,
+            vec!["zone"],
+            "The warning reports exactly the keys the concentrator did not keep."
         );
     }
 

--- a/bottlecap/src/traces/stats_concentrator_service.rs
+++ b/bottlecap/src/traces/stats_concentrator_service.rs
@@ -296,8 +296,18 @@ impl StatsConcentratorService {
     pub fn new(config: Arc<Config>) -> (Self, StatsConcentratorHandle) {
         let (tx, rx) = mpsc::unbounded_channel();
         let handle = StatsConcentratorHandle::new(tx);
-        let cardinality_limits = CardinalityLimitConfig::default();
-        let additional_metric_tag_keys = Vec::new();
+        // Overriding `additional_tags_limit` from `DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT`
+        // is resolved here, once, so the limits the collapse warnings quote are the same values
+        // the concentrator enforces.
+        let cardinality_limits = config
+            .ext
+            .additional_metric_tags_cardinality_limit
+            .map(|additional_tags_limit| CardinalityLimitConfig {
+                additional_tags_limit,
+                ..Default::default()
+            })
+            .unwrap_or_default();
+        let additional_metric_tag_keys = config.ext.additional_metric_tags.clone();
         let possible_collapsed_fields =
             CollapsedFields::possible(!additional_metric_tag_keys.is_empty());
         let concentrator = SpanConcentrator::new(
@@ -311,17 +321,20 @@ impl StatsConcentratorService {
                 .iter()
                 .map(ToString::to_string)
                 .collect(),
-            // Use libdatadog's default cardinality limits, matching the trace agent and
-            // the Serverless Compatibility Layer: 7000 whole-key, 1024 resource, 512 http
-            // endpoint, 512 peer tags, 100 additional tags. Keys beyond a limit collapse
-            // into the `tracer_blocked_value` overflow bucket, which bounds concentrator
-            // memory and the /v0.6/stats payload inside a memory-capped Lambda.
+            // Use libdatadog's default cardinality limits except for `additional_tags_limit`,
+            // which is overridden by `DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT` when
+            // set (matching the Serverless Compatibility Layer / `datadog-trace-agent`).
+            // Defaults: 7000 whole-key, 1024 resource, 512 http endpoint, 512 peer tags, 100
+            // additional tags. Keys beyond a limit collapse into the `tracer_blocked_value`
+            // overflow bucket, which bounds concentrator memory and the /v0.6/stats payload
+            // inside a memory-capped Lambda.
             //
-            // Passed explicitly rather than as `None` (which libdatadog resolves with
-            // `unwrap_or_default()`, so the two are equivalent) so that the limits the
-            // collapse warnings quote are provably the ones in force.
+            // Passed as `Some` of the resolved value rather than the raw `Option` (which
+            // libdatadog would resolve with `unwrap_or_default()`, so the two are equivalent)
+            // so that the limits the collapse warnings quote are provably the ones in force.
             Some(cardinality_limits),
-            // No additional stats tag keys: aggregate on the default key fields only.
+            // Span meta keys included as additional aggregation dimensions, from
+            // DD_TRACE_STATS_ADDITIONAL_TAGS (only set when experimental_features_enabled).
             additional_metric_tag_keys,
         );
         let service: StatsConcentratorService = Self {
@@ -593,6 +606,62 @@ mod tests {
         assert!(
             peer_tags.iter().any(|t| t.starts_with("db.system:")),
             "Expected peer_tags to contain db.system, got: {peer_tags:?}"
+        );
+    }
+
+    /// `additional_metric_tags` (populated from `DD_TRACE_STATS_ADDITIONAL_TAGS`, gated on
+    /// `DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED`) should surface matching span `meta` keys as
+    /// `ClientGroupedStats.additional_metric_tags` on export.
+    #[tokio::test]
+    async fn test_additional_metric_tags_populated_when_configured() {
+        let mut config = Config::default();
+        config.ext.additional_metric_tags = vec!["datacenter".to_string()];
+        let config = Arc::new(config);
+        let (service, handle) = StatsConcentratorService::new(config);
+        tokio::spawn(service.run());
+
+        let span = create_span_kind_span("client", vec![("datacenter", "us-east-1")]);
+        handle.add(&span).unwrap();
+
+        let result = handle.flush(true).await.unwrap();
+        let payload = result.expect("Expected stats for the client span, but got None.");
+        let all_stats: Vec<_> = payload.stats.iter().flat_map(|b| &b.stats).collect();
+        assert!(
+            all_stats
+                .iter()
+                .any(|s| s.additional_metric_tags == vec!["datacenter:us-east-1".to_string()]),
+            "Expected additional_metric_tags to contain datacenter:us-east-1, got: {:?}",
+            all_stats
+                .iter()
+                .map(|s| &s.additional_metric_tags)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// When `additional_metric_tags` is unset (the default), `additional_metric_tags` on the
+    /// exported stats must remain empty even if the span has a meta key that would otherwise
+    /// match a commonly-used tag name.
+    #[tokio::test]
+    async fn test_additional_metric_tags_empty_by_default() {
+        let config = Arc::new(Config::default());
+        let (service, handle) = StatsConcentratorService::new(config);
+        tokio::spawn(service.run());
+
+        let span = create_span_kind_span("client", vec![("datacenter", "us-east-1")]);
+        handle.add(&span).unwrap();
+
+        let result = handle.flush(true).await.unwrap();
+        let payload = result.expect("Expected stats for the client span, but got None.");
+        let all_stats: Vec<_> = payload.stats.iter().flat_map(|b| &b.stats).collect();
+        assert!(
+            all_stats
+                .iter()
+                .all(|s| s.additional_metric_tags.is_empty()),
+            "Expected additional_metric_tags to be empty by default, got: {:?}",
+            all_stats
+                .iter()
+                .map(|s| &s.additional_metric_tags)
+                .collect::<Vec<_>>()
         );
     }
 

--- a/bottlecap/src/traces/stats_concentrator_service.rs
+++ b/bottlecap/src/traces/stats_concentrator_service.rs
@@ -119,20 +119,42 @@ impl CollapsedFields {
         self.0 & field != 0
     }
 
-    /// Each field's bit, the noun to use when reporting it, and the limit that governs it.
-    fn reportable(limits: &CardinalityLimitConfig) -> [(u8, &'static str, usize); 4] {
+    /// Each field's bit, the noun to use when reporting it, the limit that governs it, and the
+    /// remediation to recommend.
+    ///
+    /// `additional_tags` is the only field with a customer-facing knob, so it is the only one
+    /// whose message names an environment variable. The rest name none deliberately: libdatadog's
+    /// own message blames `DD_TRACE_STATS_CARDINALITY_LIMIT`, which bottlecap does not read at
+    /// all, so reducing cardinality in the application is the only real remediation.
+    fn reportable(limits: &CardinalityLimitConfig) -> [(u8, &'static str, usize, &'static str); 4] {
+        const REDUCE_CARDINALITY: &str = "Reduce cardinality to keep trace stats accurate; \
+             request ids or path parameters embedded in resource names are the usual cause.";
+        const TUNE_ADDITIONAL_TAGS: &str = "List fewer keys in DD_TRACE_STATS_ADDITIONAL_TAGS, pick keys with fewer distinct \
+             values, or raise DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT.";
         [
-            (Self::RESOURCE, "resource names", limits.resource_limit),
+            (
+                Self::RESOURCE,
+                "resource names",
+                limits.resource_limit,
+                REDUCE_CARDINALITY,
+            ),
             (
                 Self::HTTP_ENDPOINT,
                 "HTTP endpoints",
                 limits.http_endpoint_limit,
+                REDUCE_CARDINALITY,
             ),
-            (Self::PEER_TAGS, "peer tag sets", limits.peer_tags_limit),
+            (
+                Self::PEER_TAGS,
+                "peer tag sets",
+                limits.peer_tags_limit,
+                REDUCE_CARDINALITY,
+            ),
             (
                 Self::ADDITIONAL_TAGS,
                 "additional metric tag sets",
                 limits.additional_tags_limit,
+                TUNE_ADDITIONAL_TAGS,
             ),
         ]
     }
@@ -540,15 +562,11 @@ impl StatsConcentratorService {
             return;
         }
 
-        // Names no environment variable, deliberately: the per-field limits are not
-        // customer-tunable in bottlecap, and both candidate knobs would mislead. libdatadog's own
-        // message blames `DD_TRACE_STATS_CARDINALITY_LIMIT`, which bottlecap does not read at all,
-        // and `DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT` governs only `additional_tags`
-        // (and only once the additional-tags feature is enabled). Reducing cardinality in the
-        // application is the only real remediation, so that is what this recommends.
+        // The remediation is per field: see `CollapsedFields::reportable` for which fields name
+        // an environment variable and why the others do not.
         let bucket_secs = Duration::from_nanos(BUCKET_DURATION_NS).as_secs();
         let observed = observe_collapsed_fields(buckets);
-        for (field, noun, limit) in CollapsedFields::reportable(&self.cardinality_limits) {
+        for (field, noun, limit, remedy) in CollapsedFields::reportable(&self.cardinality_limits) {
             if !observed.contains(field) || self.reported_collapsed_fields.contains(field) {
                 continue;
             }
@@ -556,9 +574,7 @@ impl StatsConcentratorService {
             warn!(
                 "Trace stats saw more than {limit} distinct {noun} in a {bucket_secs}s bucket; \
                  the excess is aggregated under '{TRACER_BLOCKED_VALUE}', so those stats are no \
-                 longer attributable. Reduce cardinality to keep trace stats accurate; request \
-                 ids or path parameters embedded in resource names are the usual cause. Warned \
-                 once per sandbox."
+                 longer attributable. {remedy} Warned once per sandbox."
             );
         }
     }

--- a/bottlecap/src/traces/stats_concentrator_service.rs
+++ b/bottlecap/src/traces/stats_concentrator_service.rs
@@ -1060,17 +1060,30 @@ mod tests {
     /// which collapses per-field and keeps `collapsed_spans` at 0.
     #[tokio::test]
     async fn test_collapse_warns_once_per_signal() {
-        let config = Arc::new(Config::default());
+        test_collapse_warns_once_per_signal_with_config(Arc::new(Config::default()));
+    }
+
+    /// Same as [`test_collapse_warns_once_per_signal`], but with `additional_metric_tags`
+    /// configured, so the `ADDITIONAL_TAGS` field joins the possible set: its saturation and the
+    /// early return must account for it too, and the additional-tags warning is the only one
+    /// whose remediation names the customer-facing env vars.
+    #[tokio::test]
+    async fn test_collapse_warns_once_per_signal_with_additional_tags() {
+        let mut config = Config::default();
+        config.ext.additional_metric_tags = vec!["region".to_string()];
+        test_collapse_warns_once_per_signal_with_config(Arc::new(config));
+    }
+
+    fn test_collapse_warns_once_per_signal_with_config(config: Arc<Config>) {
+        let additional_tags_enabled = !config.ext.additional_metric_tags.is_empty();
+        let expected_possible = CollapsedFields::possible(additional_tags_enabled);
         let (mut service, _handle) = StatsConcentratorService::new(config);
 
+        assert_eq!(service.possible_collapsed_fields, expected_possible);
         assert!(!service.whole_key_collapse_reported);
         assert_eq!(
             service.reported_collapsed_fields,
             CollapsedFields::default()
-        );
-        assert_eq!(
-            service.possible_collapsed_fields,
-            CollapsedFields(CollapsedFields::CORE_FIELDS)
         );
 
         // No collapse at all: nothing is reported.
@@ -1087,24 +1100,32 @@ mod tests {
 
         // Per-field collapses in a later flush are still reported, independently. Include every
         // field that can collapse with the current configuration to saturate the reporting mask.
+        // additional_metric_tags only exists on the payload when additional tags are configured,
+        // so the fabricated entry only carries a sentinel there when that is possible.
         let collapsed = [bucket(vec![(
             "svc",
             TRACER_BLOCKED_VALUE,
             TRACER_BLOCKED_VALUE,
             vec![TRACER_BLOCKED_VALUE],
-            vec![],
+            if additional_tags_enabled {
+                // additional_metric_tags encodes the sentinel with a trailing colon, unlike the
+                // valueless bare-key form used for peer_tags.
+                vec!["tracer_blocked_value:"]
+            } else {
+                vec![]
+            },
         )])];
         service.report_collapse(&collapsed, 9);
         assert_eq!(
             service.reported_collapsed_fields,
-            CollapsedFields(CollapsedFields::CORE_FIELDS)
+            CollapsedFields::possible(additional_tags_enabled)
         );
 
         // Repeat flushes take the early return, leaving state untouched.
         service.report_collapse(&collapsed, 9);
         assert_eq!(
             service.reported_collapsed_fields,
-            CollapsedFields(CollapsedFields::CORE_FIELDS)
+            CollapsedFields::possible(additional_tags_enabled)
         );
     }
 }

--- a/bottlecap/src/traces/stats_concentrator_service.rs
+++ b/bottlecap/src/traces/stats_concentrator_service.rs
@@ -184,13 +184,28 @@ fn is_sentinel_tag(tag: &str) -> bool {
     tag.split_once(':').map_or(tag, |(key, _)| key) == TRACER_BLOCKED_VALUE
 }
 
+/// Maximum number of additional metric tag keys libdatadog will aggregate on.
+///
+/// TODO: mirrors `ADDITIONAL_METRIC_TAGS_MAX_KEYS` in libdatadog's
+/// `libdd-trace-stats/src/span_concentrator/mod.rs`, which is private. Hand-copied here only to
+/// warn about excess keys in bottlecap's own terms; libdatadog still owns the actual truncation.
+const MAX_ADDITIONAL_METRIC_TAG_KEYS: usize = 4;
+
 /// Build the `CardinalityLimitConfig` override for a user-supplied
 /// `DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT`, or `None` to keep libdatadog's defaults.
 ///
-/// libdatadog only warns about out-of-range limits, it still applies them, so validate here:
-/// `0` would collapse *every* additional tag into the `tracer_blocked_value` sentinel, and any
-/// value at or above `whole_key_limit` is inert because the whole-key limit collapses the key
-/// first. Both are almost certainly misconfigurations rather than intent.
+/// libdatadog only warns about out-of-range limits, it still applies them, so validate here.
+///
+/// `0` is the dangerous one: libdatadog would collapse *every* additional tag into the
+/// `tracer_blocked_value` sentinel. Note the Go trace agent reads `0` as "no cap" instead, so a
+/// user carrying that setting over would otherwise silently lose every tag value. Falling back to
+/// the default keeps aggregation working; "unbounded" is deliberately not offered, since #1332
+/// bounded this precisely to cap concentrator memory in a memory-capped Lambda.
+///
+/// Values at or above `whole_key_limit` are clamped mainly to silence libdatadog's
+/// misconfiguration warning. Per-field limits are applied *before* the whole-key limit, so such a
+/// value is not strictly inert, but reaching it needs ~7k distinct tag combinations inside one
+/// 10s bucket, which will not happen in a Lambda invocation.
 fn resolve_cardinality_limits(configured_limit: Option<usize>) -> Option<CardinalityLimitConfig> {
     let defaults = CardinalityLimitConfig::default();
     // `saturating_sub` keeps the clamp below the whole-key limit so it stays effective.
@@ -200,7 +215,9 @@ fn resolve_cardinality_limits(configured_limit: Option<usize>) -> Option<Cardina
         0 => {
             warn!(
                 "DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT=0 would collapse all additional \
-                 metric tags into `tracer_blocked_value`; using the default of {} instead.",
+                 metric tags into `tracer_blocked_value`; using the default of {} instead. Note \
+                 that 0 does not mean unlimited here; to stop aggregating on additional tags, \
+                 unset DD_TRACE_STATS_ADDITIONAL_TAGS instead.",
                 defaults.additional_tags_limit
             );
             return None;
@@ -208,7 +225,7 @@ fn resolve_cardinality_limits(configured_limit: Option<usize>) -> Option<Cardina
         limit if limit > max_effective_limit => {
             warn!(
                 "DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT={limit} is at or above the \
-                 whole-key cardinality limit ({}), which would make it ineffective; clamping to \
+                 whole-key cardinality limit ({}), so it is effectively unbounded; clamping to \
                  {max_effective_limit}.",
                 defaults.whole_key_limit
             );
@@ -221,6 +238,43 @@ fn resolve_cardinality_limits(configured_limit: Option<usize>) -> Option<Cardina
         additional_tags_limit,
         ..defaults
     })
+}
+
+/// Warn when `DD_TRACE_STATS_ADDITIONAL_TAGS` lists more keys than libdatadog will aggregate on.
+///
+/// libdatadog sorts alphabetically and keeps only the first
+/// [`MAX_ADDITIONAL_METRIC_TAG_KEYS`], so excess keys are dropped by alphabetical accident
+/// rather than by anything the user expressed. Its own warning names the dropped keys but not
+/// the kept ones, the selection rule, or the env var, so restate all three here. Truncation
+/// itself is left to libdatadog; this only reports it.
+fn warn_on_excess_additional_metric_tag_keys(keys: &[String]) {
+    if let Some((kept, dropped)) = split_additional_metric_tag_keys(keys) {
+        warn!(
+            "DD_TRACE_STATS_ADDITIONAL_TAGS lists {} unique keys but at most {} are aggregated \
+             on. Keys are sorted alphabetically and the rest dropped, so stats will use {kept:?} \
+             and ignore {dropped:?}. Reduce the list to at most {} keys to choose explicitly.",
+            kept.len() + dropped.len(),
+            MAX_ADDITIONAL_METRIC_TAG_KEYS,
+            MAX_ADDITIONAL_METRIC_TAG_KEYS,
+        );
+    }
+}
+
+/// Split `keys` into the keys libdatadog will keep and the ones it will drop, or `None` when the
+/// list is within [`MAX_ADDITIONAL_METRIC_TAG_KEYS`].
+///
+/// Mirrors libdatadog's `normalize_additional_metric_tag_keys` (sort, dedup, truncate) so the
+/// split reported matches the split it will actually apply.
+fn split_additional_metric_tag_keys(keys: &[String]) -> Option<(Vec<&str>, Vec<&str>)> {
+    let mut normalized: Vec<&str> = keys.iter().map(String::as_str).collect();
+    normalized.sort_unstable();
+    normalized.dedup();
+
+    if normalized.len() <= MAX_ADDITIONAL_METRIC_TAG_KEYS {
+        return None;
+    }
+    let dropped = normalized.split_off(MAX_ADDITIONAL_METRIC_TAG_KEYS);
+    Some((normalized, dropped))
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -335,6 +389,7 @@ impl StatsConcentratorService {
     pub fn new(config: Arc<Config>) -> (Self, StatsConcentratorHandle) {
         let (tx, rx) = mpsc::unbounded_channel();
         let handle = StatsConcentratorHandle::new(tx);
+        warn_on_excess_additional_metric_tag_keys(&config.ext.additional_metric_tags);
         // Resolved once, here, so the limits the collapse warnings quote are the same values the
         // concentrator enforces. `unwrap_or_default()` mirrors what libdatadog does with a `None`
         // override.
@@ -731,6 +786,47 @@ mod tests {
         );
     }
 
+    /// libdatadog silently keeps only the first `MAX_ADDITIONAL_METRIC_TAG_KEYS` keys after
+    /// sorting alphabetically, so which keys survive is an alphabetical accident rather than
+    /// anything the user expressed. Verify the split we report matches that rule.
+    #[test]
+    fn test_split_additional_metric_tag_keys() {
+        let keys =
+            |keys: &[&str]| -> Vec<String> { keys.iter().map(ToString::to_string).collect() };
+
+        // Within the cap: nothing is dropped.
+        assert_eq!(split_additional_metric_tag_keys(&[]), None);
+        assert_eq!(
+            split_additional_metric_tag_keys(&keys(&["region", "shard", "zone", "tenant_id"])),
+            None
+        );
+
+        // Duplicates collapse first, so this stays within the cap.
+        assert_eq!(
+            split_additional_metric_tag_keys(&keys(&["region", "region", "shard"])),
+            None
+        );
+
+        // Over the cap: alphabetical order decides, so `zone` loses despite being listed first.
+        assert_eq!(
+            split_additional_metric_tag_keys(&keys(&[
+                "zone",
+                "tenant_id",
+                "region",
+                "shard",
+                "customer"
+            ])),
+            Some((
+                vec!["customer", "region", "shard", "tenant_id"],
+                vec!["zone"]
+            ))
+        );
+    }
+
+    /// The concentrator uses `CardinalityLimitConfig::default()`, so exceeding those limits must
+    /// collapse the excess aggregation keys into the `tracer_blocked_value` overflow key instead
+    /// of growing without bound. 7,001 distinct resources exceeds both the default
+    /// `whole_key_limit` (7,000) and `resource_limit` (1,024).
     /// The concentrator uses `CardinalityLimitConfig::default()`, so resources beyond its
     /// `resource_limit` must collapse into one `tracer_blocked_value` sentinel group. Every span
     /// shares a timestamp and lands in the same bucket, so excess resources merge while their

--- a/bottlecap/tests/apm_integration_test.rs
+++ b/bottlecap/tests/apm_integration_test.rs
@@ -15,12 +15,13 @@
 //! payload-level changes that `body_contains`-style mocks can't catch.
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use bottlecap::LAMBDA_RUNTIME_SLUG;
-use bottlecap::config::Config;
+use bottlecap::config::{Config, get_config};
 use bottlecap::tags::provider::Provider;
 use bottlecap::traces::http_client::create_client;
 use bottlecap::traces::stats_aggregator::StatsAggregator;
@@ -69,6 +70,25 @@ fn test_config() -> Arc<Config> {
         site: "datadoghq.com".to_string(),
         ..Config::default()
     })
+}
+
+/// Build a `Config` through the real parsing path: `Jail` sets the given `DD_*`
+/// environment variables, then `get_config` parses them and applies the
+/// experimental-features gate. `clear_env` makes the result independent of the
+/// ambient environment; this is safe here because no other test in this binary
+/// reads env, each `tests/*.rs` file is its own binary, and figment's Jail holds
+/// a process-wide lock while active.
+fn config_from_env(env: &[(&str, &str)]) -> Arc<Config> {
+    let mut result: Option<Config> = None;
+    figment::Jail::expect_with(|jail| {
+        jail.clear_env();
+        for (key, value) in env.iter().copied() {
+            jail.set_env(key, value);
+        }
+        result = Some(get_config(Path::new("")));
+        Ok(())
+    });
+    Arc::new(result.expect("config must be built inside the jail"))
 }
 
 fn endpoint_for(url: &str, api_key: &str) -> Endpoint {
@@ -748,9 +768,9 @@ fn make_eligible_span(span_kind: &str, peer_meta: &[(&str, &str)]) -> pb::Span {
 /// `spans`, force a flush, and return the single captured `StatsPayload`.
 async fn flush_spans_to_fake_intake(
     fake_intake: &FakeIntake,
+    config: Arc<Config>,
     spans: &[pb::Span],
 ) -> pb::StatsPayload {
-    let config = test_config();
     let http_client = create_client(None, None, false).expect("failed to create http client");
 
     let (concentrator_service, concentrator_handle) =
@@ -796,7 +816,7 @@ async fn stats_span_kind_through_fake_intake() {
     let fake_intake = FakeIntake::start().await;
     let span = make_eligible_span("server", &[]);
 
-    let payload = flush_spans_to_fake_intake(&fake_intake, &[span]).await;
+    let payload = flush_spans_to_fake_intake(&fake_intake, test_config(), &[span]).await;
 
     let grouped: Vec<_> = payload
         .stats
@@ -827,7 +847,7 @@ async fn stats_peer_tags_through_fake_intake() {
         &[("db.instance", "i-1234"), ("db.system", "postgres")],
     );
 
-    let payload = flush_spans_to_fake_intake(&fake_intake, &[span]).await;
+    let payload = flush_spans_to_fake_intake(&fake_intake, test_config(), &[span]).await;
 
     let with_peer_tags: Vec<_> = payload
         .stats
@@ -849,4 +869,164 @@ async fn stats_peer_tags_through_fake_intake() {
         peer_tags.iter().any(|t| t.starts_with("db.system:")),
         "expected peer_tags to contain db.system, got: {peer_tags:?}",
     );
+}
+
+/// Collect the grouped-stats entries from a captured `StatsPayload`.
+fn grouped_entries(payload: &pb::StatsPayload) -> Vec<&pb::ClientGroupedStats> {
+    payload
+        .stats
+        .iter()
+        .flat_map(|p| &p.stats)
+        .flat_map(|b| &b.stats)
+        .collect()
+}
+
+/// End-to-end: spans carrying `meta["region"]` fed through the concentrator with
+/// `DD_TRACE_STATS_ADDITIONAL_TAGS=region` (behind the experimental gate) must
+/// arrive at the intake with `additional_metric_tags` populated, split into one
+/// group per distinct region value, with repeated values aggregated into the
+/// same group. Span meta keys not listed in `DD_TRACE_STATS_ADDITIONAL_TAGS`
+/// must not be exported as additional metric tags.
+#[tokio::test]
+async fn stats_additional_metric_tags_through_fake_intake() {
+    let fake_intake = FakeIntake::start().await;
+    let config = config_from_env(&[
+        ("DD_API_KEY", DD_API_KEY),
+        ("DD_SITE", "datadoghq.com"),
+        ("DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED", "true"),
+        ("DD_TRACE_STATS_ADDITIONAL_TAGS", "region"),
+    ]);
+
+    let spans = vec![
+        make_eligible_span("server", &[("region", "us-east-1")]),
+        make_eligible_span("server", &[("region", "us-east-1")]),
+        make_eligible_span("server", &[("region", "eu-west-1")]),
+        // Only carries an unconfigured meta key: must not gain any additional
+        // metric tag.
+        make_eligible_span("server", &[("tenant_id", "acme")]),
+    ];
+
+    let payload = flush_spans_to_fake_intake(&fake_intake, config, &spans).await;
+    let grouped = grouped_entries(&payload);
+
+    let with_tags: Vec<_> = grouped
+        .iter()
+        .filter(|s| !s.additional_metric_tags.is_empty())
+        .collect();
+    assert_eq!(
+        with_tags.len(),
+        2,
+        "expected one group per distinct region value, got: {:?}",
+        grouped
+            .iter()
+            .map(|s| &s.additional_metric_tags)
+            .collect::<Vec<_>>(),
+    );
+
+    let us_east = with_tags
+        .iter()
+        .find(|s| s.additional_metric_tags == vec!["region:us-east-1".to_string()])
+        .expect("us-east-1 group should be present");
+    assert_eq!(us_east.hits, 2, "repeated us-east-1 values must aggregate");
+
+    let eu_west = with_tags
+        .iter()
+        .find(|s| s.additional_metric_tags == vec!["region:eu-west-1".to_string()])
+        .expect("eu-west-1 group should be present");
+    assert_eq!(eu_west.hits, 1);
+
+    let untagged = grouped
+        .iter()
+        .find(|s| s.additional_metric_tags.is_empty())
+        .expect("span without the configured key should land in its own group");
+    assert_eq!(untagged.hits, 1);
+}
+
+/// End-to-end: `DD_TRACE_STATS_ADDITIONAL_TAGS` set without the experimental
+/// gate must leave `additional_metric_tags` empty on the emitted payload, and
+/// spans differing only in the unexported meta value must merge into a single
+/// group. Proves the gate affects the payload, not just the parsed config.
+#[tokio::test]
+async fn stats_additional_metric_tags_gated_off_through_fake_intake() {
+    let fake_intake = FakeIntake::start().await;
+    let config = config_from_env(&[
+        ("DD_API_KEY", DD_API_KEY),
+        ("DD_SITE", "datadoghq.com"),
+        ("DD_TRACE_STATS_ADDITIONAL_TAGS", "region"),
+    ]);
+
+    let spans = vec![
+        make_eligible_span("server", &[("region", "us-east-1")]),
+        make_eligible_span("server", &[("region", "us-east-1")]),
+        make_eligible_span("server", &[("region", "eu-west-1")]),
+    ];
+
+    let payload = flush_spans_to_fake_intake(&fake_intake, config, &spans).await;
+    let grouped = grouped_entries(&payload);
+
+    assert_eq!(
+        grouped.len(),
+        1,
+        "spans differing only in region must merge into one group, got: {:?}",
+        grouped
+            .iter()
+            .map(|s| (&s.resource, &s.additional_metric_tags))
+            .collect::<Vec<_>>(),
+    );
+    assert!(
+        grouped[0].additional_metric_tags.is_empty(),
+        "gated-off additional tags must not appear on the payload, got: {:?}",
+        grouped[0].additional_metric_tags,
+    );
+    assert_eq!(grouped[0].hits, 3);
+}
+
+/// End-to-end: `DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT=1` with two
+/// distinct region values in the same bucket must admit the first value and
+/// collapse the second into the `tracer_blocked_value` overflow group, keeping
+/// the total hit count intact.
+#[tokio::test]
+async fn stats_additional_metric_tags_cardinality_limit_through_fake_intake() {
+    let fake_intake = FakeIntake::start().await;
+    let config = config_from_env(&[
+        ("DD_API_KEY", DD_API_KEY),
+        ("DD_SITE", "datadoghq.com"),
+        ("DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED", "true"),
+        ("DD_TRACE_STATS_ADDITIONAL_TAGS", "region"),
+        ("DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT", "1"),
+    ]);
+
+    let spans = vec![
+        make_eligible_span("server", &[("region", "us-east-1")]),
+        make_eligible_span("server", &[("region", "us-east-1")]),
+        make_eligible_span("server", &[("region", "eu-west-1")]),
+    ];
+
+    let payload = flush_spans_to_fake_intake(&fake_intake, config, &spans).await;
+    let grouped = grouped_entries(&payload);
+
+    assert_eq!(
+        grouped.len(),
+        2,
+        "expected one admitted group plus one overflow group, got: {:?}",
+        grouped
+            .iter()
+            .map(|s| &s.additional_metric_tags)
+            .collect::<Vec<_>>(),
+    );
+
+    let admitted = grouped
+        .iter()
+        .find(|s| s.additional_metric_tags == vec!["region:us-east-1".to_string()])
+        .expect("first distinct value should be admitted");
+    assert_eq!(admitted.hits, 2);
+
+    let overflow = grouped
+        .iter()
+        .find(|s| s.additional_metric_tags == vec!["tracer_blocked_value:".to_string()])
+        .expect("second distinct value should collapse into the overflow sentinel");
+    assert_eq!(overflow.hits, 1);
+
+    let total_hits: u64 = grouped.iter().map(|s| s.hits).sum();
+    assert_eq!(total_hits, 3, "cardinality limiting must not drop hits");
 }

--- a/bottlecap/tests/apm_integration_test.rs
+++ b/bottlecap/tests/apm_integration_test.rs
@@ -1030,3 +1030,85 @@ async fn stats_additional_metric_tags_cardinality_limit_through_fake_intake() {
     let total_hits: u64 = grouped.iter().map(|s| s.hits).sum();
     assert_eq!(total_hits, 3, "cardinality limiting must not drop hits");
 }
+
+/// End-to-end with multiple configured keys: spans carrying both `meta["region"]` and
+/// `meta["tenant_id"]`, with `DD_TRACE_STATS_ADDITIONAL_TAGS=region,tenant_id`, must group on
+/// the two values together: one group per distinct combination, repeats aggregating per
+/// combination, and a change in either key producing a new group.
+#[tokio::test]
+async fn stats_additional_metric_tags_multiple_keys_through_fake_intake() {
+    let fake_intake = FakeIntake::start().await;
+    let config = config_from_env(&[
+        ("DD_API_KEY", DD_API_KEY),
+        ("DD_SITE", "datadoghq.com"),
+        ("DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED", "true"),
+        ("DD_TRACE_STATS_ADDITIONAL_TAGS", "region,tenant_id"),
+    ]);
+
+    let spans = vec![
+        make_eligible_span("server", &[("region", "us-east-1"), ("tenant_id", "acme")]),
+        make_eligible_span("server", &[("region", "us-east-1"), ("tenant_id", "acme")]),
+        make_eligible_span(
+            "server",
+            &[("region", "us-east-1"), ("tenant_id", "globex")],
+        ),
+        make_eligible_span("server", &[("region", "eu-west-1"), ("tenant_id", "acme")]),
+    ];
+
+    let payload = flush_spans_to_fake_intake(&fake_intake, config, &spans).await;
+    let grouped = grouped_entries(&payload);
+
+    fn tags_of(s: &pb::ClientGroupedStats) -> Vec<&str> {
+        s.additional_metric_tags
+            .iter()
+            .map(String::as_str)
+            .collect()
+    }
+
+    assert_eq!(
+        grouped.len(),
+        3,
+        "expected one group per distinct (region, tenant_id) combination, got: {:?}",
+        grouped
+            .iter()
+            .map(|s| &s.additional_metric_tags)
+            .collect::<Vec<_>>(),
+    );
+
+    let acme_us_east = grouped
+        .iter()
+        .find(|s| tags_of(s) == vec!["region:us-east-1".to_string(), "tenant_id:acme".to_string()])
+        .expect("(us-east-1, acme) combination should be present");
+    assert_eq!(
+        acme_us_east.hits, 2,
+        "repeats of the same combination must aggregate"
+    );
+
+    for (expected_tags, expected_hits) in [
+        (
+            vec![
+                "region:us-east-1".to_string(),
+                "tenant_id:globex".to_string(),
+            ],
+            1,
+        ),
+        (
+            vec!["region:eu-west-1".to_string(), "tenant_id:acme".to_string()],
+            1,
+        ),
+    ] {
+        let group = grouped
+            .iter()
+            .find(|s| s.additional_metric_tags == expected_tags)
+            .unwrap_or_else(|| {
+                panic!(
+                    "combination {expected_tags:?} should be present, got: {:?}",
+                    grouped
+                        .iter()
+                        .map(|s| &s.additional_metric_tags)
+                        .collect::<Vec<_>>()
+                )
+            });
+        assert_eq!(group.hits, expected_hits);
+    }
+}


### PR DESCRIPTION
Stacked PRs:
- DataDog/serverless-components#141
- #1332
- #1338
- #1336 👈🏽 **This PR**

## Overview

Adds bottlecap-side config for span-derived primary tags (APMSVLS-485), matching the Serverless Compatibility Layer (`datadog-trace-agent`):

| Variable | Default | Notes |
|---|---|---|
| `DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED` | `false` | Gates the two settings below. |
| `DD_TRACE_STATS_ADDITIONAL_TAGS` | empty | Comma-separated span `meta` keys to use as additional stats aggregation dimensions. |
| `DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT` | `100` | Per-bucket cap on distinct tag-value combinations. |

These feed `StatsConcentratorService` → `SpanConcentrator::new`'s `additional_metric_tag_keys`, which `libdd-trace-stats` (via #1332's bump to `72fa8685`) already implements end-to-end: extraction from span `meta`, inclusion in the aggregation key hash, cardinality limiting, and export as `ClientGroupedStats.additional_metric_tags`. So this PR is pure wiring, exactly as #1332 predicted.

Both gated settings reset to their defaults when the experimental gate is off, so a stale env var can't leak through.

**No libdatadog change is needed.** The ticket points at `span_derived_primary_tags` (field 22) being stubbed as `vec![]`, but that field is deprecated in favor of `additional_metric_tags` (field 23) — see the comment in `stats.proto`. Field 22 intentionally stays empty; this PR uses the modern replacement.

### Misconfiguration handling

libdatadog warns about bad input but still applies it, so both settings are validated here and the warnings restated in bottlecap's terms.

`DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT`:

- `0` would collapse *every* additional metric tag into the `tracer_blocked_value` sentinel — silent, total data loss for the dimension → falls back to the default of `100`. Worth noting the Go trace agent reads `0` as *no cap*, so a user carrying that setting over would otherwise lose exactly what they meant to keep unbounded. "Unbounded" is deliberately not offered: #1332 bounded this precisely to cap concentrator memory in a memory-capped Lambda.
- Values at or above the whole-key limit (`7000`) → clamped to `6999`, mainly to silence libdatadog's misconfiguration warning. Per-field limits are applied *before* the whole-key limit, so such a value is effectively unbounded rather than strictly inert; either way, reaching it needs ~7k distinct tag combinations inside a single 10s bucket, which will not happen in a Lambda invocation.

`DD_TRACE_STATS_ADDITIONAL_TAGS`: libdatadog aggregates on at most **4** keys, sorting alphabetically and dropping the rest. So `zone,tenant_id,region,shard,customer` silently drops `zone` — by alphabetical accident, not by anything the user expressed. This is arguably the nastier failure of the two, since the config appears to work and only the dimensions are wrong. libdatadog's warning names the dropped keys but not the kept ones, the selection rule, or the env var, so bottlecap now logs all three. Truncation itself stays in libdatadog.

### SCL parity divergence

`serverless-components@9daae40` applies this env var raw (`.parse::<usize>().ok()`, no range check), so after this PR `DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT=0` means "default `100`" in Lambda and "collapse everything" in Azure Functions. Given the SCL-parity framing, `resolve_cardinality_limits` should be ported upstream to `datadog-trace-agent` as a follow-up.

### On per-bucket cardinality resets

The cardinality limit is tracked per 10s `StatsBucket` and resets per bucket. Unlike the rate limiter in #1320, this is *not* broken by Lambda freeze/thaw, so it is deliberately left alone:

- A rate limiter's budget is a rate over wall-clock read at decision time, so a freeze inflates elapsed time without any work happening and the budget refills for free.
- This limit is a count of distinct keys inside a bucket that gets flushed and freed, and buckets are keyed by *span* timestamps (`span.start + span.duration`), not processing time. A freeze just routes the next invocation's spans into a different bucket, which is correct.

Bucketing stays load-bearing for the concentrator memory and `/v0.6/stats` payload bounds.

## Testing

Config (`src/config/mod.rs`) — the experimental gate on/off for both settings, comma-separated parsing with surrounding whitespace, and an unparseable cardinality limit falling back to `None`.

Concentrator (`src/traces/stats_concentrator_service.rs`):
- `test_additional_metric_tags_populated_when_configured` — a configured key present in span `meta` surfaces as `datacenter:us-east-1` on the exported `ClientGroupedStats`.
- `test_additional_metric_tags_empty_by_default` — unset config exports no additional tags even when the span carries a matching `meta` key.
- `test_resolve_cardinality_limits` — unset/`0`/in-range/at-or-above-whole-key validation, and that overriding `additional_tags_limit` leaves the other limits at their defaults.
- `test_kept_and_dropped_additional_metric_tag_keys` — the alphabetical keep/drop split reported for an over-cap key list, derived from the concentrator's own `additional_metric_tag_keys()` getter (so the kept set can't drift from libdatadog's real cap), and that duplicates collapse before the cap applies.
- `test_observe_collapsed_fields` — per-field collapse detection scans each field independently, the whole-key overflow entry (every field set to the sentinel) is skipped rather than misreported as all four collapsing, and the two sentinel encodings (bare key for `peer_tags`, trailing colon for `additional_metric_tags`) are both recognized.
- `test_resource_collapse_observed_without_whole_key_overflow` — exceeding `resource_limit` (1,024) while staying under `whole_key_limit` (7,000) is observable via the payload scan with no whole-key overflow entry, covering the observability trap where `collapsed_spans` alone stays at 0.
- `test_collapse_warns_once_per_signal` and `test_collapse_warns_once_per_signal_with_additional_tags` — whole-key overflow and per-field collapse are reported independently, each at most once per sandbox, and repeated flushes leave state untouched; the additional-tags variant covers the second possible-fields shape where `ADDITIONAL_TAGS` joins the saturation mask, including the fabricated payload carrying the sentinel only when additional tags are configured.

`cargo test --lib`, `cargo clippy --lib --all-targets -- -D warnings`, and `cargo fmt --check` all pass.

Fake intake (`tests/apm_integration_test.rs`) — payload-level coverage through concentrator → `StatsFlusher` → msgpack/gzip → in-process fake intake, with the config built through the real parsing path (`get_config` + `figment::Jail`, so the env vars and gate are exercised, not just struct fields):

- `stats_additional_metric_tags_through_fake_intake` — spans carrying `meta["region"]` arrive with `additional_metric_tags` populated: distinct region values split into separate groups with encoded `region:<value>` tags, repeated values aggregate into the same group (hit count 2), and an unconfigured meta key (`tenant_id`) is not exported.
- `stats_additional_metric_tags_gated_off_through_fake_intake` — `DD_TRACE_STATS_ADDITIONAL_TAGS` set without the gate: spans differing only in region merge into a single group with empty `additional_metric_tags`, proving the gate affects the emitted payload, not only the parsed config.
- `stats_additional_metric_tags_cardinality_limit_through_fake_intake` — `DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT=1` with two distinct values in one bucket: the first value is admitted, the second collapses into the `tracer_blocked_value:` overflow group, and the total hit count is preserved.
- `stats_additional_metric_tags_multiple_keys_through_fake_intake` — two configured keys (`region,tenant_id`) group on both values together: one group per distinct combination, repeats of the same combination aggregating, and a change in either key producing a new group.

`cargo nextest run --workspace` (667 passed) and `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --features default` pass.

