### PR TITLE
fix(tests): stabilize durable function tag test

### DIFF
--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -2598,13 +2598,19 @@ mod tests {
 
         // The durable tag is already known, so the metric must be emitted immediately
         // instead of being held back.
-        let now: i64 = std::time::UNIX_EPOCH
+        let start_timestamp: i64 = std::time::UNIX_EPOCH
             .elapsed()
             .expect("unable to poll clock, unrecoverable")
             .as_secs()
             .try_into()
             .unwrap_or_default();
         processor.on_invoke_event("req-1".to_string());
+        let end_timestamp: i64 = std::time::UNIX_EPOCH
+            .elapsed()
+            .expect("unable to poll clock, unrecoverable")
+            .as_secs()
+            .try_into()
+            .unwrap_or_default();
         assert!(
             matches!(
                 processor.first_invocation_metric_status,
@@ -2617,21 +2623,28 @@ mod tests {
             .runtime
             .clone()
             .expect("runtime should have been resolved by on_invoke_event");
-        let ts = (now / 10) * 10;
+        let start_bucket = (start_timestamp / 10) * 10;
+        let end_bucket = (end_timestamp / 10) * 10;
         let expected_tags = dogstatsd::metric::SortedTags::parse(&format!(
             "cold_start:true,durable_function:true,runtime:{runtime}"
         ))
         .ok();
-        let entry = processor
-            .enhanced_metrics
-            .aggr_handle
-            .get_entry_by_id(
-                crate::metrics::enhanced::constants::INVOCATIONS_METRIC.into(),
-                expected_tags,
-                ts,
-            )
-            .await
-            .unwrap();
+        let mut entry = None;
+        for timestamp in (start_bucket..=end_bucket).step_by(10) {
+            entry = processor
+                .enhanced_metrics
+                .aggr_handle
+                .get_entry_by_id(
+                    crate::metrics::enhanced::constants::INVOCATIONS_METRIC.into(),
+                    expected_tags.clone(),
+                    timestamp,
+                )
+                .await
+                .unwrap();
+            if entry.is_some() {
+                break;
+            }
+        }
         assert!(
             entry.is_some(),
             "Expected the invocation metric to carry the durable_function:true tag"

--- a/bottlecap/src/lifecycle/invocation/processor.rs
+++ b/bottlecap/src/lifecycle/invocation/processor.rs
@@ -2598,19 +2598,7 @@ mod tests {
 
         // The durable tag is already known, so the metric must be emitted immediately
         // instead of being held back.
-        let start_timestamp: i64 = std::time::UNIX_EPOCH
-            .elapsed()
-            .expect("unable to poll clock, unrecoverable")
-            .as_secs()
-            .try_into()
-            .unwrap_or_default();
         processor.on_invoke_event("req-1".to_string());
-        let end_timestamp: i64 = std::time::UNIX_EPOCH
-            .elapsed()
-            .expect("unable to poll clock, unrecoverable")
-            .as_secs()
-            .try_into()
-            .unwrap_or_default();
         assert!(
             matches!(
                 processor.first_invocation_metric_status,
@@ -2623,30 +2611,30 @@ mod tests {
             .runtime
             .clone()
             .expect("runtime should have been resolved by on_invoke_event");
-        let start_bucket = (start_timestamp / 10) * 10;
-        let end_bucket = (end_timestamp / 10) * 10;
-        let expected_tags = dogstatsd::metric::SortedTags::parse(&format!(
-            "cold_start:true,durable_function:true,runtime:{runtime}"
-        ))
-        .ok();
-        let mut entry = None;
-        for timestamp in (start_bucket..=end_bucket).step_by(10) {
-            entry = processor
-                .enhanced_metrics
-                .aggr_handle
-                .get_entry_by_id(
-                    crate::metrics::enhanced::constants::INVOCATIONS_METRIC.into(),
-                    expected_tags.clone(),
-                    timestamp,
-                )
-                .await
-                .unwrap();
-            if entry.is_some() {
-                break;
-            }
-        }
+        // Flush returns every bucket, so there is no need to guess the metric's timestamp.
+        let flushed = processor
+            .enhanced_metrics
+            .aggr_handle
+            .flush()
+            .await
+            .unwrap();
+        let expected_tags = [
+            "cold_start:true".to_string(),
+            "durable_function:true".to_string(),
+            format!("runtime:{runtime}"),
+        ];
+        let found = flushed
+            .distributions
+            .iter()
+            .flat_map(|payload| &payload.sketches)
+            .any(|sketch| {
+                &*sketch.metric == crate::metrics::enhanced::constants::INVOCATIONS_METRIC
+                    && expected_tags
+                        .iter()
+                        .all(|expected| sketch.tags.iter().any(|tag| &**tag == expected.as_str()))
+            });
         assert!(
-            entry.is_some(),
+            found,
             "Expected the invocation metric to carry the durable_function:true tag"
         );
     }


### PR DESCRIPTION
## Overview

Stabilize the durable function invocation metric test by flushing the metrics aggregator and searching the returned sketches for the invocation metric and its expected tags.

This avoids guessing which 10-second aggregation bucket contains the metric when the wall clock crosses a bucket boundary. There is no production code change.

## Testing

- `cargo fmt --all -- --check`
- Focused test repeated 10 times: 10/10 passed
- `cargo nextest run lifecycle::invocation::processor`: 53/53 passed
- `cargo nextest run --workspace`: 650/650 passed
