### PR TITLE
fix(ci): stop paging through every layer version to read the latest one

### DIFF
--- a/.gitlab/scripts/build_private_image.sh
+++ b/.gitlab/scripts/build_private_image.sh
@@ -27,7 +27,7 @@ else
 fi
 
 # Increment last version
-latest_version=$(aws lambda list-layer-versions --region us-east-1 --layer-name "$LAYER_NAME" --query 'LayerVersions[0].Version || `0`')
+latest_version=$(aws lambda list-layer-versions --region us-east-1 --layer-name "$LAYER_NAME" --max-items 1 --query 'LayerVersions[0].Version || `0`')
 VERSION=$(($latest_version + 1))
 printf "Tagging container image with version: $VERSION and latest\n"
 

--- a/.gitlab/scripts/publish_layers.sh
+++ b/.gitlab/scripts/publish_layers.sh
@@ -106,7 +106,7 @@ fi
 printf "[$REGION] Starting publishing layers...\n"
 
 if [ "$AUTOMATICALLY_BUMP_VERSION" = "1" ]; then
-    latest_version=$(aws lambda list-layer-versions --region $REGION --layer-name $LAYER_NAME --query 'LayerVersions[0].Version || `0`')
+    latest_version=$(aws lambda list-layer-versions --region $REGION --layer-name $LAYER_NAME --max-items 1 --query 'LayerVersions[0].Version || `0`')
     VERSION=$(($latest_version + 1))
 
 else
@@ -145,7 +145,7 @@ else
     architectures="arm64"
 fi
 
-latest_version=$(aws lambda list-layer-versions --region $REGION --layer-name $LAYER_NAME --query 'LayerVersions[0].Version || `0`')
+latest_version=$(aws lambda list-layer-versions --region $REGION --layer-name $LAYER_NAME --max-items 1 --query 'LayerVersions[0].Version || `0`')
 if [ $latest_version -ge $VERSION ]; then
     printf "[$REGION] Layer $layer version $VERSION already exists in region $REGION, skipping...\n"
     exit 1

--- a/scripts/build_publish_deploy_bench.sh
+++ b/scripts/build_publish_deploy_bench.sh
@@ -23,7 +23,7 @@ if [ -z "${DD_API_KEY+set}" ]; then
     exit 1
 fi
 
-LATEST_VERSION=$(aws-vault exec $AWS_PROFILE -- aws lambda list-layer-versions --region "$REGION" --layer-name "${LAYER_NAME}" --query 'LayerVersions[0].Version || `0`')
+LATEST_VERSION=$(aws-vault exec $AWS_PROFILE -- aws lambda list-layer-versions --region "$REGION" --layer-name "${LAYER_NAME}" --max-items 1 --query 'LayerVersions[0].Version || `0`')
 export VERSION=$(($LATEST_VERSION+1))
 
 export EXTENSION_ARN="arn:aws:lambda:$REGION:425362996713:layer:$LAYER_NAME:$VERSION"

--- a/scripts/publish_layers.sh
+++ b/scripts/publish_layers.sh
@@ -139,7 +139,7 @@ do
         if [ ! -z "$SUFFIX" ]; then
             layer_name+="-$SUFFIX"
         fi
-        latest_version=$(aws lambda list-layer-versions --region $region --layer-name "${layer_name}" --query 'LayerVersions[0].Version || `0`')
+        latest_version=$(aws lambda list-layer-versions --region $region --layer-name "${layer_name}" --max-items 1 --query 'LayerVersions[0].Version || `0`')
         if [ $latest_version -ge $VERSION ]; then
             echo "Layer $layer_name  version $VERSION already exists in region $region, skipping..."
             continue


### PR DESCRIPTION
## Problem

The `publish layer e2e sandbox` job fails intermittently, which blocks the serverless e2e tests:

```
aws: [ERROR]: An error occurred (ThrottlingException) when calling the
ListLayerVersions operation (reached max retries: 2): Rate exceeded
```

