### PR TITLE
[APMSVLS-501] refactor(bottlecap): preparatory work for a new "test-mode" binary

### DIFF
--- a/.github/workflows/rs_ci.yml
+++ b/.github/workflows/rs_ci.yml
@@ -82,6 +82,10 @@ jobs:
         run: cargo clippy --workspace --all-targets --features default
       - working-directory: bottlecap
         run: cargo clippy --workspace --all-targets --no-default-features --features fips
+      # No other job compiles the test-mode feature: it gates test-only
+      # constructors that are absent from default and fips builds.
+      - working-directory: bottlecap
+        run: cargo clippy --workspace --all-targets --features default,test-mode
 
   build-all:
     name: Build All

--- a/.gitlab/templates/pipeline.yaml.tpl
+++ b/.gitlab/templates/pipeline.yaml.tpl
@@ -63,6 +63,9 @@ cargo clippy:
     # We need to do these separately because the fips feature is incompatible with the default feature.
     - cargo clippy --workspace --features default
     - cargo clippy --workspace --no-default-features --features fips
+    # No other job compiles the test-mode feature: it gates test-only
+    # constructors that are absent from default and fips builds.
+    - cargo clippy --workspace --features default,test-mode
 
 {{ range $flavor := (ds "flavors").flavors }}
 

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -175,7 +175,8 @@ fips = [
     "rustls-native-certs",
 ]
 # Exposes test-only constructors (for example,
-# `InvocationProcessorHandle::noop()`) to the upcoming testmode binary.
+# `InvocationProcessorHandle::noop()`) to callers that need to drive the
+# trace-processing surface without Lambda lifecycle state.
 # Not enabled in `default` or `fips`, so the items it gates do not appear
 # in production builds.
 test-mode = []

--- a/bottlecap/Cargo.toml
+++ b/bottlecap/Cargo.toml
@@ -174,6 +174,11 @@ fips = [
     "rustls/fips",
     "rustls-native-certs",
 ]
+# Exposes test-only constructors (for example,
+# `InvocationProcessorHandle::noop()`) to the upcoming testmode binary.
+# Not enabled in `default` or `fips`, so the items it gates do not appear
+# in production builds.
+test-mode = []
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage,coverage_nightly)'] }

