### PR TITLE
[APMSVLS-469] fix(traces): filter sampled-out trace chunks when tracer or extension computes stats

### DIFF
--- a/bottlecap/src/config/mod.rs
+++ b/bottlecap/src/config/mod.rs
@@ -70,12 +70,12 @@ pub struct LambdaConfig {
     pub lambda_extension_compute_stats: bool,
 
     /// `DD_SERVERLESS_ERROR_SAMPLER_ENABLED`: rescue errored trace chunks that would
-    /// otherwise be dropped, on the `lambda_extension_compute_stats` path. The
-    /// sampler runs in `AlwaysKeep` mode, so this is a plain on/off switch with
-    /// no volume ceiling: enabled rescues every errored chunk, whatever the
-    /// tracer's sampling rate. A function that errors on most invocations under
-    /// `DD_TRACE_SAMPLE_RATE=0.01` will ingest close to every trace, not 1%.
-    /// See APMSVLS-469.
+    /// otherwise be dropped, whenever stats are computed before the backend, by
+    /// either the tracer or the extension. The sampler runs in `AlwaysKeep` mode,
+    /// so this is a plain on/off switch with no volume ceiling: enabled rescues
+    /// every errored chunk, whatever the tracer's sampling rate. A function that
+    /// errors on most invocations under `DD_TRACE_SAMPLE_RATE=0.01` will ingest
+    /// close to every trace, not 1%. See APMSVLS-469.
     pub serverless_error_sampler_enabled: bool,
 
     pub span_dedup_timeout: Option<Duration>,

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -65,10 +65,10 @@ impl StatsComputedBy {
 #[allow(clippy::module_name_repetitions)]
 pub struct ServerlessTraceProcessor {
     pub obfuscation_config: Arc<obfuscation_config::ObfuscationConfig>,
-    /// Rescues errored `AutoDrop` chunks on the `lambda_extension_compute_stats`
-    /// path. Shared across invocations so a stateful mode (`RateLimited`) would
-    /// keep its rolling window; a std Mutex rather than tokio because
-    /// `process_traces` is synchronous.
+    /// Rescues errored `AutoDrop` chunks whenever stats are computed before the
+    /// backend, by either the tracer or the extension. Shared across invocations so
+    /// a stateful mode (`RateLimited`) would keep its rolling window; a std Mutex
+    /// rather than tokio because `process_traces` is synchronous.
     pub error_sampler: Arc<std::sync::Mutex<ErrorsSampler>>,
 }
 
@@ -573,8 +573,14 @@ impl TraceProcessor for ServerlessTraceProcessor {
         };
 
         // Sampled-out chunks are preserved in payloads_for_stats above, so their
-        // stats are still counted after they are removed here.
-        if config.ext.lambda_extension_compute_stats
+        // stats are still counted after they are removed here. Filter whenever
+        // stats are computed before the backend, by either the tracer or the
+        // extension: the backend only needs these chunks when it owns stats.
+        let stats_computed_by = StatsComputedBy::resolve(
+            config.ext.lambda_extension_compute_stats,
+            header_tags.generic.client_computed_stats,
+        );
+        if stats_computed_by != StatsComputedBy::Backend
             && let TracerPayloadCollection::V07(ref mut tracer_payloads) = payload
         {
             self.drop_sampled_out_chunks(tracer_payloads);
@@ -1349,137 +1355,210 @@ mod tests {
         );
     }
 
-    /// Verifies that when `lambda_extension_compute_stats` is true, `process_traces`
-    /// filters sampled-out chunks from the backend payload while preserving them in the
-    /// stats collection.
+    /// Verifies that `process_traces` filters sampled-out chunks from the backend
+    /// payload whenever stats are computed before the backend, by either the tracer
+    /// or the extension, while preserving them in the stats collection. When the
+    /// backend owns stats, all chunks are kept so the backend can compute stats.
     #[test]
     #[allow(clippy::unwrap_used)]
     fn test_process_traces_filters_sampled_out_chunks() {
-        let config = create_compute_stats_config();
-        let (tags_provider, processor) = create_test_processor(&config, enabled_error_sampler());
-        let header_tags = create_test_header_tags();
-
-        let make_span = |trace_id: u64, priority: Option<f64>| -> pb::Span {
-            let mut metrics = HashMap::new();
-            if let Some(p) = priority {
-                metrics.insert("_sampling_priority_v1".to_string(), p);
-            }
-            pb::Span {
-                trace_id,
-                span_id: trace_id,
-                parent_id: 0,
-                metrics,
-                service: "svc".to_string(),
-                name: "op".to_string(),
-                resource: "res".to_string(),
-                ..Default::default()
-            }
-        };
-
-        // Three traces: kept (priority 1), dropped (priority 0), dropped (priority -1)
-        let traces = vec![
-            vec![make_span(1, Some(1.0))],
-            vec![make_span(2, Some(0.0))],
-            vec![make_span(3, Some(-1.0))],
+        // (lambda_extension_compute_stats, client_computed_stats) -> filtering expected
+        let cases = [
+            (false, false, false), // backend owns stats: keep all chunks
+            (true, false, true),   // extension owns stats: filter
+            (false, true, true),   // tracer owns stats: filter
+            (true, true, true),    // tracer owns stats even when extension configured: filter
         ];
 
-        let (payload_info, stats_collection) =
-            processor.process_traces(config, tags_provider, header_tags, traces, 0, None);
-        let payload_info = payload_info.expect("expected Some payload");
+        for (compute_on_extension, client_computed_stats, expect_filtering) in cases {
+            let config = Arc::new(Config {
+                apm_dd_url: "https://trace.agent.datadoghq.com".to_string(),
+                ext: crate::config::LambdaConfig {
+                    lambda_extension_compute_stats: compute_on_extension,
+                    ..Default::default()
+                },
+                ..Config::default()
+            });
+            let (tags_provider, processor) =
+                create_test_processor(&config, enabled_error_sampler());
+            let header_tags = tracer_header_tags::TracerHeaderTags {
+                generic: tracer_header_tags::TracerGenericTags {
+                    client_computed_stats,
+                    ..Default::default()
+                },
+                ..create_test_header_tags()
+            };
 
-        // Stats collection must include all three traces
-        let TracerPayloadCollection::V07(ref stats_payloads) = stats_collection else {
-            panic!("expected V07");
-        };
-        let stats_span_count: usize = stats_payloads
-            .iter()
-            .flat_map(|tp| tp.chunks.iter())
-            .map(|c| c.spans.len())
-            .sum();
-        assert_eq!(stats_span_count, 3, "stats must include all traces");
+            let make_span = |trace_id: u64, priority: Option<f64>| -> pb::Span {
+                let mut metrics = HashMap::new();
+                if let Some(p) = priority {
+                    metrics.insert("_sampling_priority_v1".to_string(), p);
+                }
+                pb::Span {
+                    trace_id,
+                    span_id: trace_id,
+                    parent_id: 0,
+                    metrics,
+                    service: "svc".to_string(),
+                    name: "op".to_string(),
+                    resource: "res".to_string(),
+                    ..Default::default()
+                }
+            };
 
-        // Backend payload must only contain the kept trace (priority 1)
-        let backend_send_data = payload_info.builder.build();
-        let TracerPayloadCollection::V07(backend_payloads) = backend_send_data.get_payloads()
-        else {
-            panic!("expected V07");
-        };
-        let backend_span_count: usize = backend_payloads
-            .iter()
-            .flat_map(|tp| tp.chunks.iter())
-            .map(|c| c.spans.len())
-            .sum();
-        assert_eq!(
-            backend_span_count, 1,
-            "backend must only include kept traces"
-        );
+            // Three traces: kept (priority 1), dropped (priority 0), dropped (priority -1)
+            let traces = vec![
+                vec![make_span(1, Some(1.0))],
+                vec![make_span(2, Some(0.0))],
+                vec![make_span(3, Some(-1.0))],
+            ];
+
+            let (payload_info, stats_collection) =
+                processor.process_traces(config, tags_provider, header_tags, traces, 0, None);
+            let payload_info = payload_info.expect("expected Some payload");
+
+            // Stats collection must include all three traces
+            let TracerPayloadCollection::V07(ref stats_payloads) = stats_collection else {
+                panic!("expected V07");
+            };
+            let stats_span_count: usize = stats_payloads
+                .iter()
+                .flat_map(|tp| tp.chunks.iter())
+                .map(|c| c.spans.len())
+                .sum();
+            assert_eq!(
+                stats_span_count, 3,
+                "stats must include all traces (compute_on_extension={compute_on_extension}, \
+                 client_computed_stats={client_computed_stats})"
+            );
+
+            let backend_send_data = payload_info.builder.build();
+            let TracerPayloadCollection::V07(backend_payloads) = backend_send_data.get_payloads()
+            else {
+                panic!("expected V07");
+            };
+            let backend_span_count: usize = backend_payloads
+                .iter()
+                .flat_map(|tp| tp.chunks.iter())
+                .map(|c| c.spans.len())
+                .sum();
+            let expected_backend_span_count = if expect_filtering { 1 } else { 3 };
+            assert_eq!(
+                backend_span_count, expected_backend_span_count,
+                "compute_on_extension={compute_on_extension}, \
+                 client_computed_stats={client_computed_stats}"
+            );
+        }
     }
 
-    /// On the compute-stats path, the error sampler rescues errored chunks that
-    /// would otherwise be dropped (`AutoDrop`), stamping `_dd.errors_sr`, while
-    /// non-errored P0 chunks and explicit user drops are still dropped.
+    /// On any stats path where stats are computed before the backend (extension or
+    /// tracer), the error sampler rescues errored chunks that would otherwise be
+    /// dropped (`AutoDrop`), stamping `_dd.errors_sr`, while non-errored P0 chunks
+    /// and explicit user drops are still dropped. Priorities are never rewritten.
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn test_error_sampler_rescues_errored_p0_chunks() {
-        let config = create_compute_stats_config();
-        let (tags_provider, processor) = create_test_processor(&config, enabled_error_sampler());
-        let header_tags = create_test_header_tags();
+        // (owner label, lambda_extension_compute_stats, client_computed_stats)
+        let cases = [("extension", true, false), ("tracer", false, true)];
 
-        let make_span = |trace_id: u64, priority: f64, error: i32| -> pb::Span {
-            let mut metrics = HashMap::new();
-            metrics.insert("_sampling_priority_v1".to_string(), priority);
-            pb::Span {
-                trace_id,
-                span_id: trace_id,
-                parent_id: 0,
-                error,
-                metrics,
-                service: "svc".to_string(),
-                name: "op".to_string(),
-                resource: "res".to_string(),
-                ..Default::default()
-            }
-        };
+        for (owner, compute_on_extension, client_computed_stats) in cases {
+            let config = Arc::new(Config {
+                apm_dd_url: "https://trace.agent.datadoghq.com".to_string(),
+                ext: crate::config::LambdaConfig {
+                    lambda_extension_compute_stats: compute_on_extension,
+                    ..Default::default()
+                },
+                ..Config::default()
+            });
+            let (tags_provider, processor) =
+                create_test_processor(&config, enabled_error_sampler());
 
-        // trace 1: kept normally (priority 1). trace 2: errored P0 (rescued).
-        // trace 3: non-errored P0 (dropped). trace 4: errored user drop (dropped).
-        let traces = vec![
-            vec![make_span(1, 1.0, 0)],
-            vec![make_span(2, 0.0, 1)],
-            vec![make_span(3, 0.0, 0)],
-            vec![make_span(4, -1.0, 1)],
-        ];
+            let header_tags = tracer_header_tags::TracerHeaderTags {
+                lang: "rust",
+                lang_version: "1.0",
+                lang_interpreter: "",
+                lang_vendor: "",
+                tracer_version: "1.0",
+                container_id: "",
+                generic: tracer_header_tags::TracerGenericTags {
+                    client_computed_stats,
+                    ..Default::default()
+                },
+            };
 
-        let (payload_info, _stats) =
-            processor.process_traces(config, tags_provider, header_tags, traces, 0, None);
-        let payload_info = payload_info.expect("expected Some payload");
-        let backend_send_data = payload_info.builder.build();
-        let TracerPayloadCollection::V07(backend_payloads) = backend_send_data.get_payloads()
-        else {
-            panic!("expected V07");
-        };
+            let make_span = |trace_id: u64, priority: f64, error: i32| -> pb::Span {
+                let mut metrics = HashMap::new();
+                metrics.insert("_sampling_priority_v1".to_string(), priority);
+                pb::Span {
+                    trace_id,
+                    span_id: trace_id,
+                    parent_id: 0,
+                    error,
+                    metrics,
+                    service: "svc".to_string(),
+                    name: "op".to_string(),
+                    resource: "res".to_string(),
+                    ..Default::default()
+                }
+            };
 
-        let kept: Vec<u64> = backend_payloads
-            .iter()
-            .flat_map(|tp| tp.chunks.iter())
-            .flat_map(|c| c.spans.iter())
-            .map(|s| s.trace_id)
-            .collect();
-        assert_eq!(kept.len(), 2, "kept normal trace + rescued errored trace");
-        assert!(kept.contains(&1), "priority-1 trace kept");
-        assert!(kept.contains(&2), "errored P0 trace rescued");
-        assert!(!kept.contains(&3), "non-errored P0 trace dropped");
-        assert!(!kept.contains(&4), "errored user-drop trace not rescued");
+            // trace 1: kept normally (priority 1). trace 2: errored P0 (rescued).
+            // trace 3: non-errored P0 (dropped). trace 4: errored user drop (dropped).
+            let traces = vec![
+                vec![make_span(1, 1.0, 0)],
+                vec![make_span(2, 0.0, 1)],
+                vec![make_span(3, 0.0, 0)],
+                vec![make_span(4, -1.0, 1)],
+            ];
 
-        let rescued_root = backend_payloads
-            .iter()
-            .flat_map(|tp| tp.chunks.iter())
-            .flat_map(|c| c.spans.iter())
-            .find(|s| s.trace_id == 2)
-            .expect("rescued trace present");
-        assert!(
-            rescued_root.metrics.contains_key("_dd.errors_sr"),
-            "_dd.errors_sr stamped on rescued root"
-        );
+            let (payload_info, _stats) =
+                processor.process_traces(config, tags_provider, header_tags, traces, 0, None);
+            let payload_info = payload_info.expect("expected Some payload");
+            let backend_send_data = payload_info.builder.build();
+            let TracerPayloadCollection::V07(backend_payloads) = backend_send_data.get_payloads()
+            else {
+                panic!("expected V07");
+            };
+
+            let kept: Vec<(u64, f64)> = backend_payloads
+                .iter()
+                .flat_map(|tp| tp.chunks.iter())
+                .flat_map(|c| c.spans.iter())
+                .map(|s| (s.trace_id, s.metrics["_sampling_priority_v1"]))
+                .collect();
+            assert_eq!(
+                kept.len(),
+                2,
+                "kept normal trace + rescued errored trace (owner={owner})"
+            );
+            assert!(
+                kept.contains(&(1, 1.0)),
+                "priority-1 trace kept (owner={owner})"
+            );
+            assert!(
+                kept.contains(&(2, 0.0)),
+                "errored P0 trace rescued with its original priority (owner={owner})"
+            );
+            assert!(
+                !kept.iter().any(|(id, _)| *id == 3),
+                "non-errored P0 trace dropped (owner={owner})"
+            );
+            assert!(
+                !kept.iter().any(|(id, _)| *id == 4),
+                "errored user-drop trace not rescued (owner={owner})"
+            );
+
+            let rescued_root = backend_payloads
+                .iter()
+                .flat_map(|tp| tp.chunks.iter())
+                .flat_map(|c| c.spans.iter())
+                .find(|s| s.trace_id == 2)
+                .expect("rescued trace present");
+            assert!(
+                rescued_root.metrics.contains_key("_dd.errors_sr"),
+                "_dd.errors_sr stamped on rescued root (owner={owner})"
+            );
+        }
     }
 
     /// An error on a child span (root not errored) still makes the chunk a rescue

--- a/bottlecap/src/traces/trace_processor.rs
+++ b/bottlecap/src/traces/trace_processor.rs
@@ -204,9 +204,10 @@ struct ChunkProcessor {
     obfuscation_config: Arc<obfuscation_config::ObfuscationConfig>,
     tags_provider: Arc<provider::Provider>,
     span_pointers: Option<Vec<SpanPointer>>,
-    /// Whether the tracer signaled (via `Datadog-Client-Computed-Stats`) that it already
-    /// computed trace stats client-side. Used to decide whether to stamp `_dd.compute_stats`.
-    client_computed_stats: bool,
+    /// Which party computes trace stats for this request, resolved once by the caller from
+    /// config and the tracer's `Datadog-Client-Computed-Stats` signal. Used to decide
+    /// whether to stamp `_dd.compute_stats`.
+    stats_computed_by: StatsComputedBy,
 }
 
 impl TraceChunkProcessor for ChunkProcessor {
@@ -222,12 +223,7 @@ impl TraceChunkProcessor for ChunkProcessor {
             .spans
             .retain(|span| !filter_span_from_lambda_library_or_runtime(span));
 
-        // The stats-routing decision depends only on config and the per-request
-        // client_computed_stats flag, so resolve it once instead of per span.
-        let stamp_compute_stats = StatsComputedBy::resolve(
-            self.config.ext.lambda_extension_compute_stats,
-            self.client_computed_stats,
-        ) == StatsComputedBy::Backend;
+        let stamp_compute_stats = self.stats_computed_by == StatsComputedBy::Backend;
 
         for span in &mut chunk.spans {
             // Service name could be incorrectly set to 'aws.lambda'
@@ -526,6 +522,12 @@ impl TraceProcessor for ServerlessTraceProcessor {
         body_size: usize,
         span_pointers: Option<Vec<SpanPointer>>,
     ) -> (Option<SendDataBuilderInfo>, TracerPayloadCollection) {
+        // Who computes stats drives both the `_dd.compute_stats` stamp below and the
+        // sampled-out filtering further down, so resolve it once for this request.
+        let stats_computed_by = StatsComputedBy::resolve(
+            config.ext.lambda_extension_compute_stats,
+            header_tags.generic.client_computed_stats,
+        );
         let mut payload = trace_utils::collect_pb_trace_chunks(
             traces,
             &header_tags,
@@ -534,7 +536,7 @@ impl TraceProcessor for ServerlessTraceProcessor {
                 obfuscation_config: self.obfuscation_config.clone(),
                 tags_provider: tags_provider.clone(),
                 span_pointers,
-                client_computed_stats: header_tags.generic.client_computed_stats,
+                stats_computed_by,
             },
             true, // send agentless since we are the agent
         )
@@ -576,10 +578,6 @@ impl TraceProcessor for ServerlessTraceProcessor {
         // stats are still counted after they are removed here. Filter whenever
         // stats are computed before the backend, by either the tracer or the
         // extension: the backend only needs these chunks when it owns stats.
-        let stats_computed_by = StatsComputedBy::resolve(
-            config.ext.lambda_extension_compute_stats,
-            header_tags.generic.client_computed_stats,
-        );
         if stats_computed_by != StatsComputedBy::Backend
             && let TracerPayloadCollection::V07(ref mut tracer_payloads) = payload
         {
@@ -1174,7 +1172,7 @@ mod tests {
                 )]),
             )),
             span_pointers: None,
-            client_computed_stats: false,
+            stats_computed_by: StatsComputedBy::Backend,
         };
 
         processor.process(&mut chunk, 0);
@@ -1259,7 +1257,7 @@ mod tests {
                 )]),
             )),
             span_pointers: None,
