### PR TITLE
[APMSVLS-485] Send region as a trace stats tag by default

### DIFF
--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -89,12 +89,38 @@ pub struct LambdaConfig {
     pub trace_experimental_features_enabled: bool,
     /// `DD_TRACE_STATS_ADDITIONAL_TAGS` — comma-separated span `meta` keys included as
     /// additional dimensions on trace stats aggregation (`ClientGroupedStats.additional_metric_tags`).
-    /// Only honored when `trace_experimental_features_enabled` is true.
+    /// Defaults to `DEFAULT_ADDITIONAL_METRIC_TAGS`; an explicit setting replaces that default
+    /// wholesale. User-configured keys are honored only when `trace_experimental_features_enabled`
+    /// is true, but the default survives a disabled gate.
     pub additional_metric_tags: Vec<String>,
     /// `DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT` — per-bucket cap on distinct
     /// `additional_metric_tags` value combinations; `None` uses libdatadog's default (100).
     /// Only honored when `trace_experimental_features_enabled` is true.
     pub additional_metric_tags_cardinality_limit: Option<usize>,
+}
+
+/// Span `meta` keys used as additional trace-stats aggregation dimensions by default on Lambda.
+///
+/// `region` is intrinsic to the sandbox (parsed from the function ARN in `tags::lambda`) and is
+/// designated a span-derived primary tag at the org level. When the backend computes stats it
+/// applies that designation itself; when `DD_LAMBDA_EXTENSION_COMPUTE_STATS` moves aggregation
+/// into the extension, the backend only sees `ClientGroupedStats.additional_metric_tags`, so the
+/// dimension has to be sent from here or it disappears.
+///
+/// A default, not a floor: an explicit `DD_TRACE_STATS_ADDITIONAL_TAGS` replaces it, so a user who
+/// wants `region` alongside their own keys lists it themselves. That keeps the list clear of
+/// libdatadog's 4-key cap, which drops keys by alphabetical order rather than by intent.
+///
+/// Exempt from `DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED`: the gate exists to keep user-configured
+/// keys of unknown cardinality behind a flag, and this key is neither user-configured nor
+/// unbounded (one value per function).
+const DEFAULT_ADDITIONAL_METRIC_TAGS: &[&str] = &["region"];
+
+fn default_additional_metric_tags() -> Vec<String> {
+    DEFAULT_ADDITIONAL_METRIC_TAGS
+        .iter()
+        .map(ToString::to_string)
+        .collect()
 }
 
 impl Default for LambdaConfig {
@@ -120,7 +146,7 @@ impl Default for LambdaConfig {
             custom_metrics_exclude_tags: Vec::new(),
             lambda_durable_function_log_buffer_size: 0,
             trace_experimental_features_enabled: false,
-            additional_metric_tags: Vec::new(),
+            additional_metric_tags: default_additional_metric_tags(),
             additional_metric_tags_cardinality_limit: None,
         }
     }