[Sample failure](https://gitlab.ddbuild.io/DataDog/datadog-lambda-extension/-/jobs/1999855564). The same call is made by every layer-publishing job, so prod and integration-test publishes are exposed too.

## Background

Lambda allows **15 control-plane requests per second, per account, per region**, shared across all APIs — `ListLayerVersions`, `PublishLayerVersion`, `AddLayerVersionPermission`, `GetLayerVersion` and `DeleteLayerVersion` all draw from the same bucket. It is not adjustable. Confirmed against the CI sandbox account in `us-west-2` via Service Quotas (`L-B2AA0F47`, `Value: 15.0`, `Adjustable: false`) and in the [Lambda quotas docs](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-limits.html), which spell it out as "15 requests per second across all APIs (not 15 requests per second per API)".

## Cause

The scripts read the newest layer version with:

```
aws lambda list-layer-versions --layer-name ... --query 'LayerVersions[0].Version || `0`'
```

`--query` is applied **client-side, after** the CLI finishes auto-paginating. So this pages through every version of the layer, accumulates them all, and then throws away everything but the first. The layer currently holds ~609 versions and the API caps a page at 50, so **one invocation is 13 HTTP requests** — 12 of them pure waste.

`publish_layers.sh` makes this call twice, and the amd64 and amd64-fips jobs publish concurrently into the same region, so a single pipeline spends roughly 50 requests against a 15/second budget. The jobs were throttling themselves; no other pipeline needs to be involved.

## Fix

Add `--max-items 1`, which stops the CLI's pagination once it has one item.

The returned value is unchanged because `ListLayerVersions` returns versions newest-first and the query only ever reads index `0` — the answer was always on the first page.

| Call | `MaxItems` on the wire | HTTP requests | Value |
|---|---|---|---|
| current | *(absent — server default 50)* | 13 | 651 |
| `--max-items 1` | *(absent — server default 50)* | **1** | 651 |

Applied to all five sites that read only the newest version (`.gitlab/scripts/publish_layers.sh` ×2, `.gitlab/scripts/build_private_image.sh`, `scripts/publish_layers.sh`, `scripts/build_publish_deploy_bench.sh`). Net effect on the e2e job: ~26 requests → 2.

Deliberately left paginating: the cleanup job's version enumeration, which must see every version in order to delete the old ones.

## If this doesn't fix it

Kept out of this PR so the effect of `--max-items 1` can be measured on its own. In rough order of what I'd reach for next:

### 1. Give the AWS CLI real retries

`reached max retries: 2` is the CLI default — 3 attempts with a short backoff, which gives up in about a second. Setting `AWS_RETRY_MODE=standard` and `AWS_MAX_ATTEMPTS=10` in the pipeline's global `variables:` gets exponential backoff with jitter across every `aws` call in the pipeline. There is no per-command retry flag; env vars or `~/.aws/config` are the only ways to set this. Verified working: a test call was throttled live and recovered after `0.50s` and `1.16s` delays.

### 2. Drop the duplicate lookup

`publish_layers.sh` calls `list-layer-versions` twice with identical arguments — once to compute `VERSION` on the auto-bump path, then again for the "already exists" guard. The second can reuse the first result, halving the calls again.

### 3. Retry the job

`retry: {max: 2, when: [script_failure, runner_system_failure]}` on the e2e publish job. Safe there specifically because it runs with `AUTOMATICALLY_BUMP_VERSION=1`, so each attempt re-derives the version from what is live and a retry after a partial publish just takes the next number. Not safe for the prod publish job, where `VERSION` comes from `CI_COMMIT_TAG` and a retry after a successful publish would trip the "already exists" guard.

### 4. Reduce the cleanup job's burst

`integration-cleanup-layer` issues ~109 sequential `delete-layer-version` calls, each drawing on the same 15/second bucket, and `|| echo "...continuing..."` swallows throttling errors so failed deletes silently accumulate and make the next run's burst larger. It is in `us-east-1`, so it cannot have caused this `us-west-2` failure — but it is the same class of problem.

## Testing

- Measured request counts against the real sandbox layer in `us-west-2` with `--debug`, counting `Making request for OperationModel(name=ListLayerVersions)`: 13 requests without the flag, 1 with it, identical returned value.
- Verified the ordering assumption from the raw response body: versions come back descending (`651, 650, 649, ...`), so index `0` is the newest.
- Verified the ``|| `0` `` fallback still returns `0` for a nonexistent layer, so a first-time publish still starts at version 1.
- Confirmed page size cannot be raised instead: `--page-size 100` is rejected with `ValidationException: Value '100' at 'maxItems' failed to satisfy constraint: Member must have value less than or equal to 50`, and `--page-size 50` makes the same 13 requests as the default.
- Ran `publish_layers.sh` end-to-end against a stubbed `aws` on the auto-bump path, the tag path, and the already-exists path: correct version bump, correct dotenv ARN, and the guard still exits 1 when the version exists.

## Appendix: verified vs. inferred

**Verified:** the 15 rps quota value and that it is not adjustable (Service Quotas API against the actual CI account, plus docs); the 13→1 request reduction and unchanged return value; descending version order; the 50-item page cap; that no CLI retry flag exists.

**Inferred, not confirmed:** that this pipeline's own request volume is the *whole* cause. Self-throttling at ~50 requests against a 15/second budget is sufficient to explain the failure, but I did not pull CloudTrail for the failing timestamp, so I cannot rule out a concurrent contributor in the same account and region. If throttling persists after this change, that is the thing to check before adding more retry logic.