-            client_computed_stats: false,
+            stats_computed_by: StatsComputedBy::Backend,
         };
 
         processor.process(&mut chunk, 0);
@@ -1343,7 +1341,7 @@ mod tests {
                 )]),
             )),
             span_pointers: None,
-            client_computed_stats: false,
+            stats_computed_by: StatsComputedBy::Backend,
         };
 
         processor.process(&mut chunk, 0);
@@ -1921,6 +1919,10 @@ mod tests {
         client_computed_stats: bool,
     ) -> ChunkProcessor {
         let tags_provider = create_tags_provider(config.clone());
+        let stats_computed_by = StatsComputedBy::resolve(
+            config.ext.lambda_extension_compute_stats,
+            client_computed_stats,
+        );
         ChunkProcessor {
             config,
             obfuscation_config: Arc::new(
@@ -1928,7 +1930,7 @@ mod tests {
             ),
             tags_provider,
             span_pointers: None,
-            client_computed_stats,
+            stats_computed_by,
         }
     }
 

--- a/bottlecap/tests/apm_integration_test.rs
+++ b/bottlecap/tests/apm_integration_test.rs
@@ -484,65 +484,138 @@ fn captured_compute_stats(traces: &[pb::AgentPayload]) -> Option<String> {
     span.meta.get(COMPUTE_STATS_KEY).cloned()
 }
 
-/// An errored P0 trace is rescued and reaches the intake, while a non-errored P0 trace is dropped.
+/// An errored P0 trace is rescued and reaches the intake, while a non-errored P0 trace is
+/// dropped. Applies whenever stats are computed before the backend, by either the
+/// extension or the tracer.
 #[tokio::test]
 async fn e2e_error_sampler_rescues_only_errored_p0_traces() {
-    let make_span = |trace_id: u64, error: i32| {
-        let mut span = pb::Span {
-            service: "fake-intake-trace-service".to_string(),
-            name: "web.request".to_string(),
-            resource: "GET /fake".to_string(),
-            trace_id,
-            span_id: trace_id,
-            parent_id: 0,
-            start: STATS_SPAN_START_NS,
-            duration: 5_000_000,
-            error,
-            r#type: "web".to_string(),
-            ..pb::Span::default()
+    // (owner label, lambda_extension_compute_stats, client_computed_stats)
+    let cases = [("extension", true, false), ("tracer", false, true)];
+
+    for (owner, compute_on_extension, client_computed_stats) in cases {
+        let make_span = |trace_id: u64, error: i32| {
+            let mut span = pb::Span {
+                service: "fake-intake-trace-service".to_string(),
+                name: "web.request".to_string(),
+                resource: "GET /fake".to_string(),
+                trace_id,
+                span_id: trace_id,
+                parent_id: 0,
+                start: STATS_SPAN_START_NS,
+                duration: 5_000_000,
+                error,
+                r#type: "web".to_string(),
+                ..pb::Span::default()
+            };
+            span.metrics
+                .insert("_sampling_priority_v1".to_string(), 0.0);
+            span
         };
-        span.metrics
-            .insert("_sampling_priority_v1".to_string(), 0.0);
-        span
-    };
 
-    let rescued_trace_id = 1;
-    let dropped_trace_id = 2;
-    let outcome = run_processor_pipeline_with_traces(
-        true,
-        false,
-        vec![
-            vec![make_span(rescued_trace_id, 1)],
-            vec![make_span(dropped_trace_id, 0)],
-        ],
-    )
-    .await;
+        let rescued_trace_id = 1;
+        let dropped_trace_id = 2;
+        let outcome = run_processor_pipeline_with_traces(
+            compute_on_extension,
+            client_computed_stats,
+            vec![
+                vec![make_span(rescued_trace_id, 1)],
+                vec![make_span(dropped_trace_id, 0)],
+            ],
+        )
+        .await;
 
-    let captured_spans: Vec<&pb::Span> = outcome
-        .traces
-        .iter()
-        .flat_map(|payload| &payload.tracer_payloads)
-        .flat_map(|payload| &payload.chunks)
-        .flat_map(|chunk| &chunk.spans)
-        .collect();
-    assert_eq!(
-        captured_spans.len(),
-        1,
-        "only the rescued trace reaches intake"
-    );
-
-    let rescued_span = captured_spans[0];
-    assert_eq!(rescued_span.trace_id, rescued_trace_id);
-    assert!(
-        rescued_span.metrics.contains_key("_dd.errors_sr"),
-        "the rescued root span must carry its error sampling rate",
-    );
-    assert!(
-        captured_spans
+        let captured_spans: Vec<&pb::Span> = outcome
+            .traces
             .iter()
-            .all(|span| span.trace_id != dropped_trace_id),
-        "the non-errored P0 trace must not reach intake",
-    );
+            .flat_map(|payload| &payload.tracer_payloads)
+            .flat_map(|payload| &payload.chunks)
+            .flat_map(|chunk| &chunk.spans)
+            .collect();
+        assert_eq!(
+            captured_spans.len(),
+            1,
+            "only the rescued trace reaches intake (owner={owner})"
+        );
+
+        let rescued_span = captured_spans[0];
+        assert_eq!(rescued_span.trace_id, rescued_trace_id);
+        assert!(
+            rescued_span.metrics.contains_key("_dd.errors_sr"),
+            "the rescued root span must carry its error sampling rate (owner={owner})",
+        );
+        assert!(
+            captured_spans
+                .iter()
+                .all(|span| span.trace_id != dropped_trace_id),
+            "the non-errored P0 trace must not reach intake (owner={owner})",
+        );
+    }
+}
+
+/// Sampled-out chunks are filtered from the trace intake whenever stats are computed
+/// before the backend, by either the extension or the tracer, while backend-owned
+/// stats keep them so the backend can compute stats.
+#[tokio::test]
+async fn e2e_sampled_out_chunks_filtered_by_stats_owner() {
+    // (owner label, lambda_extension_compute_stats, client_computed_stats) -> filtering expected
+    let cases = [
+        ("backend", false, false, false),
+        ("extension", true, false, true),
+        ("tracer", false, true, true),
+    ];
+
+    for (owner, compute_on_extension, client_computed_stats, expect_filtering) in cases {
+        let make_span = |trace_id: u64, priority: f64| {
+            let mut span = pb::Span {
+                service: "fake-intake-trace-service".to_string(),
+                name: "web.request".to_string(),
+                resource: "GET /fake".to_string(),
+                trace_id,
+                span_id: trace_id,
+                parent_id: 0,
+                start: STATS_SPAN_START_NS,
+                duration: 5_000_000,
+                error: 0,
+                r#type: "web".to_string(),
+                ..pb::Span::default()
+            };
+            span.metrics
+                .insert("_sampling_priority_v1".to_string(), priority);
+            span
+        };
+
+        // kept (priority 1), auto-dropped (priority 0), explicit drop (priority -1)
+        let outcome = run_processor_pipeline_with_traces(
+            compute_on_extension,
+            client_computed_stats,
+            vec![
+                vec![make_span(1, 1.0)],
+                vec![make_span(2, 0.0)],
+                vec![make_span(3, -1.0)],
+            ],
+        )
+        .await;
+
+        let mut captured_trace_ids: Vec<u64> = outcome
+            .traces
+            .iter()
+            .flat_map(|payload| &payload.tracer_payloads)
+            .flat_map(|payload| &payload.chunks)
+            .flat_map(|chunk| &chunk.spans)
+            .map(|span| span.trace_id)
+            .collect();
+        captured_trace_ids.sort_unstable();
+
+        let expected_trace_ids: Vec<u64> = if expect_filtering {
+            vec![1]
+        } else {
+            vec![1, 2, 3]
+        };
+        assert_eq!(
+            captured_trace_ids, expected_trace_ids,
+            "unexpected intake contents (owner={owner})"
+        );
+    }
 }
 
 /// T3.1: `client_computed_stats=true` → captured span meta has `_dd.compute_stats` absent.


### PR DESCRIPTION
## Overview

Follow-up to #1320. Filters sampled-out trace chunks from trace intake whenever trace stats are computed before the backend, by either the tracer or the extension. Previously the filtering gate only checked `lambda_extension_compute_stats`, so tracers that compute stats themselves and report `Datadog-Client-Computed-Stats: true` (for example, `dd-trace-java` v1.63.0 with `DD_TRACE_STATS_COMPUTATION_ENABLED` on by default) still had their rejected chunks forwarded to intake.

| Stats owner | Sampled-out chunks sent to trace intake |
|---|---|
| Backend (`lambda_extension_compute_stats=false`, `client_computed_stats=false`) | Yes, the backend needs them to compute stats |
| Extension (`lambda_extension_compute_stats=true`) | No, filtered |
| Tracer (`client_computed_stats=true`) | No, filtered |

Behavior notes:

- Stats-ownership precedence is unchanged: `client_computed_stats=true` means the tracer owns stats even when extension-side stats are also configured.
- Within `process_traces`, stats ownership is resolved once and reused for both `_dd.compute_stats` stamping and sampled-out filtering, keeping those paths aligned.
- Sampling priorities are never rewritten.
- The pre-filter payload is still cloned before filtering, so extension-side stats include sampled-out traces.
- The error sampler from #1320 now also applies on the tracer-owned path, rescuing eligible errored `AutoDrop` chunks; explicit/user drops (negative priority) remain dropped, and `_dd.errors_sr` is stamped on rescued root spans.

## Testing

- Unit tests in `trace_processor.rs`: table-driven over all four ownership combinations, asserting filtering vs. no-filtering, the pre-filter stats payload contents, and error rescue on both non-backend paths. The tracer-owned case was confirmed failing before the fix.
- Fake-intake E2E tests in `apm_integration_test.rs`: `e2e_sampled_out_chunks_filtered_by_stats_owner` (backend keeps all chunks; extension and tracer paths filter to the kept trace only) and `e2e_error_sampler_rescues_only_errored_p0_traces` extended to both non-backend owners.
- `cargo nextest run --workspace`: 678 passed, 0 failed.
- `cargo fmt --all -- --check`, `cargo check --workspace`, and both clippy passes (default and fips features) pass.

Found while investigating excess trace volume in the `serverless-e2e-tests` `java17-sampling` scenario: 20 traces observed at a 0.2 sample rate over 50 invocations where roughly 10 were expected.