@@ -282,15 +308,19 @@ impl DatadogConfigExtension for LambdaConfig {
 }
 
 impl LambdaConfig {
-    /// Drop `additional_metric_tags` / `additional_metric_tags_cardinality_limit` unless
-    /// `trace_experimental_features_enabled` is set, matching the Serverless Compatibility
+    /// Drop user-configured `additional_metric_tags` / `additional_metric_tags_cardinality_limit`
+    /// unless `trace_experimental_features_enabled` is set, matching the Serverless Compatibility
     /// Layer (`datadog-trace-agent`).
     ///
     /// Applied after all config sources have merged, not inside `merge_from`, so that the gate
     /// and the values it gates can come from different sources in either order.
     fn apply_experimental_features_gate(&mut self) {
         if !self.trace_experimental_features_enabled {
-            self.additional_metric_tags.clear();
+            // Reset to the Lambda default rather than clearing: the gate governs user-configured
+            // keys, and `region` is a platform default that must survive a disabled gate. This is
+            // the only reset path, and it runs on every `get_config`, so clearing here would make
+            // the default unreachable in production.
+            self.additional_metric_tags = default_additional_metric_tags();
             self.additional_metric_tags_cardinality_limit = None;
         }
     }
@@ -780,14 +810,59 @@ mod lambda_config_tests {
     // trace_experimental_features_enabled, matching the Serverless Compatibility Layer
     // (datadog-trace-agent) ----
 
+    /// The gate drops the user-supplied keys but leaves the Lambda default in place.
     #[test]
-    fn additional_metric_tags_ignored_when_experimental_features_disabled() {
+    fn additional_metric_tags_reset_to_default_when_experimental_features_disabled() {
         let config = load(|jail| {
             jail.set_env("DD_TRACE_STATS_ADDITIONAL_TAGS", "region,tenant_id");
             Ok(())
         });
         assert!(!config.ext.trace_experimental_features_enabled);
-        assert!(config.ext.additional_metric_tags.is_empty());
+        assert_eq!(
+            config.ext.additional_metric_tags,
+            vec!["region".to_string()]
+        );
+    }
+
+    /// No env vars at all: the default still reaches the resolved config.
+    #[test]
+    fn additional_metric_tags_defaults_to_region() {
+        let config = load(|_| Ok(()));
+        assert_eq!(
+            config.ext.additional_metric_tags,
+            vec!["region".to_string()]
+        );
+    }
+
+    /// The production path. `apply_experimental_features_gate` is the only reset path and runs on
+    /// every `get_config`, so a default set on `LambdaConfig::default()` alone would be correct in
+    /// tests built from `Config::default()` and wrong here. Must go through `load()`.
+    #[test]
+    fn additional_metric_tags_default_survives_disabled_experimental_gate() {
+        let config = load(|jail| {
+            jail.set_env("DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED", "false");
+            Ok(())
+        });
+        assert_eq!(
+            config.ext.additional_metric_tags,
+            vec!["region".to_string()]
+        );
+    }
+
+    /// `region` is a default, not a floor: an explicit list replaces it wholesale rather than
+    /// merging, so a user's keys are never evicted by libdatadog's alphabetical 4-key cap to make
+    /// room for one they did not ask for.
+    #[test]
+    fn explicit_additional_metric_tags_replace_the_default() {
+        let config = load(|jail| {
+            jail.set_env("DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED", "true");
+            jail.set_env("DD_TRACE_STATS_ADDITIONAL_TAGS", "tenant_id");
+            Ok(())
+        });
+        assert_eq!(
+            config.ext.additional_metric_tags,
+            vec!["tenant_id".to_string()]
+        );
     }
 
     #[test]
@@ -870,7 +945,10 @@ mod lambda_config_tests {
             jail.set_env("DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED", "false");
             Ok(())
         });
-        assert!(config.ext.additional_metric_tags.is_empty());
+        assert_eq!(
+            config.ext.additional_metric_tags,
+            vec!["region".to_string()]
+        );
         assert_eq!(config.ext.additional_metric_tags_cardinality_limit, None);
     }
 }

--- a/bottlecap/src/traces/stats_concentrator_service.rs
+++ b/bottlecap/src/traces/stats_concentrator_service.rs
@@ -719,11 +719,10 @@ mod tests {
         );
     }
 
-    /// When `additional_metric_tags` is unset (the default), `additional_metric_tags` on the
-    /// exported stats must remain empty even if the span has a meta key that would otherwise
-    /// match a commonly-used tag name.
+    /// Only configured keys are surfaced: a span meta key that is not in `additional_metric_tags`
+    /// must not appear on the exported stats, even when it matches a commonly-used tag name.
     #[tokio::test]