--- a/bottlecap/src/lifecycle/invocation/processor_service.rs
+++ b/bottlecap/src/lifecycle/invocation/processor_service.rs
@@ -141,6 +141,71 @@ pub struct InvocationProcessorHandle {
 }
 
 impl InvocationProcessorHandle {
+    /// Returns a handle backed by a background task that acknowledges every
+    /// command with a sensible default. Use this for callers that need an
+    /// `InvocationProcessorHandle` (for example, to reuse `TraceAgent` or
+    /// `handle_traces`) but have no Lambda lifecycle state to drive.
+    ///
+    /// The match below is exhaustive: adding a new `ProcessorCommand` variant
+    /// will fail to compile here, so the noop behavior for it must be
+    /// decided explicitly. A response-carrying variant placed in the
+    /// fire-and-forget arm would silently drop its sender, causing the
+    /// caller to receive `ProcessorError::ChannelReceive` instead of the
+    /// intended default. Note that the compiler only catches *new* variants:
+    /// adding a `response` field to an existing fire-and-forget variant still
+    /// matches its `{ .. }` pattern, so that case must be caught by review.
+    ///
+    /// Compiled only under unit tests and when the `test-mode` feature is
+    /// enabled, so this constructor does not exist in production builds.
+    ///
+    /// Must be called from within an active Tokio runtime: the constructor
+    /// uses `tokio::spawn` to start the draining task, which panics if no
+    /// runtime is registered for the current thread.
+    #[cfg(any(test, feature = "test-mode"))]
+    #[must_use]
+    pub fn noop() -> Self {
+        let (sender, mut receiver) = mpsc::channel::<ProcessorCommand>(1000);
+        tokio::spawn(async move {
+            while let Some(command) = receiver.recv().await {
+                match command {
+                    // Request-response commands: reply with a default so the
+                    // caller doesn't block on the oneshot forever.
+                    ProcessorCommand::GetReparentingInfo { response } => {
+                        let _ = response.send(Ok(std::collections::VecDeque::new()));
+                    }
+                    ProcessorCommand::UpdateReparenting { response, .. } => {
+                        let _ = response.send(Ok(Vec::new()));
+                    }
+                    ProcessorCommand::SetColdStartSpanTraceId { response, .. } => {
+                        let _ = response.send(Ok(None));
+                    }
+                    ProcessorCommand::PlatformRuntimeDone { response, .. }
+                    | ProcessorCommand::PlatformReport { response, .. } => {
+                        let _ = response.send(());
+                    }
+                    // Fire-and-forget commands: drop silently.
+                    ProcessorCommand::InvokeEvent { .. }
+                    | ProcessorCommand::PlatformInitStart { .. }
+                    | ProcessorCommand::PlatformInitReport { .. }
+                    | ProcessorCommand::PlatformRestoreStart { .. }
+                    | ProcessorCommand::PlatformRestoreReport { .. }
+                    | ProcessorCommand::PlatformStart { .. }
+                    | ProcessorCommand::UniversalInstrumentationStart { .. }
+                    | ProcessorCommand::RecordDsmConsumeFromPayload { .. }
+                    | ProcessorCommand::UniversalInstrumentationEnd { .. }
+                    | ProcessorCommand::AddReparenting { .. }
+                    | ProcessorCommand::AddTracerSpan { .. }
+                    | ProcessorCommand::ForwardDurableContext { .. }
+                    | ProcessorCommand::OnOutOfMemoryError { .. }
+                    | ProcessorCommand::OnShutdownEvent
+                    | ProcessorCommand::SendCtxSpans { .. }
+                    | ProcessorCommand::Shutdown => {}
+                }
+            }
+        });
+        InvocationProcessorHandle { sender }
+    }
+
     pub async fn on_invoke_event(
         &self,
         request_id: String,
@@ -698,5 +763,153 @@ impl InvocationProcessorService {
         }
 
         debug!("InvocationProcessorService stopped");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn noop_request_response_methods_return_defaults() {
+        let handle = InvocationProcessorHandle::noop();
+
+        let info = handle
+            .get_reparenting_info()
+            .await
+            .expect("noop get_reparenting_info");
+        assert!(info.is_empty());
+
+        let contexts = handle
+            .update_reparenting(std::collections::VecDeque::new())
+            .await
+            .expect("noop update_reparenting");
+        assert!(contexts.is_empty());
+
+        let cold_start = handle
+            .set_cold_start_span_trace_id(42)
+            .await
+            .expect("noop set_cold_start_span_trace_id");
+        assert!(cold_start.is_none());
+    }
+
+    #[tokio::test]
+    async fn noop_fire_and_forget_commands_do_not_panic() {
+        let handle = InvocationProcessorHandle::noop();
+
+        handle
+            .on_invoke_event("rid".to_string())
+            .await
+            .expect("noop on_invoke_event");
+        handle
+            .on_shutdown_event()
+            .await
+            .expect("noop on_shutdown_event");
+        handle
+            .on_out_of_memory_error(None, 0)
+            .await
+            .expect("noop on_out_of_memory_error");
+    }
+
+    /// Guards against a future `ProcessorCommand` variant with a `response`
+    /// field being accidentally placed in the fire-and-forget arm: that would
+    /// silently drop the sender, causing `rx.await` to return
+    /// `ProcessorError::ChannelReceive`. With an explicit timeout, any such
+    /// regression fails fast instead of hanging the test suite.
+    #[tokio::test]
+    async fn noop_request_response_variants_complete_within_timeout() {
+        use crate::{
+            LAMBDA_RUNTIME_SLUG, config,
+            extension::telemetry::events::OnDemandReportMetrics,
+            traces::{
+                stats_concentrator_service::StatsConcentratorService,
+                stats_generator::StatsGenerator, trace_processor::ServerlessTraceProcessor,
+            },
+        };
+        use libdd_trace_obfuscation::obfuscation_config::ObfuscationConfig;
+        use std::collections::HashMap;
+        use tokio::time::{Duration, timeout};
+
+        let timeout_dur = Duration::from_millis(500);
+
+        let config = Arc::new(config::Config::default());
+        let (svc, concentrator) = StatsConcentratorService::new(Arc::clone(&config));
+        tokio::spawn(svc.run());
+        let trace_sender = Arc::new(SendingTraceProcessor {
+            appsec: None,
+            processor: Arc::new(ServerlessTraceProcessor {
+                obfuscation_config: Arc::new(ObfuscationConfig::new().expect("ObfuscationConfig")),
+            }),
+            trace_tx: tokio::sync::mpsc::channel(1).0,
+            stats_generator: Arc::new(StatsGenerator::new(concentrator)),
+        });
+        let tags_provider = Arc::new(provider::Provider::new(
+            Arc::clone(&config),
+            LAMBDA_RUNTIME_SLUG.to_string(),
+            &HashMap::from([("function_arn".to_string(), "test-arn".to_string())]),
+        ));
+
+        let handle = InvocationProcessorHandle::noop();
+
+        timeout(timeout_dur, handle.get_reparenting_info())
+            .await
+            .expect("get_reparenting_info timed out")
+            .expect("get_reparenting_info");
+
+        timeout(
+            timeout_dur,
+            handle.update_reparenting(std::collections::VecDeque::new()),
+        )
+        .await
+        .expect("update_reparenting timed out")
+        .expect("update_reparenting");
+
+        timeout(timeout_dur, handle.set_cold_start_span_trace_id(42))
+            .await
+            .expect("set_cold_start_span_trace_id timed out")
+            .expect("set_cold_start_span_trace_id");
+
+        timeout(
+            timeout_dur,
+            handle.on_platform_runtime_done(
+                "rid".to_string(),
+                RuntimeDoneMetrics {
+                    duration_ms: 0.0,
+                    produced_bytes: None,
+                },
+                Status::Success,
+                None,
+                Arc::clone(&tags_provider),
+                Arc::clone(&trace_sender),
+                0,
+            ),
+        )
+        .await
+        .expect("on_platform_runtime_done timed out")
+        .expect("on_platform_runtime_done");
+
+        timeout(
+            timeout_dur,
+            handle.on_platform_report(
+                "rid",
+                ReportMetrics::OnDemand(OnDemandReportMetrics {
+                    duration_ms: 0.0,
+                    billed_duration_ms: 0,
+                    memory_size_mb: 0,
+                    max_memory_used_mb: 0,
+                    init_duration_ms: None,
+                    restore_duration_ms: None,
+                }),
+                0,
+                Status::Success,
+                &None,
+                &None,
+                tags_provider,
+                trace_sender,
+            ),
+        )
+        .await
+        .expect("on_platform_report timed out")
+        .expect("on_platform_report");
     }
 }

--- a/bottlecap/src/lifecycle/invocation/processor_service.rs
+++ b/bottlecap/src/lifecycle/invocation/processor_service.rs
@@ -823,12 +823,15 @@ mod tests {
             extension::telemetry::events::OnDemandReportMetrics,
             traces::{
                 stats_concentrator_service::StatsConcentratorService,
-                stats_generator::StatsGenerator, trace_processor::ServerlessTraceProcessor,
+                stats_generator::StatsGenerator, trace_processor,
+                trace_processor::ServerlessTraceProcessor,
             },
         };
         use libdd_trace_obfuscation::obfuscation_config::ObfuscationConfig;
         use std::collections::HashMap;
         use tokio::time::{Duration, timeout};
+
+        let error_sampler = trace_processor::new_error_sampler(false);
 
         let timeout_dur = Duration::from_millis(500);
 
@@ -839,6 +842,7 @@ mod tests {
             appsec: None,
             processor: Arc::new(ServerlessTraceProcessor {
                 obfuscation_config: Arc::new(ObfuscationConfig::new().expect("ObfuscationConfig")),
+                error_sampler,
             }),
             trace_tx: tokio::sync::mpsc::channel(1).0,
             stats_generator: Arc::new(StatsGenerator::new(concentrator)),

--- a/bottlecap/src/traces/trace_agent.rs
+++ b/bottlecap/src/traces/trace_agent.rs
@@ -105,6 +105,31 @@ pub struct ProxyState {
     pub proxy_aggregator: Arc<Mutex<proxy_aggregator::Aggregator>>,
 }
 
+/// Extension seam for the [`TraceAgent`] HTTP router. Implementors receive
+/// the fully-assembled production router and return it with any additional
+/// routes merged in. Used to attach optional routes (for example, a
+/// deterministic drain endpoint) without adding a dedicated field per
+/// route to [`TraceAgent`].
+///
+/// Returning `Err` propagates out of [`TraceAgent::start`], aborting the
+/// HTTP listener task. Note that the Lambda binary's `start_trace_agent`
+/// helper spawns `start` and only logs its error; the surrounding pipeline
+/// does not observe the failure. Callers that need to react to startup
+/// errors must spawn the agent themselves.
+///
+/// Implementors that carry state must call `.with_state(...)` on their
+/// sub-router before merging, because `Router::merge` requires both
+/// routers to share the same state type.
+///
+/// Extension routes are merged *after* the per-router
+/// `RequestBodyLimitLayer`s and sit under the outer
+/// `DefaultBodyLimit::disable()`, so they have no request body limit at all.
+/// An extension route that reads a body should layer its own
+/// `RequestBodyLimitLayer` on its sub-router.
+pub trait RouterExtension: Send + Sync {
+    fn extend(&self, router: Router) -> Result<Router, Box<dyn std::error::Error + Send + Sync>>;
+}
+
 pub struct TraceAgent {
     pub config: Arc<config::Config>,
     pub trace_processor: Arc<dyn trace_processor::TraceProcessor + Send + Sync>,
@@ -118,6 +143,9 @@ pub struct TraceAgent {
     tx: Sender<SendDataBuilderInfo>,
     stats_concentrator: StatsConcentratorHandle,
     span_deduper: DedupHandle,
+    /// `None` when the caller wants no extra routes. See
+    /// [`TraceAgent::with_router_extension`].
+    router_extension: Option<Arc<dyn RouterExtension>>,
 }
 
 #[derive(Clone, Copy)]
@@ -170,11 +198,22 @@ impl TraceAgent {
             shutdown_token: CancellationToken::new(),
             stats_concentrator,
             span_deduper,
+            router_extension: None,
         }
     }
 
+    /// Attaches a [`RouterExtension`] that will be applied to the
+    /// fully-assembled production router before the outer fallback and
+    /// body-limit layers. Without this call, the agent exposes only its
+    /// production routes.
+    #[must_use]
+    pub fn with_router_extension(mut self, extension: Arc<dyn RouterExtension>) -> Self {
+        self.router_extension = Some(extension);
+        self
+    }
+
     #[allow(clippy::cast_possible_truncation)]
-    pub async fn start(&self) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn start(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let now = Instant::now();
 
         // Set up a channel to send processed stats to our stats aggregator.
@@ -192,7 +231,7 @@ impl TraceAgent {
             }
         });
 
-        let router = self.make_router(stats_tx);
+        let router = self.make_router(stats_tx)?;
 
         let port = u16::try_from(TRACE_AGENT_PORT).expect("TRACE_AGENT_PORT is too large");
         let socket = SocketAddr::from(([127, 0, 0, 1], port));
@@ -212,7 +251,10 @@ impl TraceAgent {
         Ok(())
     }
 
-    fn make_router(&self, stats_tx: Sender<pb::ClientStatsPayload>) -> Router {
+    fn make_router(
+        &self,
+        stats_tx: Sender<pb::ClientStatsPayload>,
+    ) -> Result<Router, Box<dyn std::error::Error + Send + Sync>> {
         let stats_generator = Arc::new(StatsGenerator::new(self.stats_concentrator.clone()));
         let trace_state = TraceState {
             config: Arc::clone(&self.config),
@@ -281,14 +323,20 @@ impl TraceAgent {
 
         let info_router = Router::new().route(INFO_ENDPOINT_PATH, any(Self::info));
 
-        Router::new()
+        let mut router = Router::new()
             .merge(trace_router)
             .merge(stats_router)
             .merge(proxy_router)
-            .merge(info_router)
+            .merge(info_router);
+
+        if let Some(extension) = &self.router_extension {
+            router = extension.extend(router)?;
+        }
+
+        Ok(router
             .fallback(handler_not_found)
             // Disable the default body limit so we can use our own limit
-            .layer(DefaultBodyLimit::disable())
+            .layer(DefaultBodyLimit::disable()))
     }
 
     async fn graceful_shutdown(shutdown_token: CancellationToken) {
@@ -796,8 +844,21 @@ mod tests {
     //! The `client_computed_stats` bool pinned here is what APMSVLS-487
     //! (`lpimentel/respect-client-computed-stats`) consumes.
 
-    use axum::http::{HeaderMap, HeaderName, HeaderValue};
+    use super::*;
+    use crate::{
+        LAMBDA_RUNTIME_SLUG, config,
+        traces::{
+            span_dedup_service::DedupService, stats_concentrator_service::StatsConcentratorService,
+            trace_aggregator_service::AggregatorService,
+        },
+    };
+    use axum::body::Body;
+    use axum::http::{HeaderMap, HeaderName, HeaderValue, Request};
+    use libdd_trace_obfuscation::obfuscation_config::ObfuscationConfig;
     use libdd_trace_utils::trace_utils::TracerHeaderTags;
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tower::ServiceExt;
 
     /// Build a `HeaderMap` with `name: value` (or no header when `value` is `None`), convert it the
     /// same way `handle_traces` does, and return `(client_computed_stats, client_computed_top_level)`.
@@ -876,5 +937,138 @@ mod tests {
                 "expected client_computed_top_level == true for {value:?}"
             );
         }
+    }
+
+    /// Test extension that records how many times its route was hit.
+    struct SpyExtension {
+        hits: Arc<AtomicUsize>,
+    }
+
+    impl RouterExtension for SpyExtension {
+        fn extend(
+            &self,
+            router: Router,
+        ) -> Result<Router, Box<dyn std::error::Error + Send + Sync>> {
+            Ok(router.merge(
+                Router::new()
+                    .route(
+                        "/spy",
+                        post(|State(hits): State<Arc<AtomicUsize>>| async move {
+                            hits.fetch_add(1, Ordering::SeqCst);
+                            StatusCode::NO_CONTENT
+                        }),
+                    )
+                    .with_state(Arc::clone(&self.hits)),
+            ))
+        }
+    }
+
+    /// Test extension that always fails, used to assert that `make_router`
+    /// surfaces extension errors instead of swallowing them.
+    struct FailingExtension;
+
+    impl RouterExtension for FailingExtension {
+        fn extend(
+            &self,
+            _router: Router,
+        ) -> Result<Router, Box<dyn std::error::Error + Send + Sync>> {
+            Err("extension failed during make_router".into())
+        }
+    }
+
+    fn build_test_agent() -> TraceAgent {
+        let config = Arc::new(config::Config::default());
+        let (concentrator_svc, concentrator) = StatsConcentratorService::new(Arc::clone(&config));
+        tokio::spawn(concentrator_svc.run());
+        let (aggregator_svc, aggregator_handle) = AggregatorService::default();
+        tokio::spawn(aggregator_svc.run());
+        let (dedup_svc, dedup_handle) = DedupService::new();
+        tokio::spawn(dedup_svc.run());
+        let trace_processor = Arc::new(trace_processor::ServerlessTraceProcessor {
+            obfuscation_config: Arc::new(ObfuscationConfig::new().expect("ObfuscationConfig")),
+        });
+        let stats_aggregator = Arc::new(Mutex::new(
+            stats_aggregator::StatsAggregator::new_with_concentrator(concentrator.clone()),
+        ));
+        let proxy_aggregator = Arc::new(Mutex::new(proxy_aggregator::Aggregator::default()));
+        let tags_provider = Arc::new(provider::Provider::new(
+            Arc::clone(&config),
+            LAMBDA_RUNTIME_SLUG.to_string(),
+            &HashMap::from([("function_arn".to_string(), "test-arn".to_string())]),
+        ));
+
+        TraceAgent::new(
+            config,
+            aggregator_handle,
+            trace_processor,
+            stats_aggregator,
+            Arc::new(stats_processor::ServerlessStatsProcessor {}),
+            proxy_aggregator,
+            InvocationProcessorHandle::noop(),
+            None,
+            tags_provider,
+            concentrator,
+            dedup_handle,
+        )
+    }
+
+    #[tokio::test]
+    async fn with_router_extension_adds_reachable_route_to_make_router() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let agent = build_test_agent().with_router_extension(Arc::new(SpyExtension {
+            hits: Arc::clone(&hits),
+        }));
+        let (stats_tx, _stats_rx) = mpsc::channel::<pb::ClientStatsPayload>(1);
+        let router = agent.make_router(stats_tx).expect("make_router");
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/spy")
+                    .body(Body::empty())
+                    .expect("build request"),
+            )
+            .await
+            .expect("route response");
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn make_router_propagates_extension_error() {
+        let agent = build_test_agent().with_router_extension(Arc::new(FailingExtension));
+        let (stats_tx, _stats_rx) = mpsc::channel::<pb::ClientStatsPayload>(1);
+
+        let err = agent
+            .make_router(stats_tx)
+            .expect_err("make_router should surface extension error");
+
+        assert!(
+            err.to_string()
+                .contains("extension failed during make_router"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn make_router_returns_404_for_extension_route_when_none_attached() {
+        let agent = build_test_agent();
+        let (stats_tx, _stats_rx) = mpsc::channel::<pb::ClientStatsPayload>(1);
+        let router = agent.make_router(stats_tx).expect("make_router");
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/spy")
+                    .body(Body::empty())
+                    .expect("build request"),
+            )
+            .await
+            .expect("route response");
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 }

--- a/bottlecap/src/traces/trace_agent.rs
+++ b/bottlecap/src/traces/trace_agent.rs
@@ -986,6 +986,7 @@ mod tests {
         tokio::spawn(dedup_svc.run());
         let trace_processor = Arc::new(trace_processor::ServerlessTraceProcessor {
             obfuscation_config: Arc::new(ObfuscationConfig::new().expect("ObfuscationConfig")),
+            error_sampler: trace_processor::new_error_sampler(false),
         });
         let stats_aggregator = Arc::new(Mutex::new(
             stats_aggregator::StatsAggregator::new_with_concentrator(concentrator.clone()),

--- a/bottlecap/src/traces/trace_agent.rs
+++ b/bottlecap/src/traces/trace_agent.rs
@@ -117,6 +117,10 @@ pub struct ProxyState {
 /// does not observe the failure. Callers that need to react to startup
 /// errors must spawn the agent themselves.
 ///
+/// Note that a path collision is not an `Err`: `Router::merge` panics when
+/// both routers define the same path, so a colliding extension aborts the
+/// process rather than returning an error through this trait.
+///
 /// Implementors that carry state must call `.with_state(...)` on their
 /// sub-router before merging, because `Router::merge` requires both
 /// routers to share the same state type.


### PR DESCRIPTION
TL;DR: refactoring here first to prepare for #1216 and keep that PR slightly smaller.

> NOTE: The original version of this PR was #1201. I've made several changes after feedback, so starting fresh to reduce baggage.

Part of a PR stack:
1. #1344 **👈🏽 this PR**
2. #1216

## Overview

Preparatory refactors for the upcoming `bottlecap-testmode` binary ([APMSVLS-501](https://datadoghq.atlassian.net/browse/APMSVLS-501)), which reuses `TraceAgent` / `handle_traces` but has no Lambda lifecycle to drive. Two logical changes:

The `bottlecap::startup` extraction (`build_trace_agent` and the public `startup` module) lands in #1216 alongside the `bottlecap-test-mode` binary that consumes it, where it has a caller; this PR keeps its scope to the two seams below and leaves `main.rs` and `lib.rs` untouched.

### 1. `InvocationProcessorHandle::noop()`

Constructor backed by a background task that acknowledges every `ProcessorCommand` with a sensible default so callers never block on their response oneshots:
- Request-response commands (`GetReparentingInfo`, `UpdateReparenting`, `SetColdStartSpanTraceId`, `PlatformRuntimeDone`, `PlatformReport`) reply with empty/default values.
- Fire-and-forget commands are dropped silently.

The `match` is exhaustive: adding a new `ProcessorCommand` variant will cause a compile error here, forcing test-mode behavior to be decided explicitly. A response-carrying variant placed in the fire-and-forget arm would silently drop its sender, causing the caller to receive `ProcessorError::ChannelReceive` instead of the intended default.

The noop channel capacity matches the real `InvocationProcessorService` to avoid backpressure surprises.

### 2. `RouterExtension` seam on `TraceAgent`

Adds a generic extension point that lets a caller merge additional axum routes into the trace-agent's HTTP router without `TraceAgent` knowing what those routes do. When no caller attaches an extension (the Lambda binary case), the HTTP surface on port 8126 is unchanged.

- New `pub trait RouterExtension: Send + Sync { fn extend(&self, router: Router) -> Result<Router, Box<dyn Error>>; }` defined in `traces::trace_agent`. Returning `Err` aborts agent startup and surfaces the error in the existing log path, preventing silent failures from a panicking or misconfigured extension.
- `TraceAgent` holds `router_extension: Option<Arc<dyn RouterExtension>>` with a consuming builder method `with_router_extension(self, ext: Arc<dyn RouterExtension>) -> Self`.
- `make_router` calls `extension.extend(router)?` when the field is set, before applying the outer fallback and body-limit layers.
- A `#[cfg(test)]`-only `SpyExtension` validates the seam end-to-end: the trait shape compiles, state is carried via `Arc`, and merged routes are reachable through the composed `Router` returned by `make_router`.

Any concrete flush/drain/diagnostic endpoint lives behind an impl of this trait in the consumer crate, not in `trace_agent.rs`.

## Testing

- [x] `cargo check --bin bottlecap`
- [x] `cargo check --lib`
- [x] `cargo test --lib`
- [x] `cargo clippy --workspace --all-targets --features default -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo nextest run --workspace` (532/532 passed)
- New unit tests on `InvocationProcessorHandle::noop()`: `noop_request_response_methods_return_defaults`, `noop_fire_and_forget_commands_do_not_panic`, `noop_platform_runtime_done_and_report_respond_without_blocking`, `noop_request_response_variants_complete_within_timeout`
- New unit tests on the `RouterExtension` seam: `with_router_extension_adds_reachable_route_to_make_router`, `make_router_returns_404_for_extension_route_when_none_attached`

[APMSVLS-501]: https://datadoghq.atlassian.net/browse/APMSVLS-501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