-    async fn test_additional_metric_tags_empty_by_default() {
+    async fn test_additional_metric_tags_exclude_unconfigured_keys() {
         let config = Arc::new(Config::default());
         let (service, handle) = StatsConcentratorService::new(config);
         tokio::spawn(service.run());
@@ -738,7 +737,34 @@ mod tests {
             all_stats
                 .iter()
                 .all(|s| s.additional_metric_tags.is_empty()),
-            "Expected additional_metric_tags to be empty by default, got: {:?}",
+            "Expected unconfigured keys to be excluded, got: {:?}",
+            all_stats
+                .iter()
+                .map(|s| &s.additional_metric_tags)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// `region` defaults into `additional_metric_tags`, so a span carrying it surfaces the
+    /// dimension without any user configuration. This is the whole point of the default: with
+    /// `DD_LAMBDA_EXTENSION_COMPUTE_STATS` the backend sees no spans, only this field.
+    #[tokio::test]
+    async fn test_region_surfaces_as_additional_metric_tag_by_default() {
+        let config = Arc::new(Config::default());
+        let (service, handle) = StatsConcentratorService::new(config);
+        tokio::spawn(service.run());
+
+        let span = create_span_kind_span("client", vec![("region", "us-west-2")]);
+        handle.add(&span).unwrap();
+
+        let result = handle.flush(true).await.unwrap();
+        let payload = result.expect("Expected stats for the client span, but got None.");
+        let all_stats: Vec<_> = payload.stats.iter().flat_map(|b| &b.stats).collect();
+        assert!(
+            all_stats
+                .iter()
+                .any(|s| s.additional_metric_tags == vec!["region:us-west-2".to_string()]),
+            "Expected additional_metric_tags to contain region:us-west-2, got: {:?}",
             all_stats
                 .iter()
                 .map(|s| &s.additional_metric_tags)


### PR DESCRIPTION
**Please include Jira ticket in title.**

## Overview

Stacked on #1336. Review that one first; this PR is the last commit only.

With `DD_LAMBDA_EXTENSION_COMPUTE_STATS` enabled the extension aggregates trace stats itself. The backend then never sees full spans, so it can only use the tags the extension puts on the stats payload, and any tag an org has designated as a primary tag was silently lost on Lambda trace stats. Customers who enabled the setting lost those dimensions on `trace.aws.lambda` without any indication.

This is also what is behind the two xfailed `region` primary-tag tests in serverless-e2e-tests#319. Those tests do not measure the tracer, they measure who computed the stats.

The extension now sends `region` as an additional trace stats tag by default, so it keeps working as a primary tag when the extension computes stats. The value is already parsed from the function ARN and copied into every span, so this adds one value per function and no new cardinality: the aggregation key gains a constant dimension, not a multiplier.

### Interaction with `DD_TRACE_STATS_ADDITIONAL_TAGS`

Setting it **replaces** the default rather than adding to it:

| `DD_TRACE_STATS_ADDITIONAL_TAGS` | `DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED` | Result |
|---|---|---|
| unset | off (default) | `["region"]` |
| unset | on | `["region"]` |
| `tenant_id` | on | `["tenant_id"]` |
| `region,tenant_id` | on | `["region", "tenant_id"]` |
| `region,tenant_id` | off | `["region"]` |

A user who wants `region` alongside their own keys lists it explicitly. Replacing rather than merging keeps the change clear of the four-key limit on additional stats tags: a one-key default never approaches it, and an explicit list is passed through exactly as written, so users still get all four slots. Merging would have spent one of them on a key the user did not ask for, and since keys over the limit are dropped in alphabetical order rather than by intent, `region` sorts late enough that it would often have been the one dropped anyway.

The default is deliberately not subject to `DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED`. That gate exists to keep user-configured keys of unknown cardinality behind a flag; `region` is neither user-configured nor unbounded.

Note that `apply_experimental_features_gate` resets to the default rather than clearing. It is the only reset path and runs on every `get_config`, so clearing there would make the default unreachable in production while still looking correct in tests built from `Config::default()`.

## Testing

`cargo test --lib`, `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` are clean.

Unit tests cover the default reaching the resolved config, the default surviving a disabled experimental gate (the production path, via `get_config` rather than `Config::default()`), an explicit setting replacing the default, and `region` surfacing on exported stats from a span that carries it.

Still to do before this leaves draft:

- [ ] Confirm the org-side configuration needed for these tags to be honored is in place for ddserverless.
- [ ] Run the statsv2 e2e scenario against a dev layer built from this branch (`DD_EXTENSION_ARN`), since serverless-e2e-tests pins a published layer.
- [ ] Un-xfail the two tests in serverless-e2e-tests and restore the `statsv2` rows in `FEATURE-PARITY.md`. Separate PR, after this ships in a released layer.

🤖
